### PR TITLE
ci/docs: fix release pipeline and terminology consistency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,24 @@ jobs:
         env:
           COMPOSE_BAKE: '1'
 
+  push-release-tag:
+    name: Push Release Tag
+    runs-on: ubuntu-latest
+    if: contains(github.event.head_commit.message, 'chore(release):')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read version from lerna.json
+        id: version
+        run: echo "version=$(node -e "console.log(require('./lerna.json').version)")" >> "$GITHUB_OUTPUT"
+
+      - name: Push tag
+        run: |
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+
   tutorials-test:
     name: Tutorials Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
   push-release-tag:
     name: Push Release Tag
     runs-on: ubuntu-latest
-    if: contains(github.event.head_commit.message, 'chore(release):')
+    if: github.event.head_commit.message == format('chore(release): publish packages')
     permissions:
       contents: write
     steps:
@@ -92,6 +92,12 @@ jobs:
         run: |
           git tag "v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
+
+  release:
+    name: Release
+    needs: push-release-tag
+    uses: ./.github/workflows/tag.yml
+    secrets: inherit
 
   tutorials-test:
     name: Tutorials Tests

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '**'
+  workflow_call:
 
 concurrency:
   group: tag

--- a/packages/website/docs/cli/introduction.md
+++ b/packages/website/docs/cli/introduction.md
@@ -28,7 +28,7 @@ You will be prompted for:
 | Prompt   | Description                                            |
 | -------- | ------------------------------------------------------ |
 | Base URL | URL of your SOAT server (e.g. `http://localhost:5047`) |
-| Token    | JWT session token or `sk_`-prefixed API key            |
+| Token    | JWT session token (from `login-user`) or `sk_`-prefixed API key (from `create-api-key`) |
 
 To save under a named profile, pass `--profile`:
 
@@ -53,7 +53,7 @@ Environment variables take precedence over stored profiles:
 | Variable        | Description                                                                                                      |
 | --------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `SOAT_BASE_URL` | Server base URL. When set together with `SOAT_TOKEN`, skips profile lookup entirely. When set alone, overrides the base URL of the resolved profile. |
-| `SOAT_TOKEN`    | Bearer token. Must be set together with `SOAT_BASE_URL` to skip profile lookup entirely.                         |
+| `SOAT_TOKEN`    | Bearer token — JWT session token or `sk_`-prefixed API key. Must be set together with `SOAT_BASE_URL` to skip profile lookup entirely. |
 | `SOAT_PROFILE`  | Name of the profile to use when no `--profile` flag is passed.                                                   |
 
 ## Available Commands

--- a/packages/website/docs/cli/introduction.md
+++ b/packages/website/docs/cli/introduction.md
@@ -28,7 +28,7 @@ You will be prompted for:
 | Prompt   | Description                                            |
 | -------- | ------------------------------------------------------ |
 | Base URL | URL of your SOAT server (e.g. `http://localhost:5047`) |
-| Token    | JWT session token or `sk_`-prefixed project key        |
+| Token    | JWT session token or `sk_`-prefixed API key            |
 
 To save under a named profile, pass `--profile`:
 

--- a/packages/website/docs/sdk/introduction.md
+++ b/packages/website/docs/sdk/introduction.md
@@ -31,7 +31,7 @@ const soat = new SoatClient({
 | Option    | Type                     | Required | Description                                                                          |
 | --------- | ------------------------ | -------- | ------------------------------------------------------------------------------------ |
 | `baseUrl` | `string`                 | No       | Server base URL (e.g. `https://api.example.com`). Defaults to the current origin.   |
-| `token`   | `string`                 | No       | Bearer token — JWT session token or `sk_`-prefixed project key.                      |
+| `token`   | `string`                 | No       | Bearer token — JWT session token or `sk_`-prefixed API key.                          |
 | `headers` | `Record<string, string>` | No       | Additional headers merged into every request.                                        |
 
 ## Calling Methods
@@ -85,13 +85,13 @@ When `error` is set, `data` is `undefined`. Use early returns or throws to guard
 SOAT accepts two token types as the `token` option:
 
 - **JWT session token** — obtained from `POST /api/v1/users/login`
-- **Project-scoped API key** — prefixed `sk_`, obtained from `POST /api/v1/project-keys`
+- **API key** — prefixed `sk_`, obtained from `POST /api/v1/api-keys`
 
 ```ts
 // JWT token
 const soat = new SoatClient({ baseUrl, token: sessionToken });
 
-// Project key
+// API key
 const soat = new SoatClient({ baseUrl, token: 'sk_...' });
 ```
 

--- a/packages/website/docs/tutorials/permissions.md
+++ b/packages/website/docs/tutorials/permissions.md
@@ -471,12 +471,12 @@ soat configure --profile alice
 soat login-user --username bob --password Bob1234!
 soat configure --profile bob
 
-# Create Alice's project key (using her profile)
+# Create Alice's API key (using her profile)
 ALICE_API_KEY=$(soat --profile alice create-api-key \
   --name "alice-analytics-key" \
   --project-id "$PROJECT_ID" | jq -r '.key')
 
-# Create Bob's project key, explicitly restricting it to the read-only policy
+# Create Bob's API key, explicitly restricting it to the read-only policy
 BOB_API_KEY=$(soat --profile bob create-api-key \
   --name "bob-analytics-key" \
   --project-id "$PROJECT_ID" \
@@ -551,14 +551,14 @@ BOB_TOKEN=$(curl -s -X POST "$SOAT_BASE_URL/api/v1/users/login" \
   -H "Content-Type: application/json" \
   -d '{"username":"bob","password":"Bob1234!"}' | jq -r '.token')
 
-# Alice's project key — inherits full-access
+# Alice's API key — inherits full-access
 ALICE_API_KEY=$(curl -s -X POST "$SOAT_BASE_URL/api/v1/api-keys" \
   -H "Authorization: Bearer $ALICE_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{\"name\":\"alice-analytics-key\",\"project_id\":\"$PROJECT_ID\"}" \
   | jq -r '.key')
 
-# Bob's project key — further restricted to read-only
+# Bob's API key — further restricted to read-only
 BOB_API_KEY=$(curl -s -X POST "$SOAT_BASE_URL/api/v1/api-keys" \
   -H "Authorization: Bearer $BOB_TOKEN" \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary

- **CI**: Add `workflow_call` trigger to `tag.yml` and call it directly from `main.yml` after `push-release-tag` succeeds — fixes the issue where `GITHUB_TOKEN` tag pushes don't trigger other workflows, so `tag.yml` (npm publish, Docker, website deploy) never ran for `v0.6.7`
- **CI**: Tighten `push-release-tag` condition to exact match on `'chore(release): publish packages'` to prevent false positives from PR descriptions containing `chore(release):`
- **Docs**: Replace "project key" with "API key" throughout CLI, SDK, and tutorial docs — the module is named API Keys and the endpoint is `POST /api/v1/api-keys`; the SDK doc also referenced the non-existent `POST /api/v1/project-keys`
- **Docs**: Clarify that `SOAT_TOKEN` accepts both JWT session tokens and `sk_`-prefixed API keys

## Test plan

- [ ] Merge and verify `push-release-tag` job fires on the next `chore(release): publish packages` commit
- [ ] Verify `release` job (calling `tag.yml`) runs after `push-release-tag` succeeds and publishes packages

https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL)_