### PR TITLE
Rename tool fields in OpenAPI sessions schema

### DIFF
--- a/packages/server/src/rest/openapi/v1/sessions.yaml
+++ b/packages/server/src/rest/openapi/v1/sessions.yaml
@@ -784,9 +784,9 @@ components:
                 properties:
                   id:
                     type: string
-                  name:
+                  tool_name:
                     type: string
-                  arguments:
+                  args:
                     type: object
 
     SendSessionMessageResponse:
@@ -819,9 +819,9 @@ components:
                 properties:
                   id:
                     type: string
-                  name:
+                  tool_name:
                     type: string
-                  arguments:
+                  args:
                     type: object
 
     SubmitSessionToolOutputsRequest:

--- a/packages/website/docs/modules/agents.md
+++ b/packages/website/docs/modules/agents.md
@@ -135,7 +135,7 @@ Example response when a client tool is called:
       {
         "tool_call_id": "call_xyz",
         "tool_name": "read_local_file",
-        "arguments": { "path": "/tmp/data.csv" }
+        "args": { "path": "/tmp/data.csv" }
       }
     ]
   }
@@ -658,7 +658,7 @@ Where `agt_tool_r7w4n1hc` → `"read_file"` (client) and `agt_tool_j5v1d6yt` →
          {
            "tool_call_id": "call_1",
            "tool_name": "read_file",
-           "arguments": { "path": "/tmp/sales.csv" }
+           "args": { "path": "/tmp/sales.csv" }
          }
        ]
      }


### PR DESCRIPTION
## Summary
Updated the OpenAPI schema for session tool definitions to use more concise and consistent field names.

## Key Changes
- Renamed `name` field to `tool_name` in tool object definitions
- Renamed `arguments` field to `args` in tool object definitions
- Applied changes consistently across multiple schema components (SendSessionMessageResponse and SubmitSessionToolOutputsRequest)

## Details
These field name changes improve API consistency and align with common naming conventions for tool invocation parameters. The updates affect the schema definitions for tool objects that are returned in session message responses and used in tool output submissions.

https://claude.ai/code/session_01CoYox7LpjyhHQq7hH96UJ4