### PR TITLE
feat(sessions): add idempotency_key to addSessionMessage

### DIFF
--- a/packages/cli/scripts/generate.ts
+++ b/packages/cli/scripts/generate.ts
@@ -43,6 +43,7 @@ interface OpenApiRequestBodyProperty {
 interface OpenApiRequestBodySchema {
   required?: string[];
   properties?: Record<string, OpenApiRequestBodyProperty>;
+  oneOf?: OpenApiRequestBodySchema[];
 }
 
 interface OpenApiRequestBody {
@@ -74,6 +75,7 @@ interface OpenApiPathItem {
 
 interface OpenApiComponents {
   parameters?: Record<string, OpenApiParameterFull>;
+  schemas?: Record<string, OpenApiRequestBodySchema & { $ref?: string }>;
 }
 
 interface OpenApiSpec {
@@ -154,6 +156,17 @@ for (const file of files) {
     return p;
   };
 
+  /** Resolve a schema that may be a $ref to components/schemas. */
+  const resolveSchema = (
+    schema: OpenApiRequestBodySchema & { $ref?: string }
+  ): OpenApiRequestBodySchema => {
+    if (schema.$ref) {
+      const refKey = schema.$ref.replace('#/components/schemas/', '');
+      return spec.components?.schemas?.[refKey] ?? schema;
+    }
+    return schema;
+  };
+
   for (const [, pathItem] of Object.entries(spec.paths ?? {})) {
     // Collect path-level parameters (inherited by all operations)
     const pathLevelParams = (pathItem.parameters ?? []).map(resolveParam);
@@ -196,19 +209,65 @@ for (const file of files) {
         });
       }
 
-      const bodySchema = op.requestBody?.content?.['application/json']?.schema;
-      if (bodySchema?.properties) {
-        const requiredBodyFields = new Set(bodySchema.required ?? []);
-        for (const [propName, propSchema] of Object.entries(
-          bodySchema.properties
-        )) {
-          flags.push({
-            name: propName,
-            description: propSchema.description ?? '',
-            required: requiredBodyFields.has(propName),
-            type: propSchema.type ?? 'string',
-            in: 'body',
-          });
+      const rawBodySchema = op.requestBody?.content?.['application/json']?.schema;
+      const bodySchema = rawBodySchema
+        ? resolveSchema(rawBodySchema as OpenApiRequestBodySchema & { $ref?: string })
+        : undefined;
+      if (bodySchema) {
+        const mergedProperties: Record<string, OpenApiRequestBodyProperty> = {};
+        const requiredInAll = new Set<string>();
+
+        const collectFromSchema = (schema: OpenApiRequestBodySchema) => {
+          if (schema.properties) {
+            const required = new Set(schema.required ?? []);
+            for (const [propName, propSchema] of Object.entries(
+              schema.properties
+            )) {
+              if (!mergedProperties[propName]) {
+                mergedProperties[propName] = propSchema;
+                if (required.has(propName)) requiredInAll.add(propName);
+              }
+            }
+          }
+        };
+
+        if (bodySchema.oneOf) {
+          for (const variant of bodySchema.oneOf) {
+            collectFromSchema(variant);
+          }
+          // A field is only required if it appears as required in ALL variants
+          const requiredEvery = new Set<string>();
+          for (const propName of Object.keys(mergedProperties)) {
+            if (
+              bodySchema.oneOf.every((v) => v.required?.includes(propName))
+            ) {
+              requiredEvery.add(propName);
+            }
+          }
+          for (const [propName, propSchema] of Object.entries(
+            mergedProperties
+          )) {
+            flags.push({
+              name: propName,
+              description: propSchema.description ?? '',
+              required: requiredEvery.has(propName),
+              type: propSchema.type ?? 'string',
+              in: 'body',
+            });
+          }
+        } else {
+          collectFromSchema(bodySchema);
+          for (const [propName, propSchema] of Object.entries(
+            mergedProperties
+          )) {
+            flags.push({
+              name: propName,
+              description: propSchema.description ?? '',
+              required: requiredInAll.has(propName),
+              type: propSchema.type ?? 'string',
+              in: 'body',
+            });
+          }
         }
       }
 

--- a/packages/postgresdb/src/models/ConversationMessage.ts
+++ b/packages/postgresdb/src/models/ConversationMessage.ts
@@ -23,6 +23,10 @@ import { Document } from './Document';
       unique: true,
       fields: ['conversation_id', 'position'],
     },
+    {
+      unique: true,
+      fields: ['conversation_id', 'idempotency_key'],
+    },
   ],
 })
 export class ConversationMessage extends Model {
@@ -87,4 +91,7 @@ export class ConversationMessage extends Model {
 
   @Column({ type: DataType.JSONB, allowNull: true })
   declare metadata: Record<string, unknown> | null;
+
+  @Column({ type: DataType.STRING, allowNull: true, field: 'idempotency_key' })
+  declare idempotencyKey: string | null;
 }

--- a/packages/server/src/lib/conversationMessages.ts
+++ b/packages/server/src/lib/conversationMessages.ts
@@ -64,6 +64,7 @@ const insertMessage = async (args: {
   agentId?: number | null;
   position?: number;
   metadata?: Record<string, unknown>;
+  idempotencyKey: string | null;
 }) => {
   return db.sequelize.transaction(async (t) => {
     let position = args.position;
@@ -103,10 +104,35 @@ const insertMessage = async (args: {
         agentId: args.agentId ?? null,
         position,
         metadata: args.metadata ?? null,
+        idempotencyKey: args.idempotencyKey,
       },
       { transaction: t }
     );
   });
+};
+
+const findIdempotentMessage = async (args: {
+  conversationId: number;
+  idempotencyKey: string;
+}) => {
+  const existing = await db.ConversationMessage.findOne({
+    where: {
+      conversationId: args.conversationId,
+      idempotencyKey: args.idempotencyKey,
+    },
+    include: [
+      {
+        model: db.Document,
+        as: 'document',
+        include: [{ model: db.File, as: 'file' }],
+      },
+      { model: db.Actor, as: 'actor' },
+      { model: db.Agent, as: 'agent' },
+    ],
+  });
+  return existing
+    ? { ...mapMessage(existing), idempotent: true as const }
+    : null;
 };
 
 export const addConversationMessage = async (args: {
@@ -117,6 +143,7 @@ export const addConversationMessage = async (args: {
   agentId?: string | null;
   position?: number;
   metadata?: Record<string, unknown>;
+  idempotencyKey?: string | null;
 }) => {
   const conversation = await db.Conversation.findOne({
     where: { publicId: args.conversationId },
@@ -126,14 +153,20 @@ export const addConversationMessage = async (args: {
     return null;
   }
 
-  let actorDbId: number | null = null;
-  let agentDbId: number | null = null;
+  if (args.idempotencyKey) {
+    const hit = await findIdempotentMessage({
+      conversationId: conversation.id,
+      idempotencyKey: args.idempotencyKey,
+    });
+    if (hit) return hit;
+  }
+
   const participants = await resolveParticipantDbIds({
     actorId: args.actorId,
     agentId: args.agentId,
   });
   if (!participants) return null;
-  ({ actorDbId, agentDbId } = participants);
+  const { actorDbId, agentDbId } = participants;
 
   const createdDoc = await createDocument({
     projectId: conversation.projectId,
@@ -156,6 +189,7 @@ export const addConversationMessage = async (args: {
     agentId: agentDbId,
     position: args.position,
     metadata: args.metadata,
+    idempotencyKey: args.idempotencyKey ?? null,
   });
 
   const messageWithAssociations = await db.ConversationMessage.findOne({
@@ -236,6 +270,7 @@ export const addConversationDocumentMessage = async (args: {
     agentId: participants.agentDbId,
     position: args.position,
     metadata: args.metadata,
+    idempotencyKey: null,
   });
 
   const messageWithAssociations = await db.ConversationMessage.findOne({

--- a/packages/server/src/lib/sessionMessageHelpers.ts
+++ b/packages/server/src/lib/sessionMessageHelpers.ts
@@ -1,0 +1,94 @@
+import type { AuthUser } from '../Context';
+import type { db } from '../db';
+import { DomainError } from '../errors';
+import {
+  addConversationDocumentMessage,
+  addConversationMessage,
+} from './conversationMessages';
+import { resolveMessageContent } from './messageContent';
+
+export const assertSessionMessageInput = (args: {
+  message?: string;
+  documentId?: string;
+}) => {
+  if (!args.message && !args.documentId) {
+    throw new DomainError(
+      'VALIDATION_FAILED',
+      'either message or documentId is required'
+    );
+  }
+  if (args.message && args.documentId) {
+    throw new DomainError(
+      'VALIDATION_FAILED',
+      'message and documentId are mutually exclusive'
+    );
+  }
+};
+
+export const addResolvedSessionUserMessage = async (args: {
+  conversationId: string;
+  actorId?: string | null;
+  message?: string;
+  documentId?: string;
+  authUser?: AuthUser;
+  idempotencyKey?: string;
+}) => {
+  const resolvedContent = await resolveMessageContent({
+    content: args.documentId
+      ? { type: 'document', documentId: args.documentId }
+      : (args.message ?? ''),
+    authUser: args.authUser,
+  });
+
+  const userMsg = args.documentId
+    ? await addConversationDocumentMessage({
+        conversationId: args.conversationId,
+        documentId: args.documentId,
+        role: 'user',
+        actorId: args.actorId ?? null,
+      })
+    : await addConversationMessage({
+        conversationId: args.conversationId,
+        message: resolvedContent.content,
+        role: 'user',
+        actorId: args.actorId ?? null,
+        idempotencyKey: args.idempotencyKey,
+      });
+
+  if (!userMsg) {
+    throw new DomainError('RESOURCE_NOT_FOUND', 'Session not found');
+  }
+
+  return { resolvedContent, userMsg };
+};
+
+type SessionRecord = InstanceType<(typeof db)['Session']> | null;
+
+type GenerateFn = (args: {
+  agentId: number;
+  sessionId: string;
+  toolContext?: Record<string, string>;
+}) => Promise<unknown>;
+
+export const triggerOrReturnMessage = (args: {
+  session: SessionRecord;
+  agentId: number;
+  sessionId: string;
+  toolContext?: Record<string, string>;
+  savedContent: string | null;
+  savedDocumentId: string | undefined;
+  generateFn: GenerateFn;
+}) => {
+  if (args.session?.autoGenerate && !args.session.generatingAt) {
+    return args.generateFn({
+      agentId: args.agentId,
+      sessionId: args.sessionId,
+      toolContext: args.toolContext,
+    });
+  }
+  return {
+    role: 'user' as const,
+    content: args.savedContent,
+    documentId: args.savedDocumentId,
+  };
+};

--- a/packages/server/src/lib/sessionOperations.ts
+++ b/packages/server/src/lib/sessionOperations.ts
@@ -3,18 +3,18 @@ import { db } from '../db';
 import { DomainError } from '../errors';
 import { submitToolOutputs } from './agents';
 import { generateConversationMessage } from './conversationGeneration';
-import {
-  addConversationDocumentMessage,
-  addConversationMessage,
-} from './conversationMessages';
 import { listConversationMessages } from './conversations';
-import { resolveMessageContent } from './messageContent';
 import {
   emitGenerationCompleted,
   emitGenerationRequiresAction,
   emitGenerationStarted,
   processToolOutputResult,
 } from './sessionGenerationHelpers';
+import {
+  addResolvedSessionUserMessage,
+  assertSessionMessageInput,
+  triggerOrReturnMessage,
+} from './sessionMessageHelpers';
 
 const GENERATING_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -273,60 +273,6 @@ export const listSessionMessages = async (args: {
   };
 };
 
-const assertSessionMessageInput = (args: {
-  message?: string;
-  documentId?: string;
-}) => {
-  if (!args.message && !args.documentId) {
-    throw new DomainError(
-      'VALIDATION_FAILED',
-      'either message or documentId is required'
-    );
-  }
-
-  if (args.message && args.documentId) {
-    throw new DomainError(
-      'VALIDATION_FAILED',
-      'message and documentId are mutually exclusive'
-    );
-  }
-};
-
-const addResolvedSessionUserMessage = async (args: {
-  conversationId: string;
-  actorId?: string | null;
-  message?: string;
-  documentId?: string;
-  authUser?: AuthUser;
-}) => {
-  const resolvedContent = await resolveMessageContent({
-    content: args.documentId
-      ? { type: 'document', documentId: args.documentId }
-      : (args.message ?? ''),
-    authUser: args.authUser,
-  });
-
-  const userMsg = args.documentId
-    ? await addConversationDocumentMessage({
-        conversationId: args.conversationId,
-        documentId: args.documentId,
-        role: 'user',
-        actorId: args.actorId ?? null,
-      })
-    : await addConversationMessage({
-        conversationId: args.conversationId,
-        message: resolvedContent.content,
-        role: 'user',
-        actorId: args.actorId ?? null,
-      });
-
-  if (!userMsg) {
-    throw new DomainError('RESOURCE_NOT_FOUND', 'Session not found');
-  }
-
-  return { resolvedContent, userMsg };
-};
-
 export const addSessionMessage = async (args: {
   agentId: number;
   sessionId: string;
@@ -334,6 +280,7 @@ export const addSessionMessage = async (args: {
   documentId?: string;
   toolContext?: Record<string, string>;
   authUser?: AuthUser;
+  idempotencyKey?: string;
 }) => {
   const session = await findSessionRecord({
     agentId: args.agentId,
@@ -364,23 +311,32 @@ export const addSessionMessage = async (args: {
     message: args.message,
     documentId: args.documentId,
     authUser: args.authUser,
+    idempotencyKey: args.idempotencyKey,
   });
+
+  const savedContent = userMsg.content ?? resolvedContent.content;
+  const savedDocumentId = userMsg.documentId ?? resolvedContent.documentId;
+
+  if ((userMsg as { idempotent?: boolean }).idempotent) {
+    return {
+      role: 'user' as const,
+      content: savedContent,
+      documentId: savedDocumentId,
+      idempotent: true as const,
+    };
+  }
 
   await session.update({ lastActivityAt: new Date() });
 
-  if (session.autoGenerate && !session.generatingAt) {
-    return generateSessionResponse({
-      agentId: args.agentId,
-      sessionId: args.sessionId,
-      toolContext: args.toolContext,
-    });
-  }
-
-  return {
-    role: 'user' as const,
-    content: userMsg.content ?? resolvedContent.content,
-    documentId: userMsg.documentId ?? resolvedContent.documentId,
-  };
+  return triggerOrReturnMessage({
+    session,
+    agentId: args.agentId,
+    sessionId: args.sessionId,
+    toolContext: args.toolContext,
+    savedContent,
+    savedDocumentId,
+    generateFn: generateSessionResponse,
+  });
 };
 
 export const sendSessionMessage = async (args: {

--- a/packages/server/src/rest/openapi/v1/sessions.yaml
+++ b/packages/server/src/rest/openapi/v1/sessions.yaml
@@ -259,6 +259,12 @@ paths:
             schema:
               $ref: '#/components/schemas/AddSessionMessageRequest'
       responses:
+        '200':
+          description: Duplicate request — original message returned (idempotency_key matched)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddSessionMessageSaved'
         '201':
           description: User message saved
           content:
@@ -663,6 +669,14 @@ components:
                 type: string
               nullable: true
               description: Key-value pairs injected as context headers into all tool call requests made during this generation.
+            idempotency_key:
+              type: string
+              description: >
+                Optional deduplication key scoped to this session. If a message
+                with the same key already exists in the session, the original
+                message is returned with HTTP 200 and no new message or
+                generation is triggered.
+              example: wamid.HBgLNTUxMTk4...
         - type: object
           additionalProperties: false
           required:
@@ -677,6 +691,14 @@ components:
                 type: string
               nullable: true
               description: Key-value pairs injected as context headers into all tool call requests made during this generation.
+            idempotency_key:
+              type: string
+              description: >
+                Optional deduplication key scoped to this session. If a message
+                with the same key already exists in the session, the original
+                message is returned with HTTP 200 and no new message or
+                generation is triggered.
+              example: wamid.HBgLNTUxMTk4...
 
     AddSessionMessageSaved:
       type: object

--- a/packages/server/src/rest/v1/sessionSubResources.ts
+++ b/packages/server/src/rest/v1/sessionSubResources.ts
@@ -70,6 +70,30 @@ sessionSubResourcesRouter.get('/:session_id/messages', async (ctx: Context) => {
 
 // ── Add Message ──────────────────────────────────────────────────────────
 
+const validateAddMessageBody = (body: {
+  message?: string;
+  documentId?: string;
+}) => {
+  if (body.message !== undefined && typeof body.message !== 'string') {
+    throw new DomainError('VALIDATION_FAILED', 'message must be a string');
+  }
+  if (body.documentId !== undefined && typeof body.documentId !== 'string') {
+    throw new DomainError('VALIDATION_FAILED', 'documentId must be a string');
+  }
+  if (!body.message && !body.documentId) {
+    throw new DomainError(
+      'VALIDATION_FAILED',
+      'either message or documentId is required'
+    );
+  }
+  if (body.message && body.documentId) {
+    throw new DomainError(
+      'VALIDATION_FAILED',
+      'message and documentId are mutually exclusive'
+    );
+  }
+};
+
 sessionSubResourcesRouter.post(
   '/:session_id/messages',
   async (ctx: Context) => {
@@ -79,29 +103,10 @@ sessionSubResourcesRouter.post(
       message?: string;
       documentId?: string;
       toolContext?: Record<string, string>;
+      idempotencyKey?: string;
     };
 
-    if (body.message !== undefined && typeof body.message !== 'string') {
-      throw new DomainError('VALIDATION_FAILED', 'message must be a string');
-    }
-
-    if (body.documentId !== undefined && typeof body.documentId !== 'string') {
-      throw new DomainError('VALIDATION_FAILED', 'documentId must be a string');
-    }
-
-    if (!body.message && !body.documentId) {
-      throw new DomainError(
-        'VALIDATION_FAILED',
-        'either message or documentId is required'
-      );
-    }
-
-    if (body.message && body.documentId) {
-      throw new DomainError(
-        'VALIDATION_FAILED',
-        'message and documentId are mutually exclusive'
-      );
-    }
+    validateAddMessageBody(body);
 
     const result = await addSessionMessage({
       agentId: agent.id as number,
@@ -110,11 +115,16 @@ sessionSubResourcesRouter.post(
       documentId: body.documentId,
       toolContext: body.toolContext,
       authUser: ctx.authUser,
+      idempotencyKey: body.idempotencyKey,
     });
 
-    ctx.status = 201;
+    const resultObj = result as Record<string, unknown>;
+    const isIdempotentHit = resultObj.idempotent === true;
+    ctx.status = isIdempotentHit ? 200 : 201;
     ctx.type = 'application/json';
-    ctx.body = result;
+
+    const { idempotent: _flag, ...responseBody } = resultObj;
+    ctx.body = responseBody;
   }
 );
 

--- a/packages/server/tests/unit/tests/rest/sessions.test.ts
+++ b/packages/server/tests/unit/tests/rest/sessions.test.ts
@@ -467,6 +467,58 @@ describe('Sessions', () => {
       expect(response.body.error.code).toBe('VALIDATION_FAILED');
       expect(response.body.error.message).toMatch(/message/);
     });
+
+    describe('idempotency_key', () => {
+      test('first call with idempotency_key returns 201', async () => {
+        const response = await authenticatedTestClient(userToken)
+          .post(`/api/v1/agents/${agentId}/sessions/${sessionId}/messages`)
+          .send({ message: 'Idempotent message', idempotency_key: 'idem-key-1' });
+
+        expect(response.status).toBe(201);
+        expect(response.body.role).toBe('user');
+        expect(response.body.content).toBe('Idempotent message');
+      });
+
+      test('duplicate call with same idempotency_key returns 200 with original message', async () => {
+        const key = 'idem-key-dup-' + Date.now();
+
+        const first = await authenticatedTestClient(userToken)
+          .post(`/api/v1/agents/${agentId}/sessions/${sessionId}/messages`)
+          .send({ message: 'Original message', idempotency_key: key });
+
+        expect(first.status).toBe(201);
+
+        const second = await authenticatedTestClient(userToken)
+          .post(`/api/v1/agents/${agentId}/sessions/${sessionId}/messages`)
+          .send({ message: 'Different message', idempotency_key: key });
+
+        expect(second.status).toBe(200);
+        expect(second.body.role).toBe('user');
+        expect(second.body.content).toBe('Original message');
+      });
+
+      test('same idempotency_key in different sessions is allowed', async () => {
+        const key = 'idem-key-cross-session-' + Date.now();
+
+        const sessionRes = await authenticatedTestClient(userToken)
+          .post(`/api/v1/agents/${agentId}/sessions`)
+          .send({ name: 'Second session for idempotency test' });
+        const secondSessionId = sessionRes.body.id;
+
+        const first = await authenticatedTestClient(userToken)
+          .post(`/api/v1/agents/${agentId}/sessions/${sessionId}/messages`)
+          .send({ message: 'Session 1 message', idempotency_key: key });
+
+        expect(first.status).toBe(201);
+
+        const second = await authenticatedTestClient(userToken)
+          .post(`/api/v1/agents/${agentId}/sessions/${secondSessionId}/messages`)
+          .send({ message: 'Session 2 message', idempotency_key: key });
+
+        expect(second.status).toBe(201);
+        expect(second.body.content).toBe('Session 2 message');
+      });
+    });
   });
 
   // ── Generate Session Response ──────────────────────────────────────────

--- a/packages/website/docs/modules/sessions.md
+++ b/packages/website/docs/modules/sessions.md
@@ -86,6 +86,24 @@ When the parent agent has `single_session_per_actor: true`, `POST /agents/:id/se
 
 Requests without `actor_id` are not subject to this check.
 
+### Idempotency
+
+Channels like WhatsApp use at-least-once webhook delivery — the same inbound message may arrive multiple times. Pass `idempotency_key` in the `POST .../messages` body to deduplicate:
+
+```json
+{
+  "message": "Hello",
+  "idempotency_key": "wamid.HBgLNTUxMTk4..."
+}
+```
+
+**Behavior:**
+
+- **First call** — message is saved and, if `auto_generate` is on, generation is triggered. Returns `201 Created`.
+- **Subsequent calls with the same key** — no new message or generation is created; the original message is returned immediately. Returns `200 OK`.
+
+The key is scoped to the session: the same key may be reused across different sessions without conflict.
+
 ### Inactivity TTL
 
 Sessions can be configured to expire automatically after a period of inactivity using `inactivity_ttl_seconds`.
@@ -237,6 +255,8 @@ When creating a session message (`POST .../messages`), send exactly one of:
 
 - `message`: raw text body
 - `document_id`: public ID of an existing document (its content is used as the message text)
+
+An optional `idempotency_key` string can be included with either variant to prevent duplicate processing — see [Idempotency](#idempotency) below.
 
 ## Examples
 

--- a/tests/smoke-tests.sh
+++ b/tests/smoke-tests.sh
@@ -1720,5 +1720,46 @@ $SOAT_CLI delete-agent --agent-id "$SSA_AGENT_ID"
 $SOAT_CLI delete-actor --actor-id "$SSA_ACTOR_ID"
 echo "single_session_per_actor: OK"
 
+# idempotency_key on add-session-message
+echo "--- add-session-message idempotency_key deduplication ---"
+IDEM_SESSION_RESP=$($SOAT_CLI create-agent-session \
+  --agent_id "$AGENT_ID")
+IDEM_SESSION_ID=$(printf '%s\n' "$IDEM_SESSION_RESP" | jq -r '.id')
+if [ -z "$IDEM_SESSION_ID" ] || [ "$IDEM_SESSION_ID" = "null" ]; then
+  echo "ERROR: Failed to create session for idempotency test" >&2
+  printf '%s\n' "$IDEM_SESSION_RESP" >&2
+  exit 1
+fi
+
+IDEM_KEY="smoke-idem-key-$$"
+
+IDEM_FIRST_RESP=$($SOAT_CLI add-session-message \
+  --agent_id "$AGENT_ID" \
+  --session_id "$IDEM_SESSION_ID" \
+  --message "first message" \
+  --idempotency_key "$IDEM_KEY")
+IDEM_FIRST_CONTENT=$(printf '%s\n' "$IDEM_FIRST_RESP" | jq -r '.content')
+if [ "$IDEM_FIRST_CONTENT" != "first message" ]; then
+  echo "ERROR: first idempotency_key call did not return expected content" >&2
+  printf '%s\n' "$IDEM_FIRST_RESP" >&2
+  exit 1
+fi
+echo "First call with idempotency_key: OK"
+
+IDEM_SECOND_RESP=$($SOAT_CLI add-session-message \
+  --agent_id "$AGENT_ID" \
+  --session_id "$IDEM_SESSION_ID" \
+  --message "different message" \
+  --idempotency_key "$IDEM_KEY")
+IDEM_SECOND_CONTENT=$(printf '%s\n' "$IDEM_SECOND_RESP" | jq -r '.content')
+if [ "$IDEM_SECOND_CONTENT" != "first message" ]; then
+  echo "ERROR: duplicate idempotency_key call did not return original content" >&2
+  printf '%s\n' "$IDEM_SECOND_RESP" >&2
+  exit 1
+fi
+echo "Duplicate call with idempotency_key returns original message: OK"
+
+echo "add-session-message idempotency_key: OK"
+
 echo ""
 echo "=== All smoke tests passed! ==="


### PR DESCRIPTION
## Summary

- Adds optional `idempotency_key` to `POST /api/v1/agents/{agent_id}/sessions/{session_id}/messages` to prevent duplicate processing for at-least-once webhook deliveries (e.g. WhatsApp)
- First call with a key inserts the message and returns **201**; subsequent calls with the same key return the original message with **200** — no new DB row, no generation triggered
- Key is scoped per session (unique index on `conversation_id` + `idempotency_key`)

## Test plan

- [ ] `pnpm typecheck` — passes
- [ ] `pnpm eslint --fix` — no warnings
- [ ] `pnpm test --testPathPatterns=sessions.test.ts` — new `idempotency_key` describe block covers first-call 201, repeat-call 200, and cross-session non-idempotency
- [ ] Smoke tests include idempotent message flow steps

Closes #143

https://claude.ai/code/session_01L2TuWNciJENDDHemrMDgWh

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2TuWNciJENDDHemrMDgWh)_