### PR TITLE
Allow string values for agent tool_choice property

### DIFF
--- a/packages/server/src/lib/agents.ts
+++ b/packages/server/src/lib/agents.ts
@@ -21,7 +21,7 @@ export type MappedAgent = {
   model: string | null;
   toolIds: string[] | null;
   maxSteps: number | null;
-  toolChoice: object | null;
+  toolChoice: string | object | null;
   stopConditions: object[] | null;
   activeToolIds: string[] | null;
   stepRules: object[] | null;
@@ -81,7 +81,7 @@ type AgentUpdateFields = {
   model?: string | null;
   toolIds?: string[] | null;
   maxSteps?: number | null;
-  toolChoice?: object | null;
+  toolChoice?: string | object | null;
   stopConditions?: object[] | null;
   activeToolIds?: string[] | null;
   stepRules?: object[] | null;
@@ -136,7 +136,7 @@ export const createAgent = async (args: {
   model?: string;
   toolIds?: string[];
   maxSteps?: number;
-  toolChoice?: object;
+  toolChoice?: string | object;
   stopConditions?: object[];
   activeToolIds?: string[];
   stepRules?: object[];

--- a/packages/server/src/lib/formation-modules/agentsFormationModule.ts
+++ b/packages/server/src/lib/formation-modules/agentsFormationModule.ts
@@ -7,6 +7,7 @@ import {
   toNullableNumber,
   toNullableObject,
   toNullableString,
+  toNullableStringOrObject,
   toOptionalString,
 } from '../resource-inputs/normalizers';
 import {
@@ -71,7 +72,7 @@ const mapAgentProperties = (properties: Record<string, unknown>) => {
     model: toOptionalString(properties.model),
     toolIds: toOptional(toNullableArray<string>(properties.tool_ids)),
     maxSteps: toOptional(toNullableNumber(properties.max_steps)),
-    toolChoice: toOptional(toNullableObject(properties.tool_choice)),
+    toolChoice: toOptional(toNullableStringOrObject(properties.tool_choice)),
     stopConditions: toOptional(
       toNullableArray<object>(properties.stop_conditions)
     ),
@@ -145,7 +146,7 @@ export const agentsFormationModule: FormationModule = {
       model: toNullableString(properties.model),
       toolIds: toNullableArray<string>(properties.tool_ids),
       maxSteps: toNullableNumber(properties.max_steps),
-      toolChoice: toNullableObject(properties.tool_choice),
+      toolChoice: toNullableStringOrObject(properties.tool_choice),
       stopConditions: toNullableArray<object>(properties.stop_conditions),
       activeToolIds: toNullableArray<string>(properties.active_tool_ids),
       stepRules: toNullableArray<object>(properties.step_rules),

--- a/packages/server/src/lib/resource-inputs/normalizers.ts
+++ b/packages/server/src/lib/resource-inputs/normalizers.ts
@@ -30,6 +30,16 @@ export const toNullableObject = (value: unknown): object | null | undefined => {
     : undefined;
 };
 
+export const toNullableStringOrObject = (
+  value: unknown
+): string | object | null | undefined => {
+  if (value === null) return null;
+  if (typeof value === 'string') return value;
+  return typeof value === 'object' && !Array.isArray(value)
+    ? (value as object)
+    : undefined;
+};
+
 /**
  * Accepts either camelCase or snake_case key, returning the first defined value.
  * Used to normalise fields that arrive as camelCase from the REST middleware but

--- a/packages/server/src/rest/openapi/v1/agents.yaml
+++ b/packages/server/src/rest/openapi/v1/agents.yaml
@@ -493,9 +493,8 @@ components:
           nullable: true
           description: Maximum reasoning steps
         tool_choice:
-          type: object
           nullable: true
-          description: Tool choice strategy
+          description: 'Tool choice strategy. Accepts a string (`"auto"`, `"required"`) or an object (`{ "type": "tool", "name": "my_tool" }`).'
         stop_conditions:
           type: array
           nullable: true
@@ -589,7 +588,7 @@ components:
         max_steps:
           type: integer
         tool_choice:
-          type: object
+          description: 'Tool choice strategy. Accepts a string (`"auto"`, `"required"`) or an object (`{ "type": "tool", "name": "my_tool" }`).'
         stop_conditions:
           type: array
           items:
@@ -663,8 +662,8 @@ components:
           type: integer
           nullable: true
         tool_choice:
-          type: object
           nullable: true
+          description: 'Tool choice strategy. Accepts a string (`"auto"`, `"required"`) or an object (`{ "type": "tool", "name": "my_tool" }`).'
         stop_conditions:
           type: array
           nullable: true

--- a/packages/server/src/rest/openapi/v1/formations.yaml
+++ b/packages/server/src/rest/openapi/v1/formations.yaml
@@ -449,9 +449,8 @@ components:
           nullable: true
           description: Maximum number of agentic steps per generation
         tool_choice:
-          type: object
           nullable: true
-          description: 'Controls how the model selects tools. Examples: `{ "type": "auto" }`, `{ "type": "none" }`, `{ "type": "required" }`, or `{ "type": "tool", "name": "my_tool" }`.'
+          description: 'Controls how the model selects tools. Accepts a string (`"auto"`, `"required"`) or an object (`{ "type": "tool", "name": "my_tool" }`).'
         stop_conditions:
           type: array
           nullable: true

--- a/packages/server/src/rest/v1/agents.ts
+++ b/packages/server/src/rest/v1/agents.ts
@@ -67,7 +67,7 @@ const parseUpdateAgentBody = (body: Record<string, unknown>) => {
     model: parseNullableString(body.model),
     toolIds: parseOptional<string[] | null>(body.toolIds),
     maxSteps: parseOptional<number | null>(body.maxSteps),
-    toolChoice: parseOptional<object | null>(body.toolChoice),
+    toolChoice: parseOptional<string | object | null>(body.toolChoice),
     stopConditions: parseOptional<object[] | null>(body.stopConditions),
     activeToolIds: parseOptional<string[] | null>(body.activeToolIds),
     stepRules: parseOptional<object[] | null>(body.stepRules),
@@ -117,7 +117,7 @@ const buildCreateAgentArgs = (
     model: typeof body.model === 'string' ? body.model : undefined,
     toolIds: Array.isArray(body.toolIds) ? body.toolIds : undefined,
     maxSteps: parseNumber(body.maxSteps),
-    toolChoice: body.toolChoice as object | undefined,
+    toolChoice: body.toolChoice as string | object | undefined,
     stopConditions: Array.isArray(body.stopConditions)
       ? body.stopConditions
       : undefined,

--- a/packages/server/tests/unit/tests/lib/formationsValidation.test.ts
+++ b/packages/server/tests/unit/tests/lib/formationsValidation.test.ts
@@ -900,23 +900,50 @@ describe('validateFormationTemplate', () => {
     ).toBe(true);
   });
 
-  test('returns invalid when agent tool_choice is not an object', () => {
+  test('accepts string values for agent tool_choice', () => {
+    for (const value of ['auto', 'required', 'none']) {
+      const result = validateFormationTemplate({
+        resources: {
+          MyAgent: {
+            type: 'agent',
+            properties: {
+              ai_provider_id: 'aip_1',
+              tool_choice: value,
+            },
+          },
+        },
+      });
+      expect(result.valid).toBe(true);
+    }
+  });
+
+  test('accepts object values for agent tool_choice', () => {
     const result = validateFormationTemplate({
       resources: {
         MyAgent: {
           type: 'agent',
           properties: {
             ai_provider_id: 'aip_1',
-            tool_choice: 'auto',
+            tool_choice: { type: 'tool', name: 'my_tool' },
           },
         },
       },
     });
-    expect(result.valid).toBe(false);
-    expect(
-      result.errors.some((e) => {
-        return e.path === 'resources.MyAgent.properties.tool_choice';
-      })
-    ).toBe(true);
+    expect(result.valid).toBe(true);
+  });
+
+  test('accepts null for agent tool_choice', () => {
+    const result = validateFormationTemplate({
+      resources: {
+        MyAgent: {
+          type: 'agent',
+          properties: {
+            ai_provider_id: 'aip_1',
+            tool_choice: null,
+          },
+        },
+      },
+    });
+    expect(result.valid).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
Updated the agent `tool_choice` property to accept string values (`"auto"`, `"required"`, `"none"`) in addition to object values and null, aligning with OpenAI's tool choice API specification.

## Key Changes
- **Type System Updates**: Modified `toolChoice` type from `object | null` to `string | object | null` across:
  - `MappedAgent` and `AgentUpdateFields` types in `agents.ts`
  - `createAgent` function signature
  - REST API parsing in `agents.ts`

- **Normalizer Function**: Added `toNullableStringOrObject` normalizer function to handle the new string or object input types in `normalizers.ts`

- **Formation Module**: Updated `agentsFormationModule.ts` to use the new normalizer for both agent creation and updates

- **API Documentation**: Updated OpenAPI schemas in both `agents.yaml` and `formations.yaml` to:
  - Remove restrictive `type: object` constraint
  - Add clear descriptions showing both string and object formats are accepted
  - Provide examples of valid values

- **Test Coverage**: Added comprehensive test cases validating:
  - String values (`"auto"`, `"required"`, `"none"`)
  - Object values (`{ "type": "tool", "name": "my_tool" }`)
  - Null values

## Implementation Details
The change maintains backward compatibility while expanding the accepted input formats. The normalizer function validates that string values are preserved as-is, while object values are validated to be non-array objects, and null values are explicitly handled.

https://claude.ai/code/session_01DwU1tpZobERevER1Nk4ozg