### PR TITLE
fix: HTTP tool DELETE requests now send body and preserve Content-Type header

### DIFF
--- a/packages/server/src/lib/agentToolResolver.ts
+++ b/packages/server/src/lib/agentToolResolver.ts
@@ -270,7 +270,7 @@ export const buildHttpToolExecute = (
     ];
     const rawMethod = (args.execute.method ?? 'POST').toUpperCase();
     const method = ALLOWED_METHODS.includes(rawMethod) ? rawMethod : 'POST';
-    const hasBody = !['GET', 'HEAD', 'DELETE'].includes(method);
+    const hasBody = !['GET', 'HEAD'].includes(method);
     const rawArgs =
       toolArgs && typeof toolArgs === 'object'
         ? (toolArgs as Record<string, unknown>)

--- a/packages/server/src/middleware/caseTransform.ts
+++ b/packages/server/src/middleware/caseTransform.ts
@@ -74,8 +74,12 @@ export const caseTransformMiddleware = async (ctx: Context, next: Next) => {
 
   await next();
 
-  // Transform outgoing response body from camelCase to snake_case
+  // Transform outgoing response body from camelCase to snake_case.
+  // The 'execute' key is a pass-through user document (tool execute configs)
+  // whose inner keys (e.g. HTTP headers like Content-Type) must not be
+  // transformed — they are arbitrary user-defined strings, not camelCase fields.
+  const RESPONSE_SKIP_KEYS = new Set(['execute']);
   if (isPlainObject(ctx.body) || Array.isArray(ctx.body)) {
-    ctx.body = transformKeys(ctx.body, camelToSnake);
+    ctx.body = transformKeys(ctx.body, camelToSnake, RESPONSE_SKIP_KEYS);
   }
 };

--- a/packages/server/tests/unit/tests/lib/agentToolResolver.test.ts
+++ b/packages/server/tests/unit/tests/lib/agentToolResolver.test.ts
@@ -296,6 +296,55 @@ describe('resolveAgentTools', () => {
     process.env.SOAT_ERROR_LOGS_ENABLED = originalValue;
   });
 
+  test('DELETE tool with JSON body sends Content-Type and body in request', async () => {
+    const deleteToolRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/tools')
+      .send({
+        project_id: projectId,
+        name: 'myDeleteHttpTool',
+        type: 'http',
+        description: 'Test DELETE HTTP tool with body',
+        parameters: {
+          type: 'object',
+          properties: {
+            item_id: { type: 'string' },
+          },
+        },
+        execute: {
+          url: 'https://example.com/api/items',
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+        },
+      });
+    expect(deleteToolRes.status).toBe(201);
+
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ deleted: true }), { status: 200 })
+      );
+
+    const tools = await resolveAgentTools({ toolIds: [deleteToolRes.body.id] });
+    const deleteTool = tools.myDeleteHttpTool;
+
+    if ('execute' in deleteTool && typeof deleteTool.execute === 'function') {
+      await deleteTool.execute({ item_id: 'abc' }, {} as never);
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/api/items',
+      expect.objectContaining({
+        method: 'DELETE',
+        body: JSON.stringify({ item_id: 'abc' }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+        }),
+      })
+    );
+
+    fetchMock.mockRestore();
+  });
+
   test('does not log HTTP tool call errors when SOAT_ERROR_LOGS_ENABLED is disabled', async () => {
     const originalValue = process.env.SOAT_ERROR_LOGS_ENABLED;
     process.env.SOAT_ERROR_LOGS_ENABLED = 'false';

--- a/packages/server/tests/unit/tests/rest/tools.test.ts
+++ b/packages/server/tests/unit/tests/rest/tools.test.ts
@@ -88,6 +88,32 @@ describe('Tools', () => {
     clientToolId = clientToolRes.body.id;
   });
 
+  describe('POST /api/v1/tools — execute.headers case preservation', () => {
+    test('HTTP headers in execute config are preserved exactly as given (not case-transformed)', async () => {
+      const response = await authenticatedTestClient(adminToken)
+        .post('/api/v1/tools')
+        .send({
+          project_id: projectId,
+          name: 'header-case-test-tool',
+          type: 'http',
+          description: 'Tool to test header case preservation',
+          execute: {
+            url: 'https://example.com/api/delete',
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+          },
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.execute).toBeDefined();
+      expect(response.body.execute.headers).toBeDefined();
+      expect(response.body.execute.headers['Content-Type']).toBe(
+        'application/json'
+      );
+      expect(response.body.execute.headers['_content-_type']).toBeUndefined();
+    });
+  });
+
   describe('POST /api/v1/tools', () => {
     test('authenticated user with permission can create a tool', async () => {
       const response = await authenticatedTestClient(userToken)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #128 — two related bugs in HTTP tool execution for DELETE requests:

- **Bug 1 — DELETE body not sent**: `hasBody` excluded DELETE from sending a request body, so args were appended as query params and `Content-Type` was never added. Removed DELETE from the exclusion list (DELETE with a JSON body is valid per HTTP spec).

- **Bug 2 — Header name corruption**: The `camelToSnake` response middleware converted `Content-Type` → `_content-_type` when returning tool configs. Added `'execute'` to the outbound skip keys so the execute config (including headers) is passed through without key transformation.

## Test plan

- [ ] `agentToolResolver.test.ts`: new test verifies DELETE tool sends `Content-Type: application/json` and a JSON body
- [ ] `tools.test.ts`: new test verifies `execute.headers['Content-Type']` is preserved exactly in API responses (not corrupted to `_content-_type`)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm eslint --fix` passes

https://claude.ai/code/session_01MrzMkpBMVg1epeLPBx9x5k
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrzMkpBMVg1epeLPBx9x5k)_