### PR TITLE
ci: auto-push release tag when chore(release) merges to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,24 @@ jobs:
         env:
           COMPOSE_BAKE: '1'
 
+  push-release-tag:
+    name: Push Release Tag
+    runs-on: ubuntu-latest
+    if: contains(github.event.head_commit.message, 'chore(release):')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read version from lerna.json
+        id: version
+        run: echo "version=$(node -e "console.log(require('./lerna.json').version)")" >> "$GITHUB_OUTPUT"
+
+      - name: Push tag
+        run: |
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+
   tutorials-test:
     name: Tutorials Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `push-release-tag` job to `main.yml` that fires only when a `chore(release):` commit lands on main (i.e. after `lerna version patch` is merged).

**What it does:**
1. Reads the version from `lerna.json`
2. Creates and pushes the `vX.Y.Z` tag
3. That tag push triggers `tag.yml` → npm publish + Docker + website deploy

**Before this change:** after merging the release PR you had to manually run `git push origin vX.Y.Z` from a machine with push access.

**After this change:** merge the release PR → tag is pushed automatically → release pipeline fires.

The job requires `contents: write` permission to push tags.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL)_