### PR TITLE
feat(sessions): add message_delay_seconds for debounced LLM processing

### DIFF
--- a/packages/postgresdb/src/models/Session.ts
+++ b/packages/postgresdb/src/models/Session.ts
@@ -127,6 +127,14 @@ export class Session extends Model {
   @Column({ type: DataType.DATE, allowNull: true, field: 'last_activity_at' })
   declare lastActivityAt: Date | null;
 
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: true,
+    defaultValue: null,
+    field: 'message_delay_seconds',
+  })
+  declare messageDelaySeconds: number | null;
+
   @Column({ type: DataType.DATE })
   declare createdAt: Date;
 

--- a/packages/server/src/lib/sessionDelayHelpers.ts
+++ b/packages/server/src/lib/sessionDelayHelpers.ts
@@ -1,0 +1,84 @@
+import type { db } from '../db';
+import { triggerOrReturnMessage } from './sessionMessageHelpers';
+
+type GenerateSessionResponseFn = (args: {
+  agentId: number;
+  sessionId: string;
+  toolContext?: Record<string, string>;
+}) => Promise<unknown>;
+
+// ── In-memory delay timer map ─────────────────────────────────────────────
+// Key: `${agentId}#${sessionId}` — one pending timer per session.
+// Implements debounce: each new message cancels the previous timer and
+// schedules a fresh one. The LLM is only called after the delay elapses
+// without another message arriving.
+const sessionDelayTimers = new Map<string, NodeJS.Timeout>();
+
+export const cancelDelayTimer = (sessionKey: string) => {
+  const timer = sessionDelayTimers.get(sessionKey);
+  if (timer) {
+    clearTimeout(timer);
+    sessionDelayTimers.delete(sessionKey);
+  }
+};
+
+export const scheduleDelayedGeneration = (args: {
+  sessionKey: string;
+  agentId: number;
+  sessionId: string;
+  delayMs: number;
+  toolContext?: Record<string, string>;
+  generateFn: GenerateSessionResponseFn;
+}) => {
+  cancelDelayTimer(args.sessionKey);
+  const timer = setTimeout(() => {
+    sessionDelayTimers.delete(args.sessionKey);
+    args
+      .generateFn({
+        agentId: args.agentId,
+        sessionId: args.sessionId,
+        toolContext: args.toolContext,
+      })
+      .catch(() => {});
+  }, args.delayMs);
+  sessionDelayTimers.set(args.sessionKey, timer);
+};
+
+export const triggerOrScheduleGeneration = (args: {
+  session: InstanceType<(typeof db)['Session']>;
+  agentId: number;
+  sessionId: string;
+  savedContent: string | null;
+  savedDocumentId: string | undefined;
+  toolContext?: Record<string, string>;
+  generateFn: GenerateSessionResponseFn;
+}) => {
+  const delayMs = (args.session.messageDelaySeconds ?? 0) * 1000;
+  const sessionKey = `${args.agentId}#${args.sessionId}`;
+
+  if (delayMs > 0 && args.session.autoGenerate && !args.session.generatingAt) {
+    scheduleDelayedGeneration({
+      sessionKey,
+      agentId: args.agentId,
+      sessionId: args.sessionId,
+      delayMs,
+      toolContext: args.toolContext,
+      generateFn: args.generateFn,
+    });
+    return {
+      role: 'user' as const,
+      content: args.savedContent,
+      documentId: args.savedDocumentId,
+    };
+  }
+
+  return triggerOrReturnMessage({
+    session: args.session,
+    agentId: args.agentId,
+    sessionId: args.sessionId,
+    toolContext: args.toolContext,
+    savedContent: args.savedContent,
+    savedDocumentId: args.savedDocumentId,
+    generateFn: args.generateFn,
+  });
+};

--- a/packages/server/src/lib/sessionOperations.ts
+++ b/packages/server/src/lib/sessionOperations.ts
@@ -4,6 +4,7 @@ import { DomainError } from '../errors';
 import { submitToolOutputs } from './agents';
 import { generateConversationMessage } from './conversationGeneration';
 import { listConversationMessages } from './conversations';
+import { triggerOrScheduleGeneration } from './sessionDelayHelpers';
 import {
   emitGenerationCompleted,
   emitGenerationRequiresAction,
@@ -13,7 +14,6 @@ import {
 import {
   addResolvedSessionUserMessage,
   assertSessionMessageInput,
-  triggerOrReturnMessage,
 } from './sessionMessageHelpers';
 
 const GENERATING_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
@@ -328,13 +328,13 @@ export const addSessionMessage = async (args: {
 
   await session.update({ lastActivityAt: new Date() });
 
-  return triggerOrReturnMessage({
+  return triggerOrScheduleGeneration({
     session,
     agentId: args.agentId,
     sessionId: args.sessionId,
-    toolContext: args.toolContext,
     savedContent,
     savedDocumentId,
+    toolContext: args.toolContext,
     generateFn: generateSessionResponse,
   });
 };

--- a/packages/server/src/lib/sessionTransaction.ts
+++ b/packages/server/src/lib/sessionTransaction.ts
@@ -8,6 +8,7 @@ export const createSessionTransaction = async (args: {
   autoGenerate?: boolean;
   toolContext?: Record<string, string> | null;
   inactivityTtlSeconds?: number;
+  messageDelaySeconds?: number | null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   transaction: any;
 }): Promise<InstanceType<(typeof db)['Session']>> => {
@@ -31,6 +32,7 @@ export const createSessionTransaction = async (args: {
       autoGenerate: args.autoGenerate ?? false,
       toolContext: args.toolContext ?? null,
       inactivityTtlSeconds: args.inactivityTtlSeconds ?? 0,
+      messageDelaySeconds: args.messageDelaySeconds ?? null,
       lastActivityAt: null,
     },
     { transaction: args.transaction }

--- a/packages/server/src/lib/sessions.ts
+++ b/packages/server/src/lib/sessions.ts
@@ -50,6 +50,7 @@ const extractSessionOptional = (session: Parameters<typeof mapSession>[0]) => {
     generatingAt: session.generatingAt ?? null,
     inactivityTtlSeconds: session.inactivityTtlSeconds ?? 0,
     lastActivityAt: session.lastActivityAt ?? null,
+    messageDelaySeconds: session.messageDelaySeconds ?? null,
   };
 };
 
@@ -81,6 +82,7 @@ export const createSession = async (args: {
   autoGenerate?: boolean;
   toolContext?: Record<string, string> | null;
   inactivityTtlSeconds?: number;
+  messageDelaySeconds?: number | null;
 }) => {
   const agent = await db.Agent.findByPk(args.agentId);
   if (!agent) {
@@ -127,6 +129,7 @@ export const createSession = async (args: {
       autoGenerate: args.autoGenerate,
       toolContext: args.toolContext,
       inactivityTtlSeconds: args.inactivityTtlSeconds,
+      messageDelaySeconds: args.messageDelaySeconds,
       transaction: t,
     });
   });
@@ -233,6 +236,7 @@ export const updateSession = async (args: {
   status?: string;
   autoGenerate?: boolean;
   toolContext?: Record<string, string> | null;
+  messageDelaySeconds?: number | null;
 }) => {
   const session = await db.Session.findOne({
     where: { publicId: args.sessionId, agentId: args.agentId },
@@ -259,6 +263,10 @@ export const updateSession = async (args: {
 
   if (args.toolContext !== undefined) {
     session.toolContext = args.toolContext;
+  }
+
+  if (args.messageDelaySeconds !== undefined) {
+    session.messageDelaySeconds = args.messageDelaySeconds;
   }
 
   await session.save();

--- a/packages/server/src/rest/openapi/v1/sessions.yaml
+++ b/packages/server/src/rest/openapi/v1/sessions.yaml
@@ -581,6 +581,14 @@ components:
           default: 0
           description: Number of seconds of inactivity after which the session expires. 0 means the session never expires.
           example: 300
+        message_delay_seconds:
+          type: integer
+          nullable: true
+          default: null
+          description: >
+            Number of seconds to wait after the last user message before sending to the LLM.
+            Acts as a debounce: each new message resets the timer. null or absent means no delay (immediate processing).
+          example: 3
         last_activity_at:
           type: string
           format: date-time
@@ -630,6 +638,14 @@ components:
           default: 0
           description: Number of seconds of inactivity after which the session expires. 0 means the session never expires.
           example: 300
+        message_delay_seconds:
+          type: integer
+          nullable: true
+          default: null
+          description: >
+            Number of seconds to wait after the last user message before sending to the LLM.
+            Acts as a debounce: each new message resets the timer. null or absent means no delay (immediate processing).
+          example: 3
 
     UpdateSessionRequest:
       type: object
@@ -651,6 +667,13 @@ components:
             type: string
           nullable: true
           description: Key-value pairs injected as context headers into all tool call requests made during this session.
+        message_delay_seconds:
+          type: integer
+          nullable: true
+          description: >
+            Number of seconds to wait after the last user message before sending to the LLM.
+            Acts as a debounce: each new message resets the timer. Set to null to disable the delay.
+          example: 3
 
     AddSessionMessageRequest:
       oneOf:

--- a/packages/server/src/rest/v1/sessions.ts
+++ b/packages/server/src/rest/v1/sessions.ts
@@ -96,6 +96,7 @@ sessionsRouter.post('/', async (ctx: Context) => {
     autoGenerate?: boolean;
     toolContext?: Record<string, string> | null;
     inactivityTtlSeconds?: number;
+    messageDelaySeconds?: number | null;
   };
 
   const result = await createSession({
@@ -106,6 +107,7 @@ sessionsRouter.post('/', async (ctx: Context) => {
     autoGenerate: body.autoGenerate,
     toolContext: body.toolContext,
     inactivityTtlSeconds: body.inactivityTtlSeconds,
+    messageDelaySeconds: body.messageDelaySeconds,
   });
 
   ctx.status = 201;
@@ -179,6 +181,7 @@ sessionsRouter.patch('/:session_id', async (ctx: Context) => {
     status?: string;
     autoGenerate?: boolean;
     toolContext?: Record<string, string> | null;
+    messageDelaySeconds?: number | null;
   };
 
   const result = await updateSession({
@@ -188,6 +191,7 @@ sessionsRouter.patch('/:session_id', async (ctx: Context) => {
     status: body.status,
     autoGenerate: body.autoGenerate,
     toolContext: body.toolContext,
+    messageDelaySeconds: body.messageDelaySeconds,
   });
 
   ctx.body = result;

--- a/packages/server/tests/unit/tests/rest/sessions.test.ts
+++ b/packages/server/tests/unit/tests/rest/sessions.test.ts
@@ -1971,4 +1971,148 @@ describe('Sessions', () => {
       expect(sess2.status).toBe(201);
     });
   });
+
+  // ── Message Delay ──────────────────────────────────────────────────────
+
+  describe('message delay', () => {
+    test('can create a session with message_delay_seconds', async () => {
+      const res = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions`)
+        .send({ message_delay_seconds: 5 });
+      expect(res.status).toBe(201);
+      expect(res.body.message_delay_seconds).toBe(5);
+    });
+
+    test('message_delay_seconds defaults to null', async () => {
+      const res = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions`)
+        .send({});
+      expect(res.status).toBe(201);
+      expect(res.body.message_delay_seconds).toBeNull();
+    });
+
+    test('PATCH can set and clear message_delay_seconds', async () => {
+      const createRes = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions`)
+        .send({});
+      expect(createRes.status).toBe(201);
+      const sessionId = createRes.body.id;
+
+      const setRes = await authenticatedTestClient(userToken)
+        .patch(`/api/v1/agents/${agentId}/sessions/${sessionId}`)
+        .send({ message_delay_seconds: 10 });
+      expect(setRes.status).toBe(200);
+      expect(setRes.body.message_delay_seconds).toBe(10);
+
+      const clearRes = await authenticatedTestClient(userToken)
+        .patch(`/api/v1/agents/${agentId}/sessions/${sessionId}`)
+        .send({ message_delay_seconds: null });
+      expect(clearRes.status).toBe(200);
+      expect(clearRes.body.message_delay_seconds).toBeNull();
+    });
+
+    describe('POST /messages with message_delay_seconds and auto_generate', () => {
+      let delaySessionId: string;
+
+      beforeAll(async () => {
+        const res = await authenticatedTestClient(userToken)
+          .post(`/api/v1/agents/${agentId}/sessions`)
+          .send({ auto_generate: true, message_delay_seconds: 1 });
+        expect(res.status).toBe(201);
+        delaySessionId = res.body.id;
+      });
+
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+      test('returns user message immediately instead of triggering generation synchronously', async () => {
+        const res = await authenticatedTestClient(userToken)
+          .post(
+            `/api/v1/agents/${agentId}/sessions/${delaySessionId}/messages`
+          )
+          .send({ message: 'hello with delay' });
+        expect(res.status).toBe(201);
+        expect(res.body.role).toBe('user');
+        expect(res.body.content).toBe('hello with delay');
+        expect(res.body).not.toHaveProperty('generation_id');
+      });
+
+      test('after delay elapses, generation is triggered', async () => {
+        let signalGenerationStarted!: () => void;
+        const generationStarted = new Promise<void>((r) => {
+          signalGenerationStarted = r;
+        });
+
+        mockCreateGeneration.mockImplementationOnce(() => {
+          return new Promise((resolve) => {
+            signalGenerationStarted();
+            resolve({
+              id: 'gen_delay_01',
+              traceId: 'trc_delay_01',
+              status: 'completed',
+              output: {
+                model: 'test-model',
+                content: 'Delayed reply',
+                finishReason: 'stop',
+              },
+            });
+          });
+        });
+
+        await authenticatedTestClient(userToken)
+          .post(
+            `/api/v1/agents/${agentId}/sessions/${delaySessionId}/messages`
+          )
+          .send({ message: 'trigger delayed gen' });
+
+        await generationStarted;
+        expect(mockCreateGeneration).toHaveBeenCalledTimes(1);
+      });
+
+      test('second message within delay window resets the timer (debounce)', async () => {
+        let callCount = 0;
+        let signalGenerationStarted!: () => void;
+        const generationStarted = new Promise<void>((r) => {
+          signalGenerationStarted = r;
+        });
+
+        mockCreateGeneration.mockImplementation(() => {
+          callCount++;
+          signalGenerationStarted();
+          return Promise.resolve({
+            id: `gen_debounce_0${callCount}`,
+            traceId: `trc_debounce_0${callCount}`,
+            status: 'completed',
+            output: {
+              model: 'test-model',
+              content: 'Debounced reply',
+              finishReason: 'stop',
+            },
+          });
+        });
+
+        // Send two messages in quick succession (well within the 1-second delay)
+        await authenticatedTestClient(userToken)
+          .post(
+            `/api/v1/agents/${agentId}/sessions/${delaySessionId}/messages`
+          )
+          .send({ message: 'first message' });
+
+        await authenticatedTestClient(userToken)
+          .post(
+            `/api/v1/agents/${agentId}/sessions/${delaySessionId}/messages`
+          )
+          .send({ message: 'second message within delay' });
+
+        // Wait for the delay to elapse and exactly one generation to fire
+        await generationStarted;
+        await new Promise((resolve) => {
+          return setTimeout(resolve, 200);
+        });
+
+        expect(mockCreateGeneration).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
 });

--- a/packages/website/docs/modules/sessions.md
+++ b/packages/website/docs/modules/sessions.md
@@ -68,6 +68,37 @@ Content-Type: application/json
 
 The explicit `POST .../generate` endpoint continues to work regardless of this setting. Async generation (`?async=true`) is also supported on `POST .../messages` when `auto_generate` is enabled — the request returns `202 Accepted` immediately and generation proceeds in the background.
 
+### Message Delay (Debounce)
+
+When `message_delay_seconds` is set on a session, `POST .../messages` does **not** trigger LLM generation immediately. Instead, a timer is started. If another message arrives before the timer expires, the timer resets. The LLM is only called after the configured delay has elapsed with no new messages.
+
+This is a debounce: only the last message in a rapid burst triggers generation, ensuring the model sees the complete context before responding.
+
+```http
+POST /agents/:agent_id/sessions
+Content-Type: application/json
+
+{ "auto_generate": true, "message_delay_seconds": 3 }
+```
+
+With the above configuration:
+
+- User sends "What's the" → timer starts (3 s)
+- User sends "weather in" → timer resets (3 s)
+- User sends "Paris?" → timer resets (3 s)
+- 3 seconds of silence → LLM is called with all three messages in context
+
+`POST .../messages` always returns immediately with the saved user message (`role: "user"`), regardless of the delay setting. The generation fires asynchronously after the delay elapses.
+
+**When to use:**
+- Messaging apps (WhatsApp, SMS, Slack) where users send multiple short messages in sequence
+- Voice-to-text inputs that arrive in fragments
+- Any channel where you want to wait for the user to "finish typing" before responding
+
+**Clearing the delay:** set `message_delay_seconds` to `null` to revert to immediate processing.
+
+`message_delay_seconds` has no effect when `auto_generate` is `false` or when a generation is already in progress.
+
 ### Single Session Per Actor
 
 When the parent agent has `single_session_per_actor: true`, `POST /agents/:id/sessions` with an `actor_id` will return `409 Conflict` if an open session for that actor already exists. The error body includes `meta.session_id` with the existing session's ID so the caller can reuse it without a separate lookup:
@@ -235,6 +266,7 @@ This is useful for local testing where no actor record exists yet. The values yo
 | `actor_id`                | string \| null | Optional public ID of the Actor associated with this session (`actr_` prefix); `null` when no actor is set     |
 | `tags`                    | object         | Free-form key-value metadata                                                                                   |
 | `auto_generate`           | boolean        | When `true`, saving a message via `POST .../messages` automatically triggers LLM generation (default: `false`) |
+| `message_delay_seconds`   | integer \| null | Debounce delay in seconds before the LLM is called after a user message. Each new message resets the timer. `null` means no delay (default: `null`) |
 | `inactivity_ttl_seconds`  | integer        | Seconds of inactivity before the session expires. `0` means never expires (default: `0`)                       |
 | `last_activity_at`        | string \| null | ISO 8601 timestamp of the last user message; `null` until the first message is added                           |
 | `created_at`              | string         | ISO 8601 creation timestamp                                                                                    |


### PR DESCRIPTION
Adds a `messageDelaySeconds` field to the Session model. When set, sending
a message to an auto-generate session schedules a debounced LLM call instead
of triggering it immediately. Each new message within the delay window resets
the timer, so the LLM is only called after the user stops sending messages.

The debounce is implemented in-memory (same pattern as the existing abort
controller map) in a new sessionDelayHelpers.ts module, keeping sessionOperations.ts
within the max-lines limit.

https://claude.ai/code/session_01UNAK86RijFzQV1ie875H8b