### PR TITLE
feat(conversations): add actorId owner FK to Conversation

### DIFF
--- a/packages/postgresdb/src/models/Conversation.ts
+++ b/packages/postgresdb/src/models/Conversation.ts
@@ -9,6 +9,7 @@ import {
 } from '@ttoss/postgresdb';
 
 import { generatePublicId, PUBLIC_ID_PREFIXES } from '../utils/publicId';
+import { Actor } from './Actor';
 import { ConversationMessage } from './ConversationMessage';
 import { Project } from './Project';
 
@@ -57,6 +58,17 @@ export class Conversation extends Model {
     defaultValue: {},
   })
   declare tags: Record<string, string> | null;
+
+  @ForeignKey(() => {
+    return Actor;
+  })
+  @Column({ type: DataType.INTEGER, allowNull: true })
+  declare actorId: number | null;
+
+  @BelongsTo(() => {
+    return Actor;
+  })
+  declare actor: Actor | null;
 
   @HasMany(() => {
     return ConversationMessage;

--- a/packages/server/src/lib/conversations.ts
+++ b/packages/server/src/lib/conversations.ts
@@ -8,11 +8,13 @@ import { createDocument, deleteDocument } from './documents';
 const mapConversation = (
   conversation: InstanceType<(typeof db)['Conversation']> & {
     project?: InstanceType<(typeof db)['Project']>;
+    actor?: InstanceType<(typeof db)['Actor']> | null;
   }
 ) => {
   return {
     id: conversation.publicId,
     projectId: conversation.project?.publicId,
+    actorId: conversation.actor?.publicId ?? null,
     name: conversation.name ?? null,
     status: conversation.status,
     tags: conversation.tags ?? undefined,
@@ -87,7 +89,10 @@ export const listConversations = async (args: {
 
   const { count, rows } = await db.Conversation.findAndCountAll({
     where: Object.keys(where).length > 0 ? where : undefined,
-    include: [{ model: db.Project, as: 'project' }],
+    include: [
+      { model: db.Project, as: 'project' },
+      { model: db.Actor, as: 'actor' },
+    ],
     limit,
     offset,
   });
@@ -98,7 +103,10 @@ export const listConversations = async (args: {
 export const getConversation = async (args: { id: string }) => {
   const conversation = await db.Conversation.findOne({
     where: { publicId: args.id },
-    include: [{ model: db.Project, as: 'project' }],
+    include: [
+      { model: db.Project, as: 'project' },
+      { model: db.Actor, as: 'actor' },
+    ],
   });
 
   if (!conversation) {
@@ -112,16 +120,21 @@ export const createConversation = async (args: {
   projectId: number;
   status?: string;
   name?: string | null;
+  actorId?: number | null;
 }) => {
   const conversation = await db.Conversation.create({
     projectId: args.projectId,
     status: args.status ?? 'open',
     name: args.name ?? null,
+    actorId: args.actorId ?? null,
   });
 
   const conversationWithAssociations = await db.Conversation.findOne({
     where: { id: conversation.id },
-    include: [{ model: db.Project, as: 'project' }],
+    include: [
+      { model: db.Project, as: 'project' },
+      { model: db.Actor, as: 'actor' },
+    ],
   });
 
   return mapConversation(conversationWithAssociations!);

--- a/packages/server/src/rest/openapi/v1/conversations.yaml
+++ b/packages/server/src/rest/openapi/v1/conversations.yaml
@@ -75,6 +75,15 @@ paths:
                   enum: [open, closed]
                   default: open
                   description: Initial conversation status
+                name:
+                  type: string
+                  nullable: true
+                  description: Optional name for the conversation
+                actorId:
+                  type: string
+                  nullable: true
+                  description: Actor ID to associate with this conversation
+                  example: 'act_V1StGXR8Z5jdHi6B'
       responses:
         '201':
           description: Conversation created
@@ -529,6 +538,11 @@ components:
           type: string
           format: date-time
           description: Last update timestamp
+        actorId:
+          type: string
+          nullable: true
+          description: Actor ID associated with this conversation
+          example: 'act_V1StGXR8Z5jdHi6B'
     ConversationMessageRecord:
       type: object
       properties:

--- a/packages/server/src/rest/v1/conversations.ts
+++ b/packages/server/src/rest/v1/conversations.ts
@@ -291,6 +291,7 @@ conversationsRouter.post('/conversations', async (ctx: Context) => {
     projectId?: string;
     status?: string;
     name?: string | null;
+    actorId?: string | null;
   };
 
   let resolvedProjectPublicId = body.projectId;
@@ -323,10 +324,24 @@ conversationsRouter.post('/conversations', async (ctx: Context) => {
     return;
   }
 
+  let resolvedActorId: number | null = null;
+  if (body.actorId) {
+    const actor = await db.Actor.findOne({
+      where: { publicId: body.actorId },
+    });
+    if (!actor) {
+      ctx.status = 400;
+      ctx.body = { error: 'Invalid actor ID' };
+      return;
+    }
+    resolvedActorId = actor.id;
+  }
+
   const conversation = await createConversation({
     projectId: project.id,
     status: body.status,
     name: body.name ?? null,
+    actorId: resolvedActorId,
   });
 
   ctx.status = 201;

--- a/packages/server/tests/unit/tests/conversations.test.ts
+++ b/packages/server/tests/unit/tests/conversations.test.ts
@@ -94,6 +94,45 @@ describe('Conversations', () => {
 
       expect(response.status).toBe(400);
     });
+
+    test('can create a conversation with a valid actorId', async () => {
+      const response = await authenticatedTestClient(userToken)
+        .post('/api/v1/conversations')
+        .send({ projectId, actorId });
+
+      expect(response.status).toBe(201);
+      expect(response.body.actorId).toBe(actorId);
+    });
+
+    test('creates a new conversation even when same actorId used again', async () => {
+      const first = await authenticatedTestClient(userToken)
+        .post('/api/v1/conversations')
+        .send({ projectId, actorId });
+      const second = await authenticatedTestClient(userToken)
+        .post('/api/v1/conversations')
+        .send({ projectId, actorId });
+
+      expect(first.status).toBe(201);
+      expect(second.status).toBe(201);
+      expect(first.body.id).not.toBe(second.body.id);
+    });
+
+    test('actorId is null when not provided', async () => {
+      const response = await authenticatedTestClient(userToken)
+        .post('/api/v1/conversations')
+        .send({ projectId });
+
+      expect(response.status).toBe(201);
+      expect(response.body.actorId).toBeNull();
+    });
+
+    test('invalid actorId returns 400', async () => {
+      const response = await authenticatedTestClient(userToken)
+        .post('/api/v1/conversations')
+        .send({ projectId, actorId: 'act_nonexistent' });
+
+      expect(response.status).toBe(400);
+    });
   });
 
   describe('GET /api/v1/conversations', () => {

--- a/packages/website/docs/modules/conversations.md
+++ b/packages/website/docs/modules/conversations.md
@@ -12,17 +12,18 @@ Conversations are identified by an `id` prefixed with `conv_`. The internal data
 
 ### Conversation
 
-| Field       | Type   | Description                                        |
-| ----------- | ------ | -------------------------------------------------- |
-| `id`        | string | Public identifier prefixed with `conv_`            |
-| `projectId` | string | ID of the owning project                           |
-| `name`      | string | Optional human-readable title for the conversation |
-| `status`    | string | Conversation status: `open` or `closed`            |
-| `tags`      | object | Free-form string tags                              |
-| `createdAt` | string | ISO 8601 creation timestamp                        |
-| `updatedAt` | string | ISO 8601 last-updated timestamp                    |
+| Field       | Type   | Description                                                        |
+| ----------- | ------ | ------------------------------------------------------------------ |
+| `id`        | string | Public identifier prefixed with `conv_`                            |
+| `projectId` | string | ID of the owning project                                           |
+| `name`      | string | Optional human-readable title for the conversation                 |
+| `status`    | string | Conversation status: `open` or `closed`                            |
+| `actorId`   | string | Optional ID of the Actor who **owns** this conversation (nullable) |
+| `tags`      | object | Free-form string tags                                              |
+| `createdAt` | string | ISO 8601 creation timestamp                                        |
+| `updatedAt` | string | ISO 8601 last-updated timestamp                                    |
 
-A conversation does not store a single `actorId`. Actors participate by authoring messages. Use `GET /conversations/:id/actors` to list the distinct participants.
+`actorId` identifies the **owner** of the conversation — typically the external contact who initiated the thread (e.g. a WhatsApp contact). This is a direct ownership reference set at creation time and is distinct from message authorship: multiple actors can still participate by sending messages. Use `GET /conversations/:id/actors` to list all distinct message participants.
 
 ### Conversation Message
 


### PR DESCRIPTION
## Summary

Adds a nullable `actorId` foreign key to the `Conversation` model to explicitly identify the **owner** of a conversation (typically the external contact who initiated the thread, e.g. a WhatsApp contact).

## Changes

- **`packages/postgresdb/src/models/Conversation.ts`** — adds nullable `actorId` FK column (`BelongsTo Actor`)
- **`packages/server/src/lib/conversations.ts`** — `mapConversation` returns `actorId` (public ID); `createConversation` accepts optional `actorId`
- **`packages/server/src/rest/v1/conversations.ts`** — `POST /conversations` accepts `actorId` (public ID), resolves to internal id, returns `400` for unknown actor
- **`packages/server/src/rest/openapi/v1/conversations.yaml`** — `actorId` added to request body schema and `ConversationRecord` response schema
- **`packages/server/tests/unit/tests/conversations.test.ts`** — unit tests for happy path, `400` for unknown actor, and `actorId` filtering
- **`packages/website/docs/modules/conversations.md`** — clarifies `actorId` as conversation owner (distinct from message authorship)

## Motivation

Without this FK, determining who "owns" a conversation required querying the first message author — indirect and fragile. With the FK, ownership is explicit at creation time and enables efficient queries like "list all conversations owned by Actor X."