### PR TITLE
chore(release): publish packages v0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Bug Fixes
+
+* accept string values for tool_choice in agents and formations ([#151](https://github.com/ttoss/soat/issues/151)) ([322bf45](https://github.com/ttoss/soat/commit/322bf4538d42aca7dfba1de3f60b1be4d0f22cd9))
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://github.com/ttoss/soat/issues/148)) ([1406654](https://github.com/ttoss/soat/commit/1406654ac85a2971220358591cfb73e9a96c1e51))
+
 ## [0.6.6](https://github.com/ttoss/soat/compare/v0.6.5...v0.6.6) (2026-06-05)
 
 **Note:** Version bump only for package ttoss-soat

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "npmClient": "pnpm",
   "stream": true,
   "command": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+**Note:** Version bump only for package @soat/cli
+
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+**Note:** Version bump only for package @soat/cli
+
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+**Note:** Version bump only for package @soat/cli
+
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+**Note:** Version bump only for package @soat/cli
+
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+**Note:** Version bump only for package @soat/cli
+
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+**Note:** Version bump only for package @soat/cli
+
 ## [0.6.6](https://github.com/ttoss/soat/compare/v0.6.5...v0.6.6) (2026-06-05)
 
 **Note:** Version bump only for package @soat/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/cli",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "type": "module",
   "scripts": {
     "generate": "tsx scripts/generate.ts",

--- a/packages/postgresdb/CHANGELOG.md
+++ b/packages/postgresdb/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.7](https://127.0.0.1/42723/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/42723/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/42723/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/42723/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/42723/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/42723/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/42723/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/42723/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/42723/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/34089/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/34089/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/34089/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/34089/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/34089/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/34089/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/34089/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/34089/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/34089/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
 ## [0.6.6](https://github.com/ttoss/soat/compare/v0.6.5...v0.6.6) (2026-06-05)
 
 **Note:** Version bump only for package @soat/postgresdb

--- a/packages/postgresdb/package.json
+++ b/packages/postgresdb/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@soat/postgresdb",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Database models and operations for SOAT packages",
   "type": "module",
   "exports": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+**Note:** Version bump only for package @soat/sdk
+
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+**Note:** Version bump only for package @soat/sdk
+
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+**Note:** Version bump only for package @soat/sdk
+
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+**Note:** Version bump only for package @soat/sdk
+
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+**Note:** Version bump only for package @soat/sdk
+
+## [0.6.7](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+**Note:** Version bump only for package @soat/sdk
+
 ## [0.6.6](https://github.com/ttoss/soat/compare/v0.6.5...v0.6.6) (2026-06-05)
 
 **Note:** Version bump only for package @soat/sdk

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/sdk",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "TypeScript SDK for the SOAT API",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,66 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.7](https://127.0.0.1/42723/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Bug Fixes
+
+* accept string values for tool_choice in agents and formations ([#151](https://127.0.0.1/42723/git/ttoss/issues/151)) ([322bf45](https://127.0.0.1/42723/git/ttoss/commits/322bf4538d42aca7dfba1de3f60b1be4d0f22cd9))
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/42723/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/42723/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/42723/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Bug Fixes
+
+* accept string values for tool_choice in agents and formations ([#151](https://127.0.0.1/42723/git/ttoss/issues/151)) ([322bf45](https://127.0.0.1/42723/git/ttoss/commits/322bf4538d42aca7dfba1de3f60b1be4d0f22cd9))
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/42723/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/42723/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/42723/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Bug Fixes
+
+* accept string values for tool_choice in agents and formations ([#151](https://127.0.0.1/42723/git/ttoss/issues/151)) ([322bf45](https://127.0.0.1/42723/git/ttoss/commits/322bf4538d42aca7dfba1de3f60b1be4d0f22cd9))
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/42723/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/42723/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/34089/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Bug Fixes
+
+* accept string values for tool_choice in agents and formations ([#151](https://127.0.0.1/34089/git/ttoss/issues/151)) ([322bf45](https://127.0.0.1/34089/git/ttoss/commits/322bf4538d42aca7dfba1de3f60b1be4d0f22cd9))
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/34089/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/34089/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/34089/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Bug Fixes
+
+* accept string values for tool_choice in agents and formations ([#151](https://127.0.0.1/34089/git/ttoss/issues/151)) ([322bf45](https://127.0.0.1/34089/git/ttoss/commits/322bf4538d42aca7dfba1de3f60b1be4d0f22cd9))
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/34089/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/34089/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/34089/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Bug Fixes
+
+* accept string values for tool_choice in agents and formations ([#151](https://127.0.0.1/34089/git/ttoss/issues/151)) ([322bf45](https://127.0.0.1/34089/git/ttoss/commits/322bf4538d42aca7dfba1de3f60b1be4d0f22cd9))
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/34089/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/34089/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
 ## [0.6.6](https://github.com/ttoss/soat/compare/v0.6.5...v0.6.6) (2026-06-05)
 
 **Note:** Version bump only for package @soat/server

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/server",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "main": "dist/server.mjs",
   "scripts": {
     "build": "tsdown",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.7](https://127.0.0.1/42723/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/42723/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/42723/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/42723/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/42723/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/42723/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/42723/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/42723/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/42723/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/34089/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/34089/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/34089/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/34089/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/34089/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/34089/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.7](https://127.0.0.1/34089/git/ttoss/compare/v0.6.6...v0.6.7) (2026-06-07)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/34089/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/34089/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
 ## [0.6.6](https://github.com/ttoss/soat/compare/v0.6.5...v0.6.6) (2026-06-05)
 
 **Note:** Version bump only for package @soat/website

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/website",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
Bump patch version to `0.6.7` via `pnpm lerna version patch`.

After merging, push the tag to trigger the release pipeline:

```bash
git push origin v0.6.7
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL)_