### PR TITLE
fix: await saveTrace in sync generation so trace file_id is immediately available

### DIFF
--- a/packages/server/src/lib/agentGenerationHelpers.ts
+++ b/packages/server/src/lib/agentGenerationHelpers.ts
@@ -346,7 +346,7 @@ export const savePendingGeneration = (args: {
   return requiresActionResult;
 };
 
-export const buildCompletedGenerationResult = (args: {
+export const buildCompletedGenerationResult = async (args: {
   generationId: string;
   traceId: string;
   parentTraceId?: string | null;
@@ -359,11 +359,11 @@ export const buildCompletedGenerationResult = (args: {
   };
   typedAgent: TypedAgent;
   agentId: string;
-}): GenerationResult => {
+}): Promise<GenerationResult> => {
   const serializedStepsCompleted = serializeSteps(
     args.result.steps as unknown[]
   );
-  saveTrace({
+  await saveTrace({
     traceId: args.traceId,
     projectId: args.typedAgent.project.id as number,
     projectPublicId: args.typedAgent.project.publicId,
@@ -371,7 +371,7 @@ export const buildCompletedGenerationResult = (args: {
     steps: serializedStepsCompleted,
     parentTraceId: args.parentTraceId ?? null,
     rootTraceId: args.rootTraceId ?? null,
-  }).catch(() => {});
+  });
   updateGenerationRecord({
     publicId: args.generationId,
     status: 'completed',

--- a/packages/server/src/lib/agentNonStreamGeneration.ts
+++ b/packages/server/src/lib/agentNonStreamGeneration.ts
@@ -113,7 +113,7 @@ type GenerateTextResult = {
   finishReason: string;
 };
 
-const resolveGenerationResult = (args: {
+const resolveGenerationResult = async (args: {
   generationId: string;
   traceId: string;
   parentTraceId?: string | null;
@@ -126,7 +126,7 @@ const resolveGenerationResult = (args: {
   result: GenerateTextResult;
   toolContext?: Record<string, string> | null;
   remainingDepth?: number | null;
-}): GenerationResult => {
+}): Promise<GenerationResult> => {
   const pendingToolCalls = findPendingClientTools(
     args.result.steps as Array<{
       toolCalls?: Array<{

--- a/packages/server/tests/unit/tests/lib/agentGenerationHelpers.test.ts
+++ b/packages/server/tests/unit/tests/lib/agentGenerationHelpers.test.ts
@@ -8,6 +8,7 @@ import {
   type TypedAgent,
 } from 'src/lib/agentGenerationHelpers';
 import { buildDepthGuardResult } from 'src/lib/agentGenerationRecovery';
+import * as tracesModule from 'src/lib/traces';
 
 describe('buildAllMessages', () => {
   test('returns messages unchanged when instructions is null', () => {
@@ -241,8 +242,8 @@ describe('savePendingGeneration', () => {
 });
 
 describe('buildCompletedGenerationResult', () => {
-  test('returns completed result and updates traces', () => {
-    const result = buildCompletedGenerationResult({
+  test('returns completed result and updates traces', async () => {
+    const result = await buildCompletedGenerationResult({
       generationId: 'gen_done001',
       traceId: 'trc_done001',
       result: {
@@ -263,8 +264,8 @@ describe('buildCompletedGenerationResult', () => {
     expect(result.output?.model).toBe('gpt-4');
   });
 
-  test('uses typedAgent model when response has no modelId', () => {
-    const result = buildCompletedGenerationResult({
+  test('uses typedAgent model when response has no modelId', async () => {
+    const result = await buildCompletedGenerationResult({
       generationId: 'gen_done002',
       traceId: 'trc_done002',
       result: { steps: [], response: {}, text: 'Hi', finishReason: 'stop' },
@@ -275,9 +276,9 @@ describe('buildCompletedGenerationResult', () => {
     expect(result.output?.model).toBe('test-model');
   });
 
-  test('uses empty string when both response modelId and typedAgent.model are absent', () => {
+  test('uses empty string when both response modelId and typedAgent.model are absent', async () => {
     const agentWithoutModel: TypedAgent = { ...mockAgent, model: null };
-    const result = buildCompletedGenerationResult({
+    const result = await buildCompletedGenerationResult({
       generationId: 'gen_done003',
       traceId: 'trc_done003',
       result: {
@@ -291,6 +292,34 @@ describe('buildCompletedGenerationResult', () => {
     });
 
     expect(result.output?.model).toBe('');
+  });
+
+  test('awaits saveTrace before returning so trace file_id is available in sync mode', async () => {
+    let saveTraceResolved = false;
+
+    jest.spyOn(tracesModule, 'saveTrace').mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 10);
+      });
+      saveTraceResolved = true;
+    });
+
+    await buildCompletedGenerationResult({
+      generationId: 'gen_await_trace',
+      traceId: 'trc_await_trace',
+      result: {
+        steps: [],
+        response: { modelId: 'gpt-4' },
+        text: 'Done',
+        finishReason: 'stop',
+      },
+      typedAgent: mockAgent,
+      agentId: 'agt_test001',
+    });
+
+    expect(saveTraceResolved).toBe(true);
+
+    jest.restoreAllMocks();
   });
 });
 

--- a/packages/server/tests/unit/tests/lib/agentGenerationHelpers.test.ts
+++ b/packages/server/tests/unit/tests/lib/agentGenerationHelpers.test.ts
@@ -8,6 +8,7 @@ import {
   type TypedAgent,
 } from 'src/lib/agentGenerationHelpers';
 import { buildDepthGuardResult } from 'src/lib/agentGenerationRecovery';
+import * as generationsModule from 'src/lib/generations';
 import * as tracesModule from 'src/lib/traces';
 
 describe('buildAllMessages', () => {
@@ -242,6 +243,17 @@ describe('savePendingGeneration', () => {
 });
 
 describe('buildCompletedGenerationResult', () => {
+  beforeEach(() => {
+    jest.spyOn(tracesModule, 'saveTrace').mockResolvedValue(undefined);
+    jest
+      .spyOn(generationsModule, 'updateGenerationRecord')
+      .mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('returns completed result and updates traces', async () => {
     const result = await buildCompletedGenerationResult({
       generationId: 'gen_done001',
@@ -318,8 +330,6 @@ describe('buildCompletedGenerationResult', () => {
     });
 
     expect(saveTraceResolved).toBe(true);
-
-    jest.restoreAllMocks();
   });
 });
 

--- a/packages/server/tests/unit/tests/lib/agentNonStreamGeneration.test.ts
+++ b/packages/server/tests/unit/tests/lib/agentNonStreamGeneration.test.ts
@@ -155,7 +155,7 @@ describe('agentNonStreamGeneration', () => {
     jest.spyOn(helpersModule, 'findPendingClientTools').mockReturnValue([]);
     const completedSpy = jest
       .spyOn(helpersModule, 'buildCompletedGenerationResult')
-      .mockReturnValue({
+      .mockResolvedValue({
         id: 'gen_2',
         traceId: 'trc_2',
         status: 'completed',


### PR DESCRIPTION
## Summary

Fixes #126

- `buildCompletedGenerationResult` was synchronous and called `saveTrace(...).catch(() => {})` fire-and-forget, so `file_id` was `null` immediately after a sync generation returned
- Made `buildCompletedGenerationResult` async and `await saveTrace(...)` before returning
- Propagated the async change up through `resolveGenerationResult` in `agentNonStreamGeneration.ts`

## Test plan

- [x] Added failing test (red): `awaits saveTrace before returning so trace file_id is available in sync mode` — asserts that a delayed `saveTrace` mock is resolved before `buildCompletedGenerationResult` returns
- [x] Updated existing `buildCompletedGenerationResult` tests to `await` the now-async function
- [x] Updated `agentNonStreamGeneration.test.ts` mock from `mockReturnValue` to `mockResolvedValue`
- [x] `pnpm typecheck` passes

https://claude.ai/code/session_01MSbYpS3sZmLdGVazXSMHjm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSbYpS3sZmLdGVazXSMHjm)_