### PR TITLE
feat(conversations): add metadata field to conversation messages

### DIFF
--- a/packages/postgresdb/src/models/ConversationMessage.ts
+++ b/packages/postgresdb/src/models/ConversationMessage.ts
@@ -60,4 +60,7 @@ export class ConversationMessage extends Model {
 
   @Column({ type: DataType.INTEGER, allowNull: false })
   declare position: number;
+
+  @Column({ type: DataType.JSONB, allowNull: true })
+  declare metadata: Record<string, unknown> | null;
 }

--- a/packages/server/src/lib/conversations.ts
+++ b/packages/server/src/lib/conversations.ts
@@ -47,6 +47,7 @@ const mapMessage = (
     actorId: message.actor?.publicId,
     position: message.position,
     content,
+    metadata: message.metadata ?? null,
   };
 };
 
@@ -284,6 +285,7 @@ export const addConversationMessage = async (args: {
   message: string;
   actorId: string;
   position?: number;
+  metadata?: Record<string, unknown>;
 }) => {
   const conversation = await db.Conversation.findOne({
     where: { publicId: args.conversationId },
@@ -351,6 +353,7 @@ export const addConversationMessage = async (args: {
         documentId: document.id,
         actorId: actor.id,
         position,
+        metadata: args.metadata ?? null,
       },
       { transaction: t }
     );
@@ -546,9 +549,19 @@ export const generateConversationMessage = async (args: {
       history.push({ role: 'assistant', content });
     } else {
       const speakerName = msg.actor?.name ?? 'participant';
+      const meta = (msg as { metadata?: Record<string, unknown> | null })
+        .metadata;
+      const metadataStr =
+        meta && Object.keys(meta).length > 0
+          ? ` [${Object.entries(meta)
+              .map(([k, v]) => {
+                return `${k}: ${v}`;
+              })
+              .join(', ')}]`
+          : '';
       history.push({
         role: 'user',
-        content: `[${speakerName}]: ${content}`,
+        content: `[${speakerName}]${metadataStr}: ${content}`,
       });
     }
   }

--- a/packages/server/src/lib/soat-tools/conversations.ts
+++ b/packages/server/src/lib/soat-tools/conversations.ts
@@ -150,6 +150,7 @@ export const tools: SoatToolDefinition[] = [
         message: args.message,
         actorId: args.actorId,
         position: args.position,
+        metadata: args.metadata,
       };
     },
     inputSchema: {
@@ -164,6 +165,12 @@ export const tools: SoatToolDefinition[] = [
         position: {
           type: 'number',
           description: 'Position of the message (optional)',
+        },
+        metadata: {
+          type: 'object',
+          description:
+            'Optional structured metadata to attach to the message (e.g. phone number, channel)',
+          additionalProperties: true,
         },
       },
       required: ['id', 'message', 'actorId'],

--- a/packages/server/src/rest/openapi/v1/conversations.yaml
+++ b/packages/server/src/rest/openapi/v1/conversations.yaml
@@ -320,6 +320,14 @@ paths:
                   type: integer
                   description: Zero-based position. Defaults to MAX+1 (append).
                   example: 0
+                metadata:
+                  type: object
+                  description: Optional structured metadata to attach to the message (e.g. phone number, channel). Stored as-is and injected into the AI prompt context.
+                  nullable: true
+                  additionalProperties: true
+                  example:
+                    phone: '5511999998888'
+                    channel: 'whatsapp'
       responses:
         '201':
           description: Message added
@@ -558,6 +566,14 @@ components:
           type: integer
           description: Zero-based position in the conversation
           example: 0
+        metadata:
+          type: object
+          description: Optional structured metadata attached to the message
+          nullable: true
+          additionalProperties: true
+          example:
+            phone: '5511999998888'
+            channel: 'whatsapp'
     ConversationActorRecord:
       type: object
       properties:

--- a/packages/server/src/rest/v1/conversations.ts
+++ b/packages/server/src/rest/v1/conversations.ts
@@ -714,6 +714,14 @@ conversationsRouter.get('/conversations/:id/messages', async (ctx: Context) => {
  *                 type: integer
  *                 description: Zero-based position. Defaults to MAX+1 (append).
  *                 example: 0
+ *               metadata:
+ *                 type: object
+ *                 description: Optional structured metadata to attach to the message (e.g. phone number, channel). Stored as-is and injected into the AI prompt context.
+ *                 nullable: true
+ *                 additionalProperties: true
+ *                 example:
+ *                   phone: '5511999998888'
+ *                   channel: 'whatsapp'
  *     responses:
  *       '201':
  *         description: Message added
@@ -759,6 +767,7 @@ conversationsRouter.post(
       message: string;
       actorId: string;
       position?: number;
+      metadata?: Record<string, unknown>;
     };
 
     if (!body.message) {
@@ -811,6 +820,7 @@ conversationsRouter.post(
       message: body.message,
       actorId: body.actorId,
       position: body.position,
+      metadata: body.metadata,
     });
 
     if (!message) {

--- a/packages/server/tests/unit/tests/conversations.test.ts
+++ b/packages/server/tests/unit/tests/conversations.test.ts
@@ -380,6 +380,45 @@ describe('Conversations', () => {
 
       expect(response.status).toBe(404);
     });
+
+    test('stores metadata and returns it in the response', async () => {
+      const metadata = { phone: '5511999998888', channel: 'whatsapp' };
+      const response = await authenticatedTestClient(userToken)
+        .post(`/api/v1/conversations/${conversationId}/messages`)
+        .send({ message: 'Message with metadata', actorId, metadata });
+
+      expect(response.status).toBe(201);
+      expect(response.body.metadata).toEqual(metadata);
+    });
+
+    test('returns null metadata when metadata is not provided', async () => {
+      const response = await authenticatedTestClient(userToken)
+        .post(`/api/v1/conversations/${conversationId}/messages`)
+        .send({ message: 'Message without metadata', actorId });
+
+      expect(response.status).toBe(201);
+      expect(response.body.metadata).toBeNull();
+    });
+
+    test('metadata is persisted and returned in message list', async () => {
+      const metadata = { source: 'sms', externalId: 'msg_123' };
+      const addRes = await authenticatedTestClient(userToken)
+        .post(`/api/v1/conversations/${conversationId}/messages`)
+        .send({ message: 'Persisted metadata', actorId, metadata });
+
+      expect(addRes.status).toBe(201);
+      const docId = addRes.body.documentId;
+
+      const listRes = await authenticatedTestClient(userToken).get(
+        `/api/v1/conversations/${conversationId}/messages`
+      );
+      expect(listRes.status).toBe(200);
+      const found = listRes.body.data.find(
+        (m: { documentId: string }) => m.documentId === docId
+      );
+      expect(found).toBeDefined();
+      expect(found.metadata).toEqual(metadata);
+    });
   });
 
   describe('DELETE /api/v1/conversations/:id/messages/:documentId', () => {

--- a/packages/website/docs/modules/conversations.md
+++ b/packages/website/docs/modules/conversations.md
@@ -27,12 +27,13 @@ Conversations are identified by an `id` prefixed with `conv_`. The internal data
 
 ### Conversation Message
 
-| Field        | Type    | Description                                                          |
-| ------------ | ------- | -------------------------------------------------------------------- |
-| `documentId` | string  | ID of the Document attached as a message                             |
-| `actorId`    | string  | ID of the Actor who authored the message                             |
-| `position`   | integer | Zero-based position of the message in the conversation               |
-| `content`    | string  | Full text content of the message (read from the underlying document) |
+| Field        | Type           | Description                                                                                                                |
+| ------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `documentId` | string         | ID of the Document attached as a message                                                                                   |
+| `actorId`    | string         | ID of the Actor who authored the message                                                                                   |
+| `position`   | integer        | Zero-based position of the message in the conversation                                                                     |
+| `metadata`   | object \| null | Optional structured key-value data attached to the message (e.g. `phone`, `channel`). Injected into the AI prompt context. |
+| `content`    | string         | Full text content of the message (read from the underlying document)                                                       |
 
 The pair `(conversationId, position)` is uniquely indexed. See [Message ordering](#message-ordering) for insertion semantics.
 


### PR DESCRIPTION
## Summary

Adds a nullable JSONB `metadata` field to `ConversationMessage` so callers can attach structured context (phone numbers, channel IDs, custom tags, etc.) alongside message content — without embedding that data as text prefixes.

Closes #22

## Changes

### DB
- Added `metadata` JSONB column (nullable) to `ConversationMessage` model (`packages/postgresdb/src/models/ConversationMessage.ts`)

### Server — Business Logic
- `addConversationMessage`: accepts and stores `metadata`
- `mapMessage`: returns `metadata` in the mapped record
- AI prompt history: `metadata` is injected into the conversation context passed to the LLM

### REST API
- `POST /conversations/:id/messages` body accepts optional `metadata: Record<string, unknown>`
- `@openapi` JSDoc updated; `conversations.yaml` updated (`requestBody` + `ConversationMessageRecord` schema)

### MCP soat-tools
- `add-conversation-message` tool updated with `metadata` input parameter

### Docs
- `packages/website/docs/modules/conversations.md` — `metadata` row added to the message fields table

### Tests
- 3 new tests in `conversations.test.ts`:
  - Stores and returns `metadata` when provided
  - Returns `null` for `metadata` when not provided
  - `metadata` persists through the list messages endpoint