### PR TITLE
fix: add single_session_per_actor and max_context_messages to formation agent validator

### DIFF
--- a/packages/server/src/lib/formation-modules/agentsFormationModule.ts
+++ b/packages/server/src/lib/formation-modules/agentsFormationModule.ts
@@ -76,6 +76,12 @@ const buildCreateAgentArgs = (args: {
     boundaryPolicy:
       toNullableObject(args.properties.boundary_policy) ?? undefined,
     temperature: toNullableNumber(args.properties.temperature) ?? undefined,
+    maxContextMessages:
+      toNullableNumber(args.properties.max_context_messages) ?? undefined,
+    singleSessionPerActor:
+      args.properties.single_session_per_actor != null
+        ? Boolean(args.properties.single_session_per_actor)
+        : undefined,
     knowledgeConfig:
       toNullableObject(args.properties.knowledge_config) ?? undefined,
   };
@@ -131,6 +137,11 @@ export const agentsFormationModule: FormationModule = {
       stepRules: toNullableArray<object>(properties.step_rules),
       boundaryPolicy: toNullableObject(properties.boundary_policy),
       temperature: toNullableNumber(properties.temperature),
+      maxContextMessages: toNullableNumber(properties.max_context_messages),
+      singleSessionPerActor:
+        properties.single_session_per_actor != null
+          ? Boolean(properties.single_session_per_actor)
+          : undefined,
       knowledgeConfig: toNullableObject(properties.knowledge_config),
     });
   },
@@ -155,6 +166,8 @@ export const agentsFormationModule: FormationModule = {
         step_rules: agent.stepRules,
         boundary_policy: agent.boundaryPolicy,
         temperature: agent.temperature,
+        max_context_messages: agent.maxContextMessages,
+        single_session_per_actor: agent.singleSessionPerActor,
         knowledge_config: agent.knowledgeConfig,
       };
     } catch {

--- a/packages/server/src/lib/formation-modules/agentsFormationModule.ts
+++ b/packages/server/src/lib/formation-modules/agentsFormationModule.ts
@@ -53,7 +53,43 @@ const validateAgentProperties = (args: {
   return errors;
 };
 
+const toOptionalBoolean = (value: unknown): boolean | undefined => {
+  return value != null ? Boolean(value) : undefined;
+};
+
+const toOptional = <T>(value: T | null | undefined): T | undefined => {
+  return value ?? undefined;
+};
+
 // ── Module export ────────────────────────────────────────────────────────
+
+const mapAgentProperties = (properties: Record<string, unknown>) => {
+  return {
+    aiProviderId: properties.ai_provider_id as string,
+    name: toOptionalString(properties.name),
+    instructions: toOptionalString(properties.instructions),
+    model: toOptionalString(properties.model),
+    toolIds: toOptional(toNullableArray<string>(properties.tool_ids)),
+    maxSteps: toOptional(toNullableNumber(properties.max_steps)),
+    toolChoice: toOptional(toNullableObject(properties.tool_choice)),
+    stopConditions: toOptional(
+      toNullableArray<object>(properties.stop_conditions)
+    ),
+    activeToolIds: toOptional(
+      toNullableArray<string>(properties.active_tool_ids)
+    ),
+    stepRules: toOptional(toNullableArray<object>(properties.step_rules)),
+    boundaryPolicy: toOptional(toNullableObject(properties.boundary_policy)),
+    temperature: toOptional(toNullableNumber(properties.temperature)),
+    maxContextMessages: toOptional(
+      toNullableNumber(properties.max_context_messages)
+    ),
+    singleSessionPerActor: toOptionalBoolean(
+      properties.single_session_per_actor
+    ),
+    knowledgeConfig: toOptional(toNullableObject(properties.knowledge_config)),
+  };
+};
 
 const buildCreateAgentArgs = (args: {
   properties: Record<string, unknown>;
@@ -61,29 +97,7 @@ const buildCreateAgentArgs = (args: {
 }) => {
   return {
     projectId: args.projectId,
-    aiProviderId: args.properties.ai_provider_id as string,
-    name: toOptionalString(args.properties.name),
-    instructions: toOptionalString(args.properties.instructions),
-    model: toOptionalString(args.properties.model),
-    toolIds: toNullableArray<string>(args.properties.tool_ids) ?? undefined,
-    maxSteps: toNullableNumber(args.properties.max_steps) ?? undefined,
-    toolChoice: toNullableObject(args.properties.tool_choice) ?? undefined,
-    stopConditions:
-      toNullableArray<object>(args.properties.stop_conditions) ?? undefined,
-    activeToolIds:
-      toNullableArray<string>(args.properties.active_tool_ids) ?? undefined,
-    stepRules: toNullableArray<object>(args.properties.step_rules) ?? undefined,
-    boundaryPolicy:
-      toNullableObject(args.properties.boundary_policy) ?? undefined,
-    temperature: toNullableNumber(args.properties.temperature) ?? undefined,
-    maxContextMessages:
-      toNullableNumber(args.properties.max_context_messages) ?? undefined,
-    singleSessionPerActor:
-      args.properties.single_session_per_actor != null
-        ? Boolean(args.properties.single_session_per_actor)
-        : undefined,
-    knowledgeConfig:
-      toNullableObject(args.properties.knowledge_config) ?? undefined,
+    ...mapAgentProperties(args.properties),
   };
 };
 
@@ -138,10 +152,9 @@ export const agentsFormationModule: FormationModule = {
       boundaryPolicy: toNullableObject(properties.boundary_policy),
       temperature: toNullableNumber(properties.temperature),
       maxContextMessages: toNullableNumber(properties.max_context_messages),
-      singleSessionPerActor:
-        properties.single_session_per_actor != null
-          ? Boolean(properties.single_session_per_actor)
-          : undefined,
+      singleSessionPerActor: toOptionalBoolean(
+        properties.single_session_per_actor
+      ),
       knowledgeConfig: toNullableObject(properties.knowledge_config),
     });
   },

--- a/packages/server/src/rest/openapi/v1/formations.yaml
+++ b/packages/server/src/rest/openapi/v1/formations.yaml
@@ -521,6 +521,14 @@ components:
           type: number
           nullable: true
           description: Sampling temperature
+        max_context_messages:
+          type: integer
+          nullable: true
+          description: Maximum number of recent messages to include in the context window sent to the model. When null, all messages are included.
+        single_session_per_actor:
+          type: boolean
+          nullable: true
+          description: When true, only one open session per actor_id is allowed for this agent.
         knowledge_config:
           type: object
           nullable: true


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `single_session_per_actor` and `max_context_messages` to the `AgentResourceProperties` schema in `formations.yaml`
- Updates `agentsFormationModule.ts` to pass these fields through on create, update, and read operations

Fixes #140

## Root Cause

The formation validator derives its allowlist from the `AgentResourceProperties` OpenAPI schema. These two fields were implemented in the agent REST API (#135, #129) but never added to the formation schema, so the validator rejected templates that used them.

## Test plan

- [ ] Formation template with `single_session_per_actor: true` passes validation
- [ ] Formation template with `max_context_messages: 20` passes validation
- [ ] Formation update correctly sets both fields on the agent
- [ ] Formation read correctly returns both fields

https://claude.ai/code/session_0167LjNzyw87UEmTikYSUZbK
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0167LjNzyw87UEmTikYSUZbK)_