### PR TITLE
feat(sessions): add expired status with lazy TTL update

### DIFF
--- a/packages/server/src/lib/sessionOperations.ts
+++ b/packages/server/src/lib/sessionOperations.ts
@@ -140,7 +140,9 @@ const buildGenerationResult = (
   };
 };
 
-const checkSessionExpiry = (session: InstanceType<(typeof db)['Session']>) => {
+const checkSessionExpiry = async (
+  session: InstanceType<(typeof db)['Session']>
+) => {
   const ttl = session.inactivityTtlSeconds;
   if (!ttl) {
     return;
@@ -148,6 +150,9 @@ const checkSessionExpiry = (session: InstanceType<(typeof db)['Session']>) => {
   const lastActivity = session.lastActivityAt ?? session.createdAt;
   const elapsed = Date.now() - new Date(lastActivity).getTime();
   if (elapsed > ttl * 1000) {
+    if (session.status !== 'expired') {
+      await session.update({ status: 'expired' });
+    }
     throw new DomainError(
       'SESSION_EXPIRED',
       'The session has expired due to inactivity.'
@@ -170,7 +175,7 @@ export const generateSessionResponse = async (args: {
     throw new DomainError('RESOURCE_NOT_FOUND', 'Session not found');
   }
 
-  checkSessionExpiry(session);
+  await checkSessionExpiry(session);
 
   const sessionKey = `${args.agentId}#${args.sessionId}`;
   const concurrencyResult = checkConcurrency({ sessionKey, session });

--- a/packages/server/src/lib/sessions.ts
+++ b/packages/server/src/lib/sessions.ts
@@ -3,6 +3,23 @@ import { DomainError } from '../errors';
 import { emitEvent, resolveProjectPublicId } from './eventBus';
 import { createSessionTransaction } from './sessionTransaction';
 
+const isSessionExpired = (session: InstanceType<(typeof db)['Session']>) => {
+  const ttl = session.inactivityTtlSeconds;
+  if (!ttl || session.status !== 'open') {
+    return false;
+  }
+  const lastActivity = session.lastActivityAt ?? session.createdAt;
+  return Date.now() - new Date(lastActivity).getTime() > ttl * 1000;
+};
+
+const checkAndExpireSession = async (
+  session: InstanceType<(typeof db)['Session']>
+) => {
+  if (isSessionExpired(session)) {
+    await session.update({ status: 'expired' });
+  }
+};
+
 const sessionIncludes = () => {
   return [
     { model: db.Project, as: 'project' },
@@ -183,6 +200,8 @@ export const listSessions = async (args: {
     order: [['createdAt', 'DESC']],
   });
 
+  await Promise.all(rows.map(checkAndExpireSession));
+
   return { data: rows.map(mapSession), total: count, limit, offset };
 };
 
@@ -201,6 +220,8 @@ export const getSession = async (args: {
       `Session '${args.sessionId}' not found.`
     );
   }
+
+  await checkAndExpireSession(session);
 
   return mapSession(session);
 };

--- a/packages/server/src/rest/openapi/v1/sessions.yaml
+++ b/packages/server/src/rest/openapi/v1/sessions.yaml
@@ -81,10 +81,10 @@ paths:
         - name: status
           in: query
           required: false
-          description: Filter by session status (open or closed)
+          description: Filter by session status (open, closed, or expired)
           schema:
             type: string
-            enum: [open, closed]
+            enum: [open, closed, expired]
         - name: limit
           in: query
           required: false
@@ -534,7 +534,7 @@ components:
           example: conv_V1StGXR8Z5jdHi6B
         status:
           type: string
-          enum: [open, closed]
+          enum: [open, closed, expired]
           example: open
         name:
           type: string
@@ -634,7 +634,7 @@ components:
           description: Session name (set to null to clear)
         status:
           type: string
-          enum: [open, closed]
+          enum: [open, closed, expired]
           description: Session status
         auto_generate:
           type: boolean

--- a/packages/server/tests/unit/tests/rest/sessions.test.ts
+++ b/packages/server/tests/unit/tests/rest/sessions.test.ts
@@ -1647,6 +1647,97 @@ describe('Sessions', () => {
       expect(genRes.status).toBe(200);
     });
 
+    test('expired session is excluded from ?status=open', async () => {
+      const sessionRes = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions`)
+        .send({ inactivity_ttl_seconds: 1 });
+      expect(sessionRes.status).toBe(201);
+      const expiredId = sessionRes.body.id;
+
+      await new Promise((resolve) => {
+        return setTimeout(resolve, 1500);
+      });
+
+      // Trigger lazy expiry via GET
+      const getRes = await authenticatedTestClient(userToken).get(
+        `/api/v1/agents/${agentId}/sessions/${expiredId}`
+      );
+      expect(getRes.status).toBe(200);
+      expect(getRes.body.status).toBe('expired');
+
+      // Must not appear in ?status=open
+      const listOpen = await authenticatedTestClient(userToken).get(
+        `/api/v1/agents/${agentId}/sessions?status=open`
+      );
+      expect(listOpen.status).toBe(200);
+      const openIds = listOpen.body.data.map((s: { id: string }) => {
+        return s.id;
+      });
+      expect(openIds).not.toContain(expiredId);
+
+      // Must appear in ?status=expired
+      const listExpired = await authenticatedTestClient(userToken).get(
+        `/api/v1/agents/${agentId}/sessions?status=expired`
+      );
+      expect(listExpired.status).toBe(200);
+      const expiredIds = listExpired.body.data.map((s: { id: string }) => {
+        return s.id;
+      });
+      expect(expiredIds).toContain(expiredId);
+    });
+
+    test('listSessions lazily expires rows before returning', async () => {
+      const sessionRes = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions`)
+        .send({ inactivity_ttl_seconds: 1 });
+      expect(sessionRes.status).toBe(201);
+      const lazyId = sessionRes.body.id;
+
+      await new Promise((resolve) => {
+        return setTimeout(resolve, 1500);
+      });
+
+      // Trigger expiry via list (no single GET)
+      const listRes = await authenticatedTestClient(userToken).get(
+        `/api/v1/agents/${agentId}/sessions`
+      );
+      expect(listRes.status).toBe(200);
+      const found = listRes.body.data.find((s: { id: string }) => {
+        return s.id === lazyId;
+      });
+      expect(found).toBeDefined();
+      expect(found.status).toBe('expired');
+    });
+
+    test('generate on expired session updates status to expired before returning 410', async () => {
+      const sessionRes = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions`)
+        .send({ inactivity_ttl_seconds: 1 });
+      expect(sessionRes.status).toBe(201);
+      const sessionId = sessionRes.body.id;
+
+      await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions/${sessionId}/messages`)
+        .send({ message: 'hello' });
+
+      await new Promise((resolve) => {
+        return setTimeout(resolve, 1500);
+      });
+
+      const genRes = await authenticatedTestClient(userToken).post(
+        `/api/v1/agents/${agentId}/sessions/${sessionId}/generate`
+      );
+      expect(genRes.status).toBe(410);
+      expect(genRes.body.error.code).toBe('SESSION_EXPIRED');
+
+      // DB must now reflect expired status
+      const getRes = await authenticatedTestClient(userToken).get(
+        `/api/v1/agents/${agentId}/sessions/${sessionId}`
+      );
+      expect(getRes.status).toBe(200);
+      expect(getRes.body.status).toBe('expired');
+    });
+
     test('session with TTL 0 never expires', async () => {
       mockCreateGeneration.mockResolvedValueOnce({
         id: 'gen_ttl_zero',
@@ -1736,6 +1827,35 @@ describe('Sessions', () => {
       if (existingId) {
         expect(second.body.error.meta.session_id).toBe(existingId);
       }
+    });
+
+    test('expired session does not block new session creation', async () => {
+      const actorRes = await authenticatedTestClient(adminToken)
+        .post('/api/v1/actors')
+        .send({ project_id: projectId, name: 'Expired Session Actor' });
+      const expiredActorId = actorRes.body.id;
+
+      // Create a session with very short TTL
+      const sess1 = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${singleSessionAgentId}/sessions`)
+        .send({ actor_id: expiredActorId, inactivity_ttl_seconds: 1 });
+      expect(sess1.status).toBe(201);
+      const expiredSessId = sess1.body.id;
+
+      // Wait for TTL to elapse and trigger lazy expiry via GET
+      await new Promise((resolve) => {
+        return setTimeout(resolve, 1500);
+      });
+      const getRes = await authenticatedTestClient(userToken).get(
+        `/api/v1/agents/${singleSessionAgentId}/sessions/${expiredSessId}`
+      );
+      expect(getRes.body.status).toBe('expired');
+
+      // New session for same actor should now succeed (expired != open)
+      const sess2 = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${singleSessionAgentId}/sessions`)
+        .send({ actor_id: expiredActorId });
+      expect(sess2.status).toBe(201);
     });
 
     test('no enforcement when actor_id is absent', async () => {

--- a/packages/website/docs/modules/sessions.md
+++ b/packages/website/docs/modules/sessions.md
@@ -37,7 +37,7 @@ The session automatically creates and manages the underlying conversation. An op
 
 ### Lifecycle
 
-A session starts in `open` status. It can be updated to `closed` when the interaction is complete. Deleting a session cascades to the underlying conversation.
+A session starts in `open` status. It can be updated to `closed` when the interaction is complete. If `inactivity_ttl_seconds` is configured, the status transitions to `expired` lazily when the session is next fetched or listed after the TTL elapses. Deleting a session cascades to the underlying conversation.
 
 ### Actor ID
 
@@ -93,7 +93,9 @@ Sessions can be configured to expire automatically after a period of inactivity 
 - **`0` (default)** — the session never expires.
 - **Any positive integer** — the session expires if no user message has been added for that many seconds since `last_activity_at` (or `created_at` if no messages exist yet).
 
-When a session has expired, calls to `POST .../generate` return `410 Gone` with error code `SESSION_EXPIRED`. The caller should open a fresh session to continue.
+When a session has exceeded its TTL, its `status` is lazily updated to `expired` the next time it is fetched or listed. Once expired, calls to `POST .../generate` return `410 Gone` with error code `SESSION_EXPIRED`. The caller should open a fresh session to continue.
+
+Expired sessions are excluded from `?status=open` queries and can be filtered explicitly with `?status=expired`.
 
 ```json
 POST /agents/{agent_id}/sessions
@@ -114,7 +116,7 @@ HTTP 410 Gone
 }
 ```
 
-The TTL is checked on every generation request — there is no background job. Sessions are never automatically deleted; only the generation call is rejected.
+The TTL is checked on every read — there is no background job. Sessions are never automatically deleted; only the generation call is rejected.
 
 ### Tool Context
 
@@ -210,7 +212,7 @@ This is useful for local testing where no actor record exists yet. The values yo
 | `id`                      | string         | Public identifier prefixed with `sess_`                                                                        |
 | `agent_id`                | string         | Public ID of the agent this session belongs to                                                                 |
 | `conversation_id`         | string         | Public ID of the underlying conversation                                                                       |
-| `status`                  | string         | `open` (default) or `closed`                                                                                   |
+| `status`                  | string         | `open` (default), `closed`, or `expired`                                                                       |
 | `name`                    | string         | Optional display name                                                                                          |
 | `actor_id`                | string \| null | Optional public ID of the Actor associated with this session (`actr_` prefix); `null` when no actor is set     |
 | `tags`                    | object         | Free-form key-value metadata                                                                                   |


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `expired` to the `status` enum on Session (`open | closed | expired`)
- `checkAndExpireSession` helper in `sessions.ts` updates `status → expired` lazily when TTL condition is met
- `getSession` and `listSessions` call the helper before mapping and returning, so `?status=open` naturally excludes expired sessions and `?status=expired` works
- `generateSessionResponse` in `sessionOperations.ts` also marks the session expired before throwing `SESSION_EXPIRED` (410), keeping the DB consistent
- OpenAPI spec updated with `expired` in status enums; SDK and CLI regenerated
- Docs updated (Lifecycle section + Data Model table)

## Test plan

- [ ] Expired session excluded from `?status=open`, returned by `?status=expired`
- [ ] `listSessions` lazily expires rows before returning
- [ ] Single GET of expired session returns `expired` status
- [ ] Generate on expired session sets `status = expired` in DB before returning 410
- [ ] `single_session_per_actor`: expired session does not block new session creation

Closes #136
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAtxDC8zKRTNwpeqP316yQ)_