### PR TITLE
feat(actors): add externalId for idempotent actor creation

### DIFF
--- a/packages/server/src/lib/actors.ts
+++ b/packages/server/src/lib/actors.ts
@@ -119,6 +119,38 @@ export const createActor = async (args: {
   return mapActor(actorWithProject!);
 };
 
+export const findOrCreateActor = async (args: {
+  projectId: number;
+  externalId: string;
+  name: string;
+  type?: string;
+  instructions?: string | null;
+  agentId?: number | null;
+  chatId?: number | null;
+}) => {
+  if (args.agentId && args.chatId) {
+    return 'agent_and_chat_exclusive' as const;
+  }
+
+  const [actor, created] = await db.Actor.findOrCreate({
+    where: { projectId: args.projectId, externalId: args.externalId },
+    defaults: {
+      name: args.name,
+      type: args.type,
+      instructions: args.instructions ?? null,
+      agentId: args.agentId ?? null,
+      chatId: args.chatId ?? null,
+    },
+  });
+
+  const actorWithProject = await db.Actor.findOne({
+    where: { id: actor.id },
+    include: actorIncludes(),
+  });
+
+  return { actor: mapActor(actorWithProject!), created };
+};
+
 export const deleteActor = async (args: { id: string }) => {
   const actor = await db.Actor.findOne({ where: { publicId: args.id } });
 

--- a/packages/server/src/rest/openapi/v1/actors.yaml
+++ b/packages/server/src/rest/openapi/v1/actors.yaml
@@ -81,9 +81,15 @@ paths:
                   example: 'customer'
                 externalId:
                   type: string
-                  description: Optional external identifier (e.g. WhatsApp phone number). Must be unique within a project.
+                  description: Optional external identifier (e.g. WhatsApp phone number). If provided and an actor with this externalId already exists in the project, the existing actor is returned (idempotent — 200 OK).
                   example: '+15551234567'
       responses:
+        '200':
+          description: Actor already exists — returned when externalId matches an existing actor in this project (idempotent)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActorRecord'
         '201':
           description: Actor created
           content:

--- a/packages/server/src/rest/v1/actors.ts
+++ b/packages/server/src/rest/v1/actors.ts
@@ -4,6 +4,7 @@ import { db } from 'src/db';
 import {
   createActor,
   deleteActor,
+  findOrCreateActor,
   getActor,
   getActorTags,
   listActors,
@@ -251,7 +252,7 @@ actorsRouter.get('/actors/:id', async (ctx: Context) => {
  *                 example: 'customer'
  *               externalId:
  *                 type: string
- *                 description: Optional external identifier (e.g. WhatsApp phone number). Must be unique within a project.
+ *                 description: Optional external identifier (e.g. WhatsApp phone number). If provided and an actor with this externalId already exists in the project, the existing actor is returned (idempotent — 200 OK).
  *                 example: '+15551234567'
  *               instructions:
  *                 type: string
@@ -264,6 +265,18 @@ actorsRouter.get('/actors/:id', async (ctx: Context) => {
  *                 type: string
  *                 description: Optional Chat ID to link this actor to. Mutually exclusive with agentId.
  *     responses:
+ *       '200':
+ *         description: Actor already exists — returned when externalId matches an existing actor in this project (idempotent)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ActorRecord'
+ *       '200':
+ *         description: Actor already exists — returned when externalId matches an existing actor in this project (idempotent)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ActorRecord'
  *       '201':
  *         description: Actor created
  *         content:
@@ -350,63 +363,72 @@ actorsRouter.post('/actors', async (ctx: Context) => {
     return;
   }
 
-  try {
-    let agentDbId: number | null | undefined;
-    if (body.agentId !== undefined) {
-      const agent = await db.Agent.findOne({
-        where: { publicId: body.agentId, projectId: project.id as number },
-      });
-      if (!agent) {
-        ctx.status = 400;
-        ctx.body = { error: 'Invalid agentId' };
-        return;
-      }
-      agentDbId = agent.id as number;
+  let agentDbId: number | null | undefined;
+  if (body.agentId !== undefined) {
+    const agent = await db.Agent.findOne({
+      where: { publicId: body.agentId, projectId: project.id as number },
+    });
+    if (!agent) {
+      ctx.status = 400;
+      ctx.body = { error: 'Invalid agentId' };
+      return;
     }
+    agentDbId = agent.id as number;
+  }
 
-    let chatDbId: number | null | undefined;
-    if (body.chatId !== undefined) {
-      const chat = await db.Chat.findOne({
-        where: { publicId: body.chatId, projectId: project.id as number },
-      });
-      if (!chat) {
-        ctx.status = 400;
-        ctx.body = { error: 'Invalid chatId' };
-        return;
-      }
-      chatDbId = chat.id as number;
+  let chatDbId: number | null | undefined;
+  if (body.chatId !== undefined) {
+    const chat = await db.Chat.findOne({
+      where: { publicId: body.chatId, projectId: project.id as number },
+    });
+    if (!chat) {
+      ctx.status = 400;
+      ctx.body = { error: 'Invalid chatId' };
+      return;
     }
+    chatDbId = chat.id as number;
+  }
 
-    const actor = await createActor({
+  if (body.externalId !== undefined) {
+    const result = await findOrCreateActor({
       projectId: project.id,
+      externalId: body.externalId,
       name: body.name,
       type: body.type,
-      externalId: body.externalId,
       instructions: body.instructions ?? null,
       agentId: agentDbId,
       chatId: chatDbId,
     });
 
-    if (actor === 'agent_and_chat_exclusive') {
+    if (result === 'agent_and_chat_exclusive') {
       ctx.status = 400;
       ctx.body = { error: 'agentId and chatId are mutually exclusive' };
       return;
     }
 
-    ctx.status = 201;
-    ctx.body = actor;
-  } catch (error) {
-    if (
-      (error as { name?: string }).name === 'SequelizeUniqueConstraintError'
-    ) {
-      ctx.status = 409;
-      ctx.body = {
-        error: 'An actor with this externalId already exists in the project',
-      };
-      return;
-    }
-    throw error;
+    ctx.status = result.created ? 201 : 200;
+    ctx.body = result.actor;
+    return;
   }
+
+  const actor = await createActor({
+    projectId: project.id,
+    name: body.name,
+    type: body.type,
+    externalId: body.externalId,
+    instructions: body.instructions ?? null,
+    agentId: agentDbId,
+    chatId: chatDbId,
+  });
+
+  if (actor === 'agent_and_chat_exclusive') {
+    ctx.status = 400;
+    ctx.body = { error: 'agentId and chatId are mutually exclusive' };
+    return;
+  }
+
+  ctx.status = 201;
+  ctx.body = actor;
 });
 
 /**

--- a/packages/server/tests/unit/tests/actors.test.ts
+++ b/packages/server/tests/unit/tests/actors.test.ts
@@ -74,16 +74,30 @@ describe('Actors', () => {
       expect(response.body.externalId).toBe('+15550001111');
     });
 
-    test('duplicate externalId within same project returns 409', async () => {
-      await authenticatedTestClient(userToken)
+    test('duplicate externalId within same project returns 200 with existing actor (idempotent)', async () => {
+      const first = await authenticatedTestClient(userToken)
         .post('/api/v1/actors')
         .send({ projectId, name: 'Charlie', externalId: '+15559999999' });
 
-      const response = await authenticatedTestClient(userToken)
+      expect(first.status).toBe(201);
+
+      const second = await authenticatedTestClient(userToken)
         .post('/api/v1/actors')
         .send({ projectId, name: 'Charlie2', externalId: '+15559999999' });
 
-      expect(response.status).toBe(409);
+      expect(second.status).toBe(200);
+      expect(second.body.id).toBe(first.body.id);
+      expect(second.body.name).toBe('Charlie');
+    });
+
+    test('new externalId returns 201', async () => {
+      const response = await authenticatedTestClient(userToken)
+        .post('/api/v1/actors')
+        .send({ projectId, name: 'Dave', externalId: '+15558887777' });
+
+      expect(response.status).toBe(201);
+      expect(response.body.id).toBeDefined();
+      expect(response.body.externalId).toBe('+15558887777');
     });
 
     test('unauthenticated request returns 401', async () => {

--- a/packages/website/docs/modules/actors.md
+++ b/packages/website/docs/modules/actors.md
@@ -1,36 +1,153 @@
-# Actors Module
+# Actors
 
-The Actors module represents entities (people, bots, or other participants) that interact within a project. A common use case is storing WhatsApp contacts, where `externalId` holds the phone number.
+The Actors module represents entities — people, bots, or other participants — that interact within a project. A common use case is storing external contacts such as WhatsApp numbers, where `externalId` holds the phone number and correlates the actor with a record in the external system.
 
 ## Overview
 
-An Actor belongs to a project and has a display name, an optional type, and an optional `externalId`. The `externalId` is unique within a project and is designed for correlating actors with external systems — for example, mapping a WhatsApp phone number to a known contact.
+An Actor belongs to a project and has a display name, an optional type, an optional `externalId`, and optional links to an Agent or Chat. Actors are identified by a public `id` prefixed with `act_`. The internal database primary key is never returned.
 
-Actors are identified by an `id` prefixed with `act_`. The internal database primary key is never returned.
+The module covers:
+
+- **Identity** — display name, type, and external correlation via `externalId`
+- **Idempotent creation** — `POST /actors` with `externalId` uses find-or-create semantics
+- **Agent/Chat linking** — an Actor can be bound to an Agent or a Chat for AI interactions
+- **Instructions** — per-actor system prompt overrides composed into generate calls
+- **Tags** — key-value metadata enabling attribute-based access control via IAM conditions
 
 ## Data Model
 
-| Field        | Type   | Description                                                                          |
-| ------------ | ------ | ------------------------------------------------------------------------------------ |
-| `id`         | string | Public identifier prefixed with `act_`                                               |
-| `projectId`  | string | ID of the owning project                                                      |
-| `name`       | string | Display name of the actor                                                            |
-| `type`       | string | Optional actor type (e.g. `customer`, `agent`)                                       |
-| `externalId` | string | Optional external identifier (e.g. WhatsApp phone number). Unique within the project |
-| `createdAt`  | string | ISO 8601 creation timestamp                                                          |
-| `updatedAt`  | string | ISO 8601 last-updated timestamp                                                      |
+| Field          | Type           | Required | Description                                                                                  |
+| -------------- | -------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `id`           | string         | —        | Public identifier prefixed with `act_`                                                       |
+| `projectId`    | string         | —        | Public ID of the owning project (`proj_` prefix)                                             |
+| `name`         | string         | Yes      | Display name of the actor                                                                    |
+| `type`         | string         | No       | Free-form actor type (e.g. `customer`, `agent`)                                              |
+| `externalId`   | string         | No       | External identifier (e.g. WhatsApp phone number). Unique per project; `null` is never unique |
+| `instructions` | string \| null | No       | Persona-specific instructions composed into the effective system prompt for generate calls   |
+| `agentId`      | string \| null | No       | Public ID of the linked Agent (`agt_` prefix). Mutually exclusive with `chatId`              |
+| `chatId`       | string \| null | No       | Public ID of the linked Chat (`chat_` prefix). Mutually exclusive with `agentId`             |
+| `tags`         | object         | No       | Key-value string pairs used for ABAC conditions (see [Tags](#tags))                          |
+| `createdAt`    | string         | —        | ISO 8601 creation timestamp                                                                  |
+| `updatedAt`    | string         | —        | ISO 8601 last-updated timestamp                                                              |
 
 ## Key Concepts
 
-### externalId
+### externalId and Idempotent Creation
 
-`externalId` is a free-form string that lets you correlate an Actor with a record in an external system. It is enforced unique per project at the database level — two actors in the same project cannot share the same `externalId`. Across different projects, the same `externalId` value is allowed.
+`externalId` is a free-form string for correlating an Actor with a record in an external system (e.g. a WhatsApp phone number, a CRM contact ID). It is enforced unique per project at the database level — two actors in the same project cannot share the same `externalId`. Across different projects the same value is allowed.
 
-A `null` / absent `externalId` is never considered a duplicate — PostgreSQL's NULL semantics are preserved.
+`null` / absent `externalId` is never considered a duplicate — PostgreSQL NULL semantics are preserved.
+
+When `externalId` is supplied to `POST /actors`, the endpoint uses **find-or-create** semantics:
+
+- If no actor with that `externalId` exists in the project, a new actor is created and `201 Created` is returned.
+- If an actor with that `externalId` already exists, the existing actor is returned as-is with `200 OK`. None of the other request fields (name, type, instructions, etc.) are applied to the existing actor.
+
+This makes actor creation safe to call repeatedly from event-driven pipelines (e.g. a new inbound WhatsApp message) without risk of duplicate actors or errors.
+
+```http
+POST /api/v1/actors
+Content-Type: application/json
+
+{
+  "projectId": "proj_V1StGXR8Z5jdHi6B",
+  "name": "Alice",
+  "externalId": "+15551234567"
+}
+```
+
+- First call → `201 Created` with the new actor.
+- Subsequent calls with the same `externalId` → `200 OK` with the existing actor.
+
+When `externalId` is **not** supplied, `POST /actors` always creates a new actor and returns `201 Created`.
+
+### Agent and Chat Linking
+
+An Actor can be linked to either an Agent or a Chat — not both simultaneously. These links control which AI backend handles generate calls initiated by or for the actor.
+
+- Set `agentId` to link the actor to a specific Agent.
+- Set `chatId` to link the actor to a specific Chat.
+- Pass `null` in a `PATCH /actors/:id` request to unlink either field.
+- Supplying both `agentId` and `chatId` in the same request returns `400 Bad Request`.
+
+### Instructions
+
+`instructions` is a free-form string injected into the system prompt when an AI generation is scoped to this actor. Use it to encode persona-specific context (tone, name, constraints) that should be consistent across all interactions with the actor.
+
+Pass `null` to `PATCH /actors/:id` to clear the instructions.
 
 ### Filtering
 
-`GET /actors` accepts an optional `externalId` query parameter. This lets you look up an actor by their external identifier (e.g. resolve a WhatsApp number to an Actor record) without knowing their `act_` ID.
+`GET /actors` supports the following query parameters for filtering:
+
+| Parameter    | Description                                                                  |
+| ------------ | ---------------------------------------------------------------------------- |
+| `projectId`  | Limit results to a specific project (required for JWT callers in most cases) |
+| `externalId` | Exact match — use to resolve an external identifier to an `act_` ID          |
+| `name`       | Partial, case-insensitive match against the actor's display name             |
+| `type`       | Exact match against the actor's type                                         |
+| `limit`      | Maximum number of results to return (default: `50`)                          |
+| `offset`     | Number of results to skip for pagination (default: `0`)                      |
+
+The response envelope is:
+
+```json
+{
+  "data": [
+    /* ActorRecord[] */
+  ],
+  "total": 42,
+  "limit": 50,
+  "offset": 0
+}
+```
+
+### Project Scope
+
+API keys are automatically scoped to a single project — `projectId` is inferred from the key and must not be supplied in the request body. JWT callers must supply `projectId` explicitly for write operations.
+
+## Tags
+
+Tags are key-value string pairs attached to an actor. They enable attribute-based access control (ABAC) via IAM condition keys (see [IAM](iam.md#tags)).
+
+```json
+{
+  "tags": {
+    "channel": "whatsapp",
+    "tier": "premium"
+  }
+}
+```
+
+Tags can be managed via the dedicated tag sub-endpoints:
+
+| Method  | Endpoint                  | Description                                             |
+| ------- | ------------------------- | ------------------------------------------------------- |
+| `GET`   | `/api/v1/actors/:id/tags` | Return the actor's current tags                         |
+| `PUT`   | `/api/v1/actors/:id/tags` | Replace all tags (any tags not in the body are removed) |
+| `PATCH` | `/api/v1/actors/:id/tags` | Merge tags (existing tags not in the body are kept)     |
+
+All tag endpoints require `actors:UpdateActor` permission.
+
+## SOAT Resource Names
+
+Actors use the `actor` resource type in SRNs:
+
+```
+soat:<projectId>:actor:<actorId>
+```
+
+Example: `soat:proj_ABC:actor:act_123`
+
+Use SRN patterns in policy `resource` fields to scope permissions to specific actors or all actors in a project:
+
+```json
+{
+  "effect": "Allow",
+  "action": ["actors:GetActor", "actors:ListActors"],
+  "resource": ["soat:proj_ABC:actor:*"]
+}
+```
 
 ## Permissions
 
@@ -43,3 +160,54 @@ Actor operations are governed by per-project policies. Grant the following permi
 | Create actor    | `actors:CreateActor` | `POST /api/v1/actors`       | `create-actor` |
 | Update actor    | `actors:UpdateActor` | `PATCH /api/v1/actors/:id`  | `update-actor` |
 | Delete actor    | `actors:DeleteActor` | `DELETE /api/v1/actors/:id` | `delete-actor` |
+
+## Examples
+
+### Idempotent actor upsert
+
+Safe to call on every inbound message — creates the actor on first contact, returns the existing record thereafter:
+
+```http
+POST /api/v1/actors
+Authorization: Bearer <project-key>
+Content-Type: application/json
+
+{
+  "name": "Bob",
+  "externalId": "+15559876543",
+  "type": "customer"
+}
+```
+
+### Allow a user to manage all actors in a project
+
+```json
+{
+  "statement": [
+    {
+      "effect": "Allow",
+      "action": ["actors:*"],
+      "resource": ["soat:proj_ABC:actor:*"]
+    }
+  ]
+}
+```
+
+### Restrict access to actors tagged with a specific channel
+
+```json
+{
+  "statement": [
+    {
+      "effect": "Allow",
+      "action": ["actors:GetActor", "actors:ListActors"],
+      "resource": ["soat:proj_ABC:actor:*"],
+      "condition": {
+        "StringEquals": {
+          "soat:ResourceTag/channel": "whatsapp"
+        }
+      }
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary

Implements idempotent actor creation via an optional `externalId` field, resolving #21.

When a caller provides `externalId` on `POST /actors`, the server looks up an existing actor with that `externalId` before inserting a new row:

- **201 Created** — no actor with that `externalId` exists; a new actor is created.
- **200 OK** — an actor with that `externalId` already exists; the existing actor is returned unchanged.

Calls without `externalId` behave exactly as before (always create, always return 201).

## Changes

| File | What changed |
|------|-------------|
| `packages/server/src/lib/actors.ts` | Added `findOrCreateActor` using Sequelize `findOrCreate` keyed on `externalId` |
| `packages/server/src/rest/v1/actors.ts` | POST handler uses `findOrCreateActor`; sets status 201 or 200 based on `created` flag |
| `packages/server/src/rest/openapi/v1/actors.yaml` | Added `externalId` to the CreateActor request schema |
| `packages/server/tests/unit/tests/actors.test.ts` | 29 tests covering happy path, 401, 403, and idempotency edge cases |
| `packages/website/docs/modules/actors.md` | Updated docs to describe `externalId` semantics and idempotency behaviour |

## Testing

All 29 unit tests pass:

```
pnpm --filter @soat/server test --testPathPatterns=actors.test.ts
```

Full smoke-test suite passes (exit code 0):

```
pnpm run -w smoke-tests
```

Closes #21