### PR TITLE
Replace curl REST calls in smoke tests with CLI; document CLI-first rule

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -223,6 +223,10 @@ pnpm --filter @soat/server test --testPathPatterns=mcp.test.ts
 
 The smoke tests (`tests/smoke-tests.sh`) are end-to-end shell scripts that run against a live server. They require `curl` and `jq`.
 
+### CLI-first rule
+
+**All operations in `smoke-tests.sh` must be performed via the `$SOAT_CLI` wrapper** (e.g. `$SOAT_CLI create-agent`, `$SOAT_CLI create-agent-session`). The only permitted exception is the MCP JSON-RPC protocol check (`POST /mcp`), which uses `curl` because the `/mcp` endpoint is not a REST API operation and has no CLI equivalent. Do **not** use `curl` to call any `/api/v1/*` endpoint — if the CLI does not yet support an operation, add it to the CLI first.
+
 ### Running
 
 ```bash

--- a/tests/smoke-tests.sh
+++ b/tests/smoke-tests.sh
@@ -1687,11 +1687,11 @@ if [ -z "$SSA_ACTOR_ID" ] || [ "$SSA_ACTOR_ID" = "null" ]; then
   exit 1
 fi
 
-SSA_AGENT_RESP=$(curl -s -X POST \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{\"project_id\":\"$PROJECT_PUBLIC_ID\",\"ai_provider_id\":\"$AI_PROVIDER_ID\",\"name\":\"smoke-ssa-agent\",\"single_session_per_actor\":true}" \
-  "$BASE_URL/api/v1/agents")
+SSA_AGENT_RESP=$($SOAT_CLI create-agent \
+  --project_id "$PROJECT_PUBLIC_ID" \
+  --ai_provider_id "$AI_PROVIDER_ID" \
+  --name smoke-ssa-agent \
+  --single_session_per_actor true)
 SSA_AGENT_ID=$(printf '%s\n' "$SSA_AGENT_RESP" | jq -r '.id')
 if [ -z "$SSA_AGENT_ID" ] || [ "$SSA_AGENT_ID" = "null" ]; then
   echo "ERROR: Failed to create single_session_per_actor agent" >&2
@@ -1700,11 +1700,9 @@ if [ -z "$SSA_AGENT_ID" ] || [ "$SSA_AGENT_ID" = "null" ]; then
 fi
 echo "SSA agent created: $SSA_AGENT_ID"
 
-SSA_SESSION_RESP=$(curl -s -X POST \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{\"actor_id\":\"$SSA_ACTOR_ID\"}" \
-  "$BASE_URL/api/v1/agents/$SSA_AGENT_ID/sessions")
+SSA_SESSION_RESP=$($SOAT_CLI create-agent-session \
+  --agent_id "$SSA_AGENT_ID" \
+  --actor_id "$SSA_ACTOR_ID")
 SSA_SESSION_ID=$(printf '%s\n' "$SSA_SESSION_RESP" | jq -r '.id')
 if [ -z "$SSA_SESSION_ID" ] || [ "$SSA_SESSION_ID" = "null" ]; then
   echo "ERROR: First session creation should succeed" >&2
@@ -1713,15 +1711,9 @@ if [ -z "$SSA_SESSION_ID" ] || [ "$SSA_SESSION_ID" = "null" ]; then
 fi
 echo "First session created: $SSA_SESSION_ID"
 
-SSA_CONFLICT_RESP=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{\"actor_id\":\"$SSA_ACTOR_ID\"}" \
-  "$BASE_URL/api/v1/agents/$SSA_AGENT_ID/sessions")
-if [ "$SSA_CONFLICT_RESP" != "409" ]; then
-  echo "ERROR: Expected 409 on duplicate session, got $SSA_CONFLICT_RESP" >&2
-  exit 1
-fi
+expect_cli_error_status 409 create-agent-session \
+  --agent_id "$SSA_AGENT_ID" \
+  --actor_id "$SSA_ACTOR_ID"
 echo "Duplicate session correctly rejected with 409."
 
 $SOAT_CLI delete-agent --agent-id "$SSA_AGENT_ID"


### PR DESCRIPTION
## Summary

- Replaced all `/api/v1/*` curl calls in `smoke-tests.sh` with `$SOAT_CLI` equivalents:
  - `create-agent --single_session_per_actor true` (was a raw curl POST)
  - `create-agent-session --agent_id ... --actor_id ...` (was a raw curl POST)
  - `expect_cli_error_status 409 create-agent-session ...` (was curl with `-w "%{http_code}"`)
- The `/mcp` JSON-RPC call remains as curl — it tests the MCP protocol endpoint directly, which has no REST-equivalent CLI command
- Codified the CLI-first rule in `.claude/rules/tests.md`: all `/api/v1/*` operations must use `$SOAT_CLI`; curl is only permitted for the MCP protocol check

## Test plan

- [ ] `pnpm run -w smoke-tests` passes end-to-end
- [ ] No remaining `curl` calls to `/api/v1/*` in `smoke-tests.sh`

https://claude.ai/code/session_01RQ5tMY9AaJiKveaAJt7aeg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQ5tMY9AaJiKveaAJt7aeg)_