### PR TITLE
feat(agents): single_session_per_actor — enforce one open session per actor

### DIFF
--- a/packages/postgresdb/src/models/Agent.ts
+++ b/packages/postgresdb/src/models/Agent.ts
@@ -90,6 +90,9 @@ export class Agent extends Model {
   @Column({ type: DataType.JSONB, allowNull: true })
   declare knowledgeConfig: object | null;
 
+  @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: false })
+  declare singleSessionPerActor: boolean;
+
   @Column({ type: DataType.DATE })
   declare createdAt: Date;
 

--- a/packages/server/src/errors/codes.ts
+++ b/packages/server/src/errors/codes.ts
@@ -28,6 +28,11 @@ export const ERROR_CODES = {
     description:
       'The generation does not exist or is not in a pending state for tool output submission.',
   },
+  SINGLE_SESSION_CONFLICT: {
+    httpStatus: 409,
+    description:
+      'An open session already exists for this actor. Use the existing session or close it first.',
+  },
   GENERATION_ALREADY_IN_PROGRESS: {
     httpStatus: 409,
     description:

--- a/packages/server/src/lib/agents.ts
+++ b/packages/server/src/lib/agents.ts
@@ -29,6 +29,7 @@ export type MappedAgent = {
   temperature: number | null;
   knowledgeConfig: object | null;
   maxContextMessages: number | null;
+  singleSessionPerActor: boolean;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -65,6 +66,7 @@ const mapAgent = (
     temperature: agent.temperature,
     knowledgeConfig: agent.knowledgeConfig,
     maxContextMessages: agent.maxContextMessages,
+    singleSessionPerActor: agent.singleSessionPerActor,
     createdAt: agent.createdAt,
     updatedAt: agent.updatedAt,
   };
@@ -87,6 +89,7 @@ type AgentUpdateFields = {
   temperature?: number | null;
   knowledgeConfig?: object | null;
   maxContextMessages?: number | null;
+  singleSessionPerActor?: boolean;
 };
 
 const AGENT_SCALAR_FIELDS = [
@@ -103,6 +106,7 @@ const AGENT_SCALAR_FIELDS = [
   'temperature',
   'knowledgeConfig',
   'maxContextMessages',
+  'singleSessionPerActor',
 ] as const;
 
 const buildAgentUpdates = (
@@ -140,6 +144,7 @@ export const createAgent = async (args: {
   temperature?: number;
   knowledgeConfig?: object;
   maxContextMessages?: number;
+  singleSessionPerActor?: boolean;
 }): Promise<MappedAgent> => {
   const aiProviderId = await resolveAiProviderDbId(args.aiProviderId);
   if (!aiProviderId)

--- a/packages/server/src/lib/sessions.ts
+++ b/packages/server/src/lib/sessions.ts
@@ -86,6 +86,19 @@ export const createSession = async (args: {
       );
     }
     existingActorId = existingActor.id;
+
+    if (agent.singleSessionPerActor) {
+      const conflictingSession = await db.Session.findOne({
+        where: { agentId: agent.id, actorId: existingActorId, status: 'open' },
+      });
+      if (conflictingSession) {
+        throw new DomainError(
+          'SINGLE_SESSION_CONFLICT',
+          'An open session already exists for this actor.',
+          { session_id: conflictingSession.publicId }
+        );
+      }
+    }
   }
 
   const session = await db.sequelize.transaction((t) => {

--- a/packages/server/src/rest/openapi/v1/agents.yaml
+++ b/packages/server/src/rest/openapi/v1/agents.yaml
@@ -555,6 +555,9 @@ components:
           type: integer
           nullable: true
           description: Maximum number of recent messages to include in the context window sent to the model. When null, all messages are included.
+        single_session_per_actor:
+          type: boolean
+          description: When true, only one open session per actor_id is allowed for this agent. Creating a second open session for the same actor returns 409.
         created_at:
           type: string
           format: date-time
@@ -633,6 +636,9 @@ components:
         max_context_messages:
           type: integer
           description: Maximum number of recent messages included in the context window. Null means no limit.
+        single_session_per_actor:
+          type: boolean
+          description: When true, only one open session per actor_id is allowed for this agent.
 
     UpdateAgentRequest:
       type: object
@@ -712,6 +718,10 @@ components:
           type: integer
           nullable: true
           description: Maximum number of recent messages included in the context window. Null means no limit.
+        single_session_per_actor:
+          type: boolean
+          nullable: true
+          description: When true, only one open session per actor_id is allowed for this agent.
 
     CreateAgentGenerationRequest:
       type: object

--- a/packages/server/src/rest/openapi/v1/sessions.yaml
+++ b/packages/server/src/rest/openapi/v1/sessions.yaml
@@ -52,6 +52,18 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          description: An open session already exists for this actor (single_session_per_actor is enabled)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: SINGLE_SESSION_CONFLICT
+                  message: An open session already exists for this actor.
+                  meta:
+                    session_id: sess_abc123
     get:
       tags:
         - Sessions

--- a/packages/server/src/rest/v1/agents.ts
+++ b/packages/server/src/rest/v1/agents.ts
@@ -40,6 +40,7 @@ type CreateAgentBody = {
   temperature?: unknown;
   knowledgeConfig?: unknown;
   maxContextMessages?: unknown;
+  singleSessionPerActor?: unknown;
   projectId?: string;
 };
 
@@ -74,6 +75,10 @@ const parseUpdateAgentBody = (body: Record<string, unknown>) => {
     temperature: parseOptional<number | null>(body.temperature),
     knowledgeConfig: parseOptional<object | null>(body.knowledgeConfig),
     maxContextMessages: parseOptional<number | null>(body.maxContextMessages),
+    singleSessionPerActor:
+      typeof body.singleSessionPerActor === 'boolean'
+        ? body.singleSessionPerActor
+        : undefined,
   };
 };
 
@@ -124,6 +129,10 @@ const buildCreateAgentArgs = (
     temperature: parseNumber(body.temperature),
     knowledgeConfig: body.knowledgeConfig as object | undefined,
     maxContextMessages: parseNumber(body.maxContextMessages),
+    singleSessionPerActor:
+      typeof body.singleSessionPerActor === 'boolean'
+        ? body.singleSessionPerActor
+        : undefined,
   };
 };
 

--- a/packages/server/tests/unit/tests/rest/sessions.test.ts
+++ b/packages/server/tests/unit/tests/rest/sessions.test.ts
@@ -1701,7 +1701,7 @@ describe('Sessions', () => {
     });
 
     test('agent has single_session_per_actor true', async () => {
-      const res = await authenticatedTestClient(userToken).get(
+      const res = await authenticatedTestClient(adminToken).get(
         `/api/v1/agents/${singleSessionAgentId}`
       );
       expect(res.status).toBe(200);

--- a/packages/server/tests/unit/tests/rest/sessions.test.ts
+++ b/packages/server/tests/unit/tests/rest/sessions.test.ts
@@ -646,9 +646,9 @@ describe('Sessions', () => {
       const callArgs = mockCreateGeneration.mock.calls[0][0] as {
         messages: Array<{ role: string; content: string }>;
       };
-      const nonSystemMessages = callArgs.messages.filter(
-        (m) => m.role !== 'system'
-      );
+      const nonSystemMessages = callArgs.messages.filter((m) => {
+        return m.role !== 'system';
+      });
       expect(nonSystemMessages).toHaveLength(2);
       expect(nonSystemMessages[0].content).toContain('Message 3');
       expect(nonSystemMessages[1].content).toContain('Message 4');
@@ -1674,6 +1674,129 @@ describe('Sessions', () => {
         .send({});
 
       expect(genRes.status).toBe(200);
+    });
+  });
+
+  // ── single_session_per_actor ───────────────────────────────────────────
+
+  describe('single_session_per_actor', () => {
+    let singleSessionAgentId: string;
+    let singleSessionActorId: string;
+
+    beforeAll(async () => {
+      const agentRes = await authenticatedTestClient(userToken)
+        .post('/api/v1/agents')
+        .send({
+          project_id: projectId,
+          ai_provider_id: aiProviderId,
+          name: 'Single Session Agent',
+          single_session_per_actor: true,
+        });
+      singleSessionAgentId = agentRes.body.id;
+
+      const actorRes = await authenticatedTestClient(adminToken)
+        .post('/api/v1/actors')
+        .send({ project_id: projectId, name: 'Single Session Actor' });
+      singleSessionActorId = actorRes.body.id;
+    });
+
+    test('agent has single_session_per_actor true', async () => {
+      const res = await authenticatedTestClient(userToken).get(
+        `/api/v1/agents/${singleSessionAgentId}`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.single_session_per_actor).toBe(true);
+    });
+
+    test('first session with actor_id succeeds', async () => {
+      const res = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${singleSessionAgentId}/sessions`)
+        .send({ actor_id: singleSessionActorId });
+      expect(res.status).toBe(201);
+      expect(res.body.id).toMatch(/^sess_/);
+    });
+
+    test('second session with same actor_id returns 409 with session_id in meta', async () => {
+      // ensure first session exists
+      const first = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${singleSessionAgentId}/sessions`)
+        .send({ actor_id: singleSessionActorId });
+      // might be 409 if previous test created it, or 201
+      const existingId =
+        first.status === 201
+          ? first.body.id
+          : first.body.error?.meta?.session_id;
+
+      const second = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${singleSessionAgentId}/sessions`)
+        .send({ actor_id: singleSessionActorId });
+      expect(second.status).toBe(409);
+      expect(second.body.error.code).toBe('SINGLE_SESSION_CONFLICT');
+      expect(second.body.error.meta.session_id).toMatch(/^sess_/);
+      if (existingId) {
+        expect(second.body.error.meta.session_id).toBe(existingId);
+      }
+    });
+
+    test('no enforcement when actor_id is absent', async () => {
+      const res1 = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${singleSessionAgentId}/sessions`)
+        .send({});
+      expect(res1.status).toBe(201);
+
+      const res2 = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${singleSessionAgentId}/sessions`)
+        .send({});
+      expect(res2.status).toBe(201);
+    });
+
+    test('no enforcement when single_session_per_actor is false', async () => {
+      const agentRes = await authenticatedTestClient(userToken)
+        .post('/api/v1/agents')
+        .send({
+          project_id: projectId,
+          ai_provider_id: aiProviderId,
+          name: 'No Single Session Agent',
+          single_session_per_actor: false,
+        });
+      const normalAgentId = agentRes.body.id;
+
+      const actorRes = await authenticatedTestClient(adminToken)
+        .post('/api/v1/actors')
+        .send({ project_id: projectId, name: 'Normal Actor' });
+      const normalActorId = actorRes.body.id;
+
+      const res1 = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${normalAgentId}/sessions`)
+        .send({ actor_id: normalActorId });
+      expect(res1.status).toBe(201);
+
+      const res2 = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${normalAgentId}/sessions`)
+        .send({ actor_id: normalActorId });
+      expect(res2.status).toBe(201);
+    });
+
+    test('after closing existing session, new session can be created', async () => {
+      const actorRes = await authenticatedTestClient(adminToken)
+        .post('/api/v1/actors')
+        .send({ project_id: projectId, name: 'Reopen Actor' });
+      const actorId = actorRes.body.id;
+
+      const sess1 = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${singleSessionAgentId}/sessions`)
+        .send({ actor_id: actorId });
+      expect(sess1.status).toBe(201);
+      const sessId = sess1.body.id;
+
+      await authenticatedTestClient(userToken)
+        .patch(`/api/v1/agents/${singleSessionAgentId}/sessions/${sessId}`)
+        .send({ status: 'closed' });
+
+      const sess2 = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${singleSessionAgentId}/sessions`)
+        .send({ actor_id: actorId });
+      expect(sess2.status).toBe(201);
     });
   });
 });

--- a/packages/website/docs/modules/agents.md
+++ b/packages/website/docs/modules/agents.md
@@ -39,6 +39,7 @@ Each agent stores its AI provider, instructions, tool references, and execution 
 | `temperature`      | number        | no       | Sampling temperature                                                                                                             |
 | `knowledge_config` | object        | no       | Knowledge retrieval config injected before every generation — see [Knowledge Config](#knowledge-config)                          |
 | `max_context_messages` | number    | no       | Maximum number of recent messages sent to the model per generation — see [Context Window Limiting](#context-window-limiting)     |
+| `single_session_per_actor` | boolean | no  | When `true`, only one open session per `actor_id` is allowed — see [Single Session Per Actor](#single-session-per-actor)         |
 
 ### Agent Tool
 
@@ -328,6 +329,26 @@ Set `max_context_messages` on the agent to cap how many recent messages are incl
 ```
 
 When `null` (the default), all messages are included.
+
+### Single Session Per Actor
+
+When `single_session_per_actor` is `true`, the server enforces that only one open session per `actor_id` can exist at a time for that agent.
+
+- If a second `POST /agents/:id/sessions` is made with the same `actor_id` while an open session already exists, the server returns `409 Conflict` with error code `SINGLE_SESSION_CONFLICT` and `meta.session_id` pointing to the existing session.
+- Requests without an `actor_id` are not affected regardless of this flag.
+- Closing or deleting the existing session allows a new one to be created.
+
+```json
+{
+  "error": {
+    "code": "SINGLE_SESSION_CONFLICT",
+    "message": "An open session already exists for this actor.",
+    "meta": {
+      "session_id": "sess_..."
+    }
+  }
+}
+```
 
 ### Active Tools
 

--- a/packages/website/docs/modules/sessions.md
+++ b/packages/website/docs/modules/sessions.md
@@ -68,6 +68,24 @@ Content-Type: application/json
 
 The explicit `POST .../generate` endpoint continues to work regardless of this setting. Async generation (`?async=true`) is also supported on `POST .../messages` when `auto_generate` is enabled — the request returns `202 Accepted` immediately and generation proceeds in the background.
 
+### Single Session Per Actor
+
+When the parent agent has `single_session_per_actor: true`, `POST /agents/:id/sessions` with an `actor_id` will return `409 Conflict` if an open session for that actor already exists. The error body includes `meta.session_id` with the existing session's ID so the caller can reuse it without a separate lookup:
+
+```json
+{
+  "error": {
+    "code": "SINGLE_SESSION_CONFLICT",
+    "message": "An open session already exists for this actor.",
+    "meta": {
+      "session_id": "sess_..."
+    }
+  }
+}
+```
+
+Requests without `actor_id` are not subject to this check.
+
 ### Inactivity TTL
 
 Sessions can be configured to expire automatically after a period of inactivity using `inactivity_ttl_seconds`.

--- a/tests/smoke-tests.sh
+++ b/tests/smoke-tests.sh
@@ -1676,5 +1676,57 @@ echo "Session formation deleted."
 
 echo "Formations new resource types coverage: OK"
 
+# single_session_per_actor
+echo "--- single_session_per_actor enforcement ---"
+SSA_ACTOR_RESP=$($SOAT_CLI create-actor \
+  --project_id "$PROJECT_PUBLIC_ID" --name smoke-ssa-actor)
+SSA_ACTOR_ID=$(printf '%s\n' "$SSA_ACTOR_RESP" | jq -r '.id')
+if [ -z "$SSA_ACTOR_ID" ] || [ "$SSA_ACTOR_ID" = "null" ]; then
+  echo "ERROR: Failed to create actor for single_session_per_actor test" >&2
+  printf '%s\n' "$SSA_ACTOR_RESP" >&2
+  exit 1
+fi
+
+SSA_AGENT_RESP=$(curl -s -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"project_id\":\"$PROJECT_PUBLIC_ID\",\"ai_provider_id\":\"$AI_PROVIDER_ID\",\"name\":\"smoke-ssa-agent\",\"single_session_per_actor\":true}" \
+  "$BASE_URL/api/v1/agents")
+SSA_AGENT_ID=$(printf '%s\n' "$SSA_AGENT_RESP" | jq -r '.id')
+if [ -z "$SSA_AGENT_ID" ] || [ "$SSA_AGENT_ID" = "null" ]; then
+  echo "ERROR: Failed to create single_session_per_actor agent" >&2
+  printf '%s\n' "$SSA_AGENT_RESP" >&2
+  exit 1
+fi
+echo "SSA agent created: $SSA_AGENT_ID"
+
+SSA_SESSION_RESP=$(curl -s -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"actor_id\":\"$SSA_ACTOR_ID\"}" \
+  "$BASE_URL/api/v1/agents/$SSA_AGENT_ID/sessions")
+SSA_SESSION_ID=$(printf '%s\n' "$SSA_SESSION_RESP" | jq -r '.id')
+if [ -z "$SSA_SESSION_ID" ] || [ "$SSA_SESSION_ID" = "null" ]; then
+  echo "ERROR: First session creation should succeed" >&2
+  printf '%s\n' "$SSA_SESSION_RESP" >&2
+  exit 1
+fi
+echo "First session created: $SSA_SESSION_ID"
+
+SSA_CONFLICT_RESP=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"actor_id\":\"$SSA_ACTOR_ID\"}" \
+  "$BASE_URL/api/v1/agents/$SSA_AGENT_ID/sessions")
+if [ "$SSA_CONFLICT_RESP" != "409" ]; then
+  echo "ERROR: Expected 409 on duplicate session, got $SSA_CONFLICT_RESP" >&2
+  exit 1
+fi
+echo "Duplicate session correctly rejected with 409."
+
+$SOAT_CLI delete-agent --agent-id "$SSA_AGENT_ID"
+$SOAT_CLI delete-actor --actor-id "$SSA_ACTOR_ID"
+echo "single_session_per_actor: OK"
+
 echo ""
 echo "=== All smoke tests passed! ==="


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `single_session_per_actor` (boolean, default `false`) to the `Agent` DB model and OpenAPI spec
- Adds `SINGLE_SESSION_CONFLICT` error code (HTTP 409) to `packages/server/src/errors/codes.ts`
- Enforces the constraint in `createSession`: when `agent.singleSessionPerActor && actorId`, checks for an existing open session and throws 409 with `meta.session_id` pointing to the conflicting session
- Updates `CreateAgentRequest` and `UpdateAgentRequest` OpenAPI schemas; regenerated SDK and CLI
- Updates module docs for agents and sessions
- Adds tests covering: happy path, 409 conflict with `meta.session_id`, no enforcement without `actor_id`, no enforcement when flag is `false`, and re-create after closing the existing session
- Adds smoke test steps

Closes #135

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm eslint --fix` passes
- [ ] `pnpm test --testPathPatterns=sessions.test.ts` passes (requires Docker)
- [ ] `pnpm run -w smoke-tests` passes end-to-end

https://claude.ai/code/session_01BfoJA1Lxj95cduQAbBhR8Z
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfoJA1Lxj95cduQAbBhR8Z)_