### PR TITLE
Support tool messages in conversation history and generation

### DIFF
--- a/packages/server/src/lib/agentGeneration.ts
+++ b/packages/server/src/lib/agentGeneration.ts
@@ -1,6 +1,5 @@
 import { generatePublicId, PUBLIC_ID_PREFIXES } from '@soat/postgresdb';
-import type { LanguageModel, ModelMessage, Tool } from 'ai';
-import { generateText, stepCountIs } from 'ai';
+import type { LanguageModel, Tool } from 'ai';
 import createDebug from 'debug';
 import type { AuthUser } from 'src/Context';
 import { resolveAiProviderSecret } from 'src/lib/aiProviders';
@@ -15,15 +14,15 @@ import {
 } from './agentGenerationHelpers';
 import {
   buildDepthGuardResult,
-  recoverPendingFromDb,
   resolveAgentForGeneration,
+  resolvePendingGeneration,
 } from './agentGenerationRecovery';
-import { buildKnowledgeMessages, buildWriteMemoryTool } from './agentKnowledge';
+import { buildKnowledgeMessages, buildKnowledgeTools } from './agentKnowledge';
 import { buildModel } from './agentModel';
 import {
-  buildPrepareStep,
   buildToolResultMessages as buildToolResultMessagesFromOutputs,
   runNonStreamGeneration,
+  runToolOutputGeneration,
 } from './agentNonStreamGeneration';
 import { resolveAgentTools } from './agentToolResolver';
 import { emitEvent, resolveProjectPublicId } from './eventBus';
@@ -48,21 +47,6 @@ type GenerationContext = {
   generationId: string;
   toolContext?: Record<string, string> | null;
   remainingDepth?: number | null;
-};
-
-const buildKnowledgeTools = (args: {
-  typedAgent: TypedAgent;
-  resolvedTools: Record<string, unknown>;
-}): void => {
-  const knowledgeConfig = args.typedAgent.knowledgeConfig as
-    | { writeMemoryId?: string }
-    | null
-    | undefined;
-  if (knowledgeConfig?.writeMemoryId) {
-    args.resolvedTools['write_memory'] = buildWriteMemoryTool({
-      writeMemoryId: knowledgeConfig.writeMemoryId,
-    });
-  }
 };
 
 const resolveGenerationModel = async (args: {
@@ -369,57 +353,16 @@ export const submitToolOutputs = async (args: {
   toolOutputs: Array<{ toolCallId: string; output: unknown }>;
   authHeader?: string;
 }): Promise<GenerationResult> => {
-  let pending = pendingGenerations.get(args.generationId);
-
-  // If not in memory (e.g. server restarted), recover from DB.
-  if (!pending) {
-    pending = await recoverPendingFromDb({
-      generationId: args.generationId,
-      agentId: args.agentId,
-      projectIds: args.projectIds,
-      authHeader: args.authHeader,
-    });
-  }
-  if (!pending || pending.agentId !== args.agentId) {
-    throw new DomainError(
-      'GENERATION_NOT_FOUND',
-      `Generation '${args.generationId}' not found or does not belong to agent '${args.agentId}'.`
-    );
-  }
-
+  const pending = await resolvePendingGeneration(args);
   pendingGenerations.delete(args.generationId);
 
   const toolResultMessages = buildToolResultMessagesFromOutputs({
     toolOutputs: args.toolOutputs,
     pendingToolCalls: pending.pendingToolCalls,
   });
-  const allMessages = [...pending.messages, ...toolResultMessages];
-  const system = (
-    pending.messages.find((m) => {
-      return (m as { role: string }).role === 'system';
-    }) as { role: string; content: string } | undefined
-  )?.content;
-  const nonSystemMessages = allMessages.filter((m) => {
-    return (m as { role?: string }).role !== 'system';
-  });
 
-  const result = await generateText({
-    model: pending.resolvedModel,
-    system,
-    messages: nonSystemMessages as ModelMessage[],
-    tools:
-      Object.keys(pending.resolvedTools).length > 0
-        ? pending.resolvedTools
-        : undefined,
-    prepareStep: buildPrepareStep({
-      stepRules: pending.agentConfig.stepRules,
-      logContext: 'non_stream',
-    }),
-    stopWhen: stepCountIs(pending.agentConfig.maxSteps),
-    temperature: pending.agentConfig.temperature ?? undefined,
-  });
+  const result = await runToolOutputGeneration({ pending, toolResultMessages });
 
-  // Extract the tool exchange messages that weren't already in the conversation history
   const pendingToolMessages = pending.messages.slice(
     pending.allMessagesCount ?? 0
   );

--- a/packages/server/src/lib/agentGeneration.ts
+++ b/packages/server/src/lib/agentGeneration.ts
@@ -395,9 +395,9 @@ export const submitToolOutputs = async (args: {
   });
   const allMessages = [...pending.messages, ...toolResultMessages];
   const system = (
-    pending.messages.find(
-      (m) => (m as { role: string }).role === 'system'
-    ) as { role: string; content: string } | undefined
+    pending.messages.find((m) => {
+      return (m as { role: string }).role === 'system';
+    }) as { role: string; content: string } | undefined
   )?.content;
   const nonSystemMessages = allMessages.filter((m) => {
     return (m as { role?: string }).role !== 'system';

--- a/packages/server/src/lib/agentGeneration.ts
+++ b/packages/server/src/lib/agentGeneration.ts
@@ -44,7 +44,7 @@ type GenerationContext = {
   typedAgent: TypedAgent;
   model: LanguageModel;
   resolvedTools: Record<string, Tool>;
-  allMessages: Array<{ role: string; content: string }>;
+  allMessages: Array<{ role: string; content: unknown }>;
   generationId: string;
   toolContext?: Record<string, string> | null;
   remainingDepth?: number | null;
@@ -146,7 +146,7 @@ const buildGenerationContext = async (args: {
   const knowledgeMessages = await buildKnowledgeMessages({
     knowledgeConfig: typedAgent.knowledgeConfig,
     projectIds: args.projectIds,
-    messages: resolvedMessages,
+    messages: resolvedMessages as Array<{ role: string; content: string }>,
   });
 
   log(
@@ -394,13 +394,11 @@ export const submitToolOutputs = async (args: {
     pendingToolCalls: pending.pendingToolCalls,
   });
   const allMessages = [...pending.messages, ...toolResultMessages];
-  const typedPendingMessages = pending.messages as Array<{
-    role: string;
-    content: string;
-  }>;
-  const system = typedPendingMessages.find((m) => {
-    return m.role === 'system';
-  })?.content;
+  const system = (
+    pending.messages.find(
+      (m) => (m as { role: string }).role === 'system'
+    ) as { role: string; content: string } | undefined
+  )?.content;
   const nonSystemMessages = allMessages.filter((m) => {
     return (m as { role?: string }).role !== 'system';
   });
@@ -421,6 +419,10 @@ export const submitToolOutputs = async (args: {
     temperature: pending.agentConfig.temperature ?? undefined,
   });
 
+  // Extract the tool exchange messages that weren't already in the conversation history
+  const pendingToolMessages = pending.messages.slice(
+    pending.allMessagesCount ?? 0
+  );
   const completedResult: GenerationResult = {
     id: args.generationId,
     traceId: pending.traceId,
@@ -429,6 +431,11 @@ export const submitToolOutputs = async (args: {
       model: result.response?.modelId ?? '',
       content: result.text,
       finishReason: result.finishReason,
+      toolMessages: [
+        ...pendingToolMessages,
+        ...toolResultMessages,
+        ...(result.response?.messages ?? []),
+      ],
     },
   };
 

--- a/packages/server/src/lib/agentGenerationHelpers.ts
+++ b/packages/server/src/lib/agentGenerationHelpers.ts
@@ -26,6 +26,7 @@ export type PendingGeneration = {
   }>;
   messages: Array<unknown>;
   steps: unknown[];
+  allMessagesCount: number;
   resolvedModel: LanguageModel;
   agentConfig: {
     instructions: string | null;
@@ -48,6 +49,7 @@ export type GenerationResult = {
     model: string;
     content: string;
     finishReason: string;
+    toolMessages?: unknown[];
   };
   requiredAction?: {
     type: 'submit_tool_outputs';
@@ -81,8 +83,8 @@ export const pendingGenerations = new Map<string, PendingGeneration>();
 
 export const buildAllMessages = (
   instructions: string | null,
-  messages: Array<{ role: string; content: string }>
-): Array<{ role: string; content: string }> => {
+  messages: Array<{ role: string; content: unknown }>
+): Array<{ role: string; content: unknown }> => {
   if (!instructions) return messages;
   return [{ role: 'system', content: instructions }, ...messages];
 };
@@ -132,7 +134,7 @@ const buildPrepareStep = (
 
 export const runStreamGeneration = (args: {
   model: LanguageModel;
-  allMessages: Array<{ role: string; content: string }>;
+  allMessages: Array<{ role: string; content: unknown }>;
   resolvedTools: Record<string, Tool>;
   typedAgent: TypedAgent;
   generationId: string;
@@ -143,7 +145,7 @@ export const runStreamGeneration = (args: {
 }): ReadableStream => {
   const system = args.allMessages.find((m) => {
     return m.role === 'system';
-  })?.content;
+  })?.content as string | undefined;
   const nonSystemMessages = args.allMessages.filter((m) => {
     return m.role !== 'system';
   });
@@ -223,7 +225,7 @@ const storePendingGenerationState = (args: {
     toolName: string;
     input: unknown;
   }>;
-  allMessages: Array<{ role: string; content: string }>;
+  allMessages: Array<{ role: string; content: unknown }>;
   result: { steps: unknown[]; response: { messages: unknown[] } };
   model: LanguageModel;
   resolvedTools: Record<string, Tool>;
@@ -246,6 +248,7 @@ const storePendingGenerationState = (args: {
     }),
     messages: [...args.allMessages, ...args.result.response.messages],
     steps: serializeSteps(args.result.steps),
+    allMessagesCount: args.allMessages.length,
     resolvedModel: args.model,
     agentConfig: {
       instructions: args.typedAgent.instructions,
@@ -276,6 +279,7 @@ const storePendingGenerationState = (args: {
     rootTraceId: args.rootTraceId ?? null,
     toolContext: args.toolContext ?? null,
     remainingDepth: args.remainingDepth ?? null,
+    allMessagesCount: args.allMessages.length,
   };
   updateGenerationRecord({
     publicId: args.generationId,
@@ -293,7 +297,7 @@ export const savePendingGeneration = (args: {
     toolName: string;
     input: unknown;
   }>;
-  allMessages: Array<{ role: string; content: string }>;
+  allMessages: Array<{ role: string; content: unknown }>;
   result: { steps: unknown[]; response: { messages: unknown[] } };
   model: LanguageModel;
   typedAgent: TypedAgent;
@@ -346,7 +350,7 @@ export const buildCompletedGenerationResult = async (args: {
   rootTraceId?: string | null;
   result: {
     steps: unknown[];
-    response?: { modelId?: string };
+    response?: { modelId?: string; messages?: unknown[] };
     text: string;
     finishReason: string;
   };
@@ -380,6 +384,7 @@ export const buildCompletedGenerationResult = async (args: {
       model: args.result.response?.modelId ?? args.typedAgent.model ?? '',
       content: args.result.text,
       finishReason: args.result.finishReason,
+      toolMessages: args.result.response?.messages ?? [],
     },
   };
 

--- a/packages/server/src/lib/agentGenerationRecovery.ts
+++ b/packages/server/src/lib/agentGenerationRecovery.ts
@@ -83,6 +83,7 @@ type PendingStateDb = {
   rootTraceId: string | null;
   toolContext: Record<string, string> | null;
   remainingDepth: number | null;
+  allMessagesCount?: number;
 };
 
 const buildPendingFromState = async (args: {
@@ -134,6 +135,7 @@ const buildPendingFromState = async (args: {
     }),
     messages: args.pendingState.messages,
     steps: args.pendingState.steps ?? [],
+    allMessagesCount: args.pendingState.allMessagesCount ?? 0,
     resolvedModel: model,
     agentConfig: {
       instructions: args.typedAgent.instructions,

--- a/packages/server/src/lib/agentGenerationRecovery.ts
+++ b/packages/server/src/lib/agentGenerationRecovery.ts
@@ -1,9 +1,11 @@
 import { resolveAiProviderSecret } from 'src/lib/aiProviders';
 
 import { db } from '../db';
+import { DomainError } from '../errors';
 import {
   type GenerationResult,
   type PendingGeneration,
+  pendingGenerations,
   type TypedAgent,
 } from './agentGenerationHelpers';
 import { buildModel } from './agentModel';
@@ -182,4 +184,29 @@ export const recoverPendingFromDb = async (args: {
     traceId: gen.traceId,
     pendingState,
   });
+};
+
+export const resolvePendingGeneration = async (args: {
+  generationId: string;
+  agentId: string;
+  projectIds?: number[];
+  authHeader?: string;
+}): Promise<PendingGeneration> => {
+  const pending =
+    pendingGenerations.get(args.generationId) ??
+    (await recoverPendingFromDb({
+      generationId: args.generationId,
+      agentId: args.agentId,
+      projectIds: args.projectIds,
+      authHeader: args.authHeader,
+    }));
+
+  if (!pending || pending.agentId !== args.agentId) {
+    throw new DomainError(
+      'GENERATION_NOT_FOUND',
+      `Generation '${args.generationId}' not found or does not belong to agent '${args.agentId}'.`
+    );
+  }
+
+  return pending;
 };

--- a/packages/server/src/lib/agentKnowledge.ts
+++ b/packages/server/src/lib/agentKnowledge.ts
@@ -118,3 +118,18 @@ export const buildWriteMemoryTool = (args: { writeMemoryId: string }): Tool => {
     },
   });
 };
+
+export const buildKnowledgeTools = (args: {
+  typedAgent: { knowledgeConfig: unknown };
+  resolvedTools: Record<string, unknown>;
+}): void => {
+  const knowledgeConfig = args.typedAgent.knowledgeConfig as
+    | { writeMemoryId?: string }
+    | null
+    | undefined;
+  if (knowledgeConfig?.writeMemoryId) {
+    args.resolvedTools['write_memory'] = buildWriteMemoryTool({
+      writeMemoryId: knowledgeConfig.writeMemoryId,
+    });
+  }
+};

--- a/packages/server/src/lib/agentKnowledge.ts
+++ b/packages/server/src/lib/agentKnowledge.ts
@@ -44,7 +44,7 @@ const formatResult = (
 export const buildKnowledgeMessages = async (args: {
   knowledgeConfig: unknown;
   projectIds?: number[];
-  messages: Array<{ role: string; content: string }>;
+  messages: Array<{ role: string; content: unknown }>;
 }): Promise<Array<{ role: string; content: string }>> => {
   const config = args.knowledgeConfig as KnowledgeConfig | null | undefined;
   if (!config) return [];
@@ -52,7 +52,10 @@ export const buildKnowledgeMessages = async (args: {
   const lastUserMessage = [...args.messages].reverse().find((m) => {
     return m.role === 'user';
   });
-  const query = lastUserMessage?.content ?? config.query;
+  const query =
+    typeof lastUserMessage?.content === 'string'
+      ? lastUserMessage.content
+      : config.query;
 
   log(
     'buildKnowledgeMessages: query=%s memoryIds=%o documentPaths=%o',

--- a/packages/server/src/lib/agentNonStreamGeneration.ts
+++ b/packages/server/src/lib/agentNonStreamGeneration.ts
@@ -271,7 +271,11 @@ export const buildToolResultMessages = (args: {
 export const runToolOutputGeneration = async (args: {
   pending: PendingGeneration;
   toolResultMessages: unknown[];
-}) => {
+}): Promise<{
+  text: string;
+  finishReason: string;
+  response?: { modelId?: string; messages?: unknown[] };
+}> => {
   const { pending, toolResultMessages } = args;
   const allMessages = [...pending.messages, ...toolResultMessages];
   const system = (

--- a/packages/server/src/lib/agentNonStreamGeneration.ts
+++ b/packages/server/src/lib/agentNonStreamGeneration.ts
@@ -274,6 +274,7 @@ export const runToolOutputGeneration = async (args: {
 }): Promise<{
   text: string;
   finishReason: string;
+  steps: unknown[];
   response?: { modelId?: string; messages?: unknown[] };
 }> => {
   const { pending, toolResultMessages } = args;

--- a/packages/server/src/lib/agentNonStreamGeneration.ts
+++ b/packages/server/src/lib/agentNonStreamGeneration.ts
@@ -267,3 +267,35 @@ export const buildToolResultMessages = (args: {
     };
   });
 };
+
+export const runToolOutputGeneration = async (args: {
+  pending: PendingGeneration;
+  toolResultMessages: unknown[];
+}) => {
+  const { pending, toolResultMessages } = args;
+  const allMessages = [...pending.messages, ...toolResultMessages];
+  const system = (
+    pending.messages.find((m) => {
+      return (m as { role: string }).role === 'system';
+    }) as { role: string; content: string } | undefined
+  )?.content;
+  const nonSystemMessages = allMessages.filter((m) => {
+    return (m as { role?: string }).role !== 'system';
+  });
+
+  return generateText({
+    model: pending.resolvedModel,
+    system,
+    messages: nonSystemMessages as ModelMessage[],
+    tools:
+      Object.keys(pending.resolvedTools).length > 0
+        ? pending.resolvedTools
+        : undefined,
+    prepareStep: buildPrepareStep({
+      stepRules: pending.agentConfig.stepRules,
+      logContext: 'non_stream',
+    }),
+    stopWhen: stepCountIs(pending.agentConfig.maxSteps),
+    temperature: pending.agentConfig.temperature ?? undefined,
+  });
+};

--- a/packages/server/src/lib/agentNonStreamGeneration.ts
+++ b/packages/server/src/lib/agentNonStreamGeneration.ts
@@ -69,7 +69,7 @@ const callGenerateText = async (args: {
   agentId: string;
   model: LanguageModel;
   system: string | undefined;
-  nonSystemMessages: Array<{ role: string; content: string }>;
+  nonSystemMessages: Array<{ role: string; content: unknown }>;
   resolvedTools: Record<string, Tool>;
   typedAgent: TypedAgent;
   prepareStep: ReturnType<typeof buildPrepareStep>;
@@ -118,7 +118,7 @@ const resolveGenerationResult = async (args: {
   traceId: string;
   parentTraceId?: string | null;
   rootTraceId?: string | null;
-  allMessages: Array<{ role: string; content: string }>;
+  allMessages: Array<{ role: string; content: unknown }>;
   resolvedTools: Record<string, Tool>;
   model: LanguageModel;
   typedAgent: TypedAgent;
@@ -174,7 +174,7 @@ const resolveGenerationResult = async (args: {
 
 export const runNonStreamGeneration = async (args: {
   model: LanguageModel;
-  allMessages: Array<{ role: string; content: string }>;
+  allMessages: Array<{ role: string; content: unknown }>;
   resolvedTools: Record<string, Tool>;
   typedAgent: TypedAgent;
   generationId: string;
@@ -188,7 +188,7 @@ export const runNonStreamGeneration = async (args: {
 }): Promise<GenerationResult> => {
   const system = args.allMessages.find((message) => {
     return message.role === 'system';
-  })?.content;
+  })?.content as string | undefined;
 
   const nonSystemMessages = args.allMessages.filter((message) => {
     return message.role !== 'system';

--- a/packages/server/src/lib/conversationGeneration.ts
+++ b/packages/server/src/lib/conversationGeneration.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import { db } from '../db';
 import { DomainError } from '../errors';
 import { createGeneration, type GenerationResult } from './agents';
+import type { GenerationInputMessage } from './generationInputMessages';
 import { addConversationMessage } from './conversationMessages';
 import { emitEvent, resolveProjectPublicId } from './eventBus';
 
@@ -61,10 +62,24 @@ const buildMessageEntry = (args: {
 
 const buildConversationHistory = (args: {
   messages: Array<ConversationMessage>;
-}) => {
-  return args.messages.map((msg) => {
-    return buildMessageEntry({ msg });
-  });
+}): Array<{ role: string; content: unknown }> => {
+  const result: Array<{ role: string; content: unknown }> = [];
+  for (const msg of args.messages) {
+    if (msg.role === 'assistant') {
+      const toolMessages = (msg as { metadata?: Record<string, unknown> | null })
+        .metadata?.toolMessages;
+      if (Array.isArray(toolMessages) && toolMessages.length > 0) {
+        for (const tm of toolMessages) {
+          result.push(tm as { role: string; content: unknown });
+        }
+      } else {
+        result.push(buildMessageEntry({ msg }));
+      }
+    } else {
+      result.push(buildMessageEntry({ msg }));
+    }
+  }
+  return result;
 };
 
 type InternalGenerationResult =
@@ -74,6 +89,7 @@ type InternalGenerationResult =
       traceId: string;
       content: string;
       model: string;
+      toolMessages?: unknown[];
     }
   | {
       status: 'requires_action';
@@ -84,13 +100,13 @@ type InternalGenerationResult =
 
 const runAgentGeneration = async (args: {
   agent: InstanceType<(typeof db)['Agent']>;
-  messagesForModel: Array<{ role: string; content: string }>;
+  messagesForModel: Array<{ role: string; content: unknown }>;
   toolContext?: Record<string, string>;
   abortSignal?: AbortSignal;
 }): Promise<InternalGenerationResult> => {
   const result = await createGeneration({
     agentId: args.agent.publicId,
-    messages: args.messagesForModel,
+    messages: args.messagesForModel as GenerationInputMessage[],
     toolContext: args.toolContext,
     abortSignal: args.abortSignal,
   });
@@ -117,12 +133,13 @@ const runAgentGeneration = async (args: {
     traceId: result.traceId,
     content: result.output?.content ?? '',
     model: result.output?.model ?? '',
+    toolMessages: result.output?.toolMessages,
   };
 };
 
 const runGenerationForAgent = async (args: {
   generatingAgent: GenerationContext['generatingAgent'];
-  messagesForModel: Array<{ role: string; content: string }>;
+  messagesForModel: Array<{ role: string; content: unknown }>;
   model?: string;
   toolContext?: Record<string, string>;
   abortSignal?: AbortSignal;
@@ -255,6 +272,7 @@ export const generateConversationMessage = async (args: {
     traceId,
     content: assistantContent,
     model: modelName,
+    toolMessages,
   } = genResult;
 
   const persisted = await addConversationMessage({
@@ -263,6 +281,8 @@ export const generateConversationMessage = async (args: {
     role: 'assistant',
     agentId: args.agentId,
     position: snapshotPosition + 1,
+    metadata:
+      toolMessages && toolMessages.length > 0 ? { toolMessages } : undefined,
   });
 
   if (!persisted) {

--- a/packages/server/src/lib/conversationGeneration.ts
+++ b/packages/server/src/lib/conversationGeneration.ts
@@ -3,9 +3,9 @@ import fs from 'node:fs';
 import { db } from '../db';
 import { DomainError } from '../errors';
 import { createGeneration, type GenerationResult } from './agents';
-import type { GenerationInputMessage } from './generationInputMessages';
 import { addConversationMessage } from './conversationMessages';
 import { emitEvent, resolveProjectPublicId } from './eventBus';
+import type { GenerationInputMessage } from './generationInputMessages';
 
 type ConversationMessage = InstanceType<(typeof db)['ConversationMessage']> & {
   document?: InstanceType<(typeof db)['Document']> & {
@@ -66,8 +66,9 @@ const buildConversationHistory = (args: {
   const result: Array<{ role: string; content: unknown }> = [];
   for (const msg of args.messages) {
     if (msg.role === 'assistant') {
-      const toolMessages = (msg as { metadata?: Record<string, unknown> | null })
-        .metadata?.toolMessages;
+      const toolMessages = (
+        msg as { metadata?: Record<string, unknown> | null }
+      ).metadata?.toolMessages;
       if (Array.isArray(toolMessages) && toolMessages.length > 0) {
         for (const tm of toolMessages) {
           result.push(tm as { role: string; content: unknown });

--- a/packages/server/src/lib/generationInputMessages.ts
+++ b/packages/server/src/lib/generationInputMessages.ts
@@ -11,7 +11,10 @@ export type GenerationInputMessage = {
 
 export const resolveGenerationInputMessages = async (args: {
   projectIds?: number[];
-  messages: Array<{ role: string; content: ResolvableMessageContent | unknown[] }>;
+  messages: Array<{
+    role: string;
+    content: ResolvableMessageContent | unknown[];
+  }>;
   authHeader?: string;
   authUser?: AuthUser;
   allowedToolIds?: string[];

--- a/packages/server/src/lib/generationInputMessages.ts
+++ b/packages/server/src/lib/generationInputMessages.ts
@@ -6,21 +6,26 @@ import {
 
 export type GenerationInputMessage = {
   role: string;
-  content: ResolvableMessageContent;
+  content: ResolvableMessageContent | unknown[];
 };
 
 export const resolveGenerationInputMessages = async (args: {
   projectIds?: number[];
-  messages: GenerationInputMessage[];
+  messages: Array<{ role: string; content: ResolvableMessageContent | unknown[] }>;
   authHeader?: string;
   authUser?: AuthUser;
   allowedToolIds?: string[];
   agentBoundaryPolicy?: unknown;
-}): Promise<Array<{ role: string; content: string }>> => {
+}): Promise<Array<{ role: string; content: unknown }>> => {
   const resolved = await Promise.all(
     args.messages.map(async (message) => {
+      // Pass through complex content (e.g. AI SDK tool messages) without resolution
+      if (Array.isArray(message.content)) {
+        return { role: message.role, content: message.content };
+      }
+
       const resolvedContent = await resolveMessageContent({
-        content: message.content,
+        content: message.content as ResolvableMessageContent,
         projectIds: args.projectIds,
         authHeader: args.authHeader,
         authUser: args.authUser,

--- a/packages/server/src/lib/sessionGenerationHelpers.ts
+++ b/packages/server/src/lib/sessionGenerationHelpers.ts
@@ -75,11 +75,14 @@ export const processToolOutputResult = async (args: {
   agentPublicId: string;
 }) => {
   if (args.result.status === 'completed' && args.result.output?.content) {
+    const toolMessages = args.result.output.toolMessages;
     await addConversationMessage({
       conversationId: args.conversation.publicId,
       message: args.result.output.content,
       role: 'assistant',
       agentId: args.agentPublicId,
+      metadata:
+        toolMessages && toolMessages.length > 0 ? { toolMessages } : undefined,
     });
   }
 

--- a/packages/server/tests/unit/tests/lib/agentGeneration.test.ts
+++ b/packages/server/tests/unit/tests/lib/agentGeneration.test.ts
@@ -140,6 +140,7 @@ describe('submitToolOutputs', () => {
         },
       ],
       messages: [{ role: 'user', content: 'hello' }],
+      allMessagesCount: 1,
       steps: [],
       resolvedModel: {} as never,
       agentConfig: {

--- a/packages/server/tests/unit/tests/lib/agentGeneration.test.ts
+++ b/packages/server/tests/unit/tests/lib/agentGeneration.test.ts
@@ -244,6 +244,18 @@ describe('resolveGenerationInputMessages', () => {
     ).rejects.toThrow("Document 'doc_missing' not found");
   });
 
+  test('passes through array content unchanged', async () => {
+    const { resolveGenerationInputMessages } =
+      await loadGenerationInputMessagesModule();
+
+    const arrayContent = [{ type: 'tool-result', toolCallId: 'tc_1' }];
+    const result = await resolveGenerationInputMessages({
+      messages: [{ role: 'tool', content: arrayContent }],
+    });
+
+    expect(result).toEqual([{ role: 'tool', content: arrayContent }]);
+  });
+
   test('keeps string message content unchanged', async () => {
     const { resolveGenerationInputMessages } =
       await loadGenerationInputMessagesModule();


### PR DESCRIPTION
## Summary
This PR adds support for persisting and handling tool exchange messages (from AI SDK tool use) in conversation history. Tool messages are now stored in conversation message metadata and properly reconstructed when building conversation history for subsequent generations.

## Key Changes

- **Tool message persistence**: Assistant messages now store tool exchange messages in metadata when available, allowing tool interactions to be preserved across conversation turns
- **Conversation history reconstruction**: Updated `buildConversationHistory` to extract and include tool messages from assistant message metadata when building the message list for the model
- **Type flexibility**: Changed message content type from `string` to `unknown` throughout the generation pipeline to accommodate complex message structures (including AI SDK tool messages which can be objects/arrays)
- **Generation result tracking**: Added `toolMessages` field to `GenerationResult` and `InternalGenerationResult` to capture tool exchange messages from model responses
- **Pending generation state**: Added `allMessagesCount` to track the original message count before tool messages are added, enabling proper extraction of new tool messages in `submitToolOutputs`
- **Message resolution**: Updated `resolveGenerationInputMessages` to pass through array-based content (tool messages) without attempting string resolution

## Notable Implementation Details

- Tool messages are extracted from `metadata.toolMessages` on assistant messages and injected into the conversation history before building the message list for the model
- The `allMessagesCount` field in pending generation state allows distinguishing between original conversation messages and newly generated tool exchange messages
- Type casting is used strategically where content is known to be a string (e.g., when extracting system instructions) while maintaining flexibility for complex message types elsewhere
- Tool messages are collected from multiple sources in `submitToolOutputs`: pending messages, tool result messages, and response messages

https://claude.ai/code/session_01QSa1z6pzzXwREmG5aDs3Wu