### PR TITLE
ci: fix workflow_call condition and if expression syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
     name: Push Release Tag
     runs-on: ubuntu-latest
 
-    if: github.event.head_commit.message == format('chore(release): publish packages')
+    if: github.event.head_commit.message == 'chore(release): publish packages'
     permissions:
       contents: write
     steps:
@@ -98,6 +98,7 @@ jobs:
   release:
     name: Release
     needs: push-release-tag
+    if: needs.push-release-tag.result == 'success'
     uses: ./.github/workflows/tag.yml
     secrets: inherit
 


### PR DESCRIPTION
## Summary

Fixes the `main.yml` failure (0 jobs ran) introduced in #158.

Two issues:
- `format('chore(release): publish packages')` — `format()` with a single arg and no format specifiers is unusual and likely caused GitHub to reject the workflow at parse time. Replaced with a plain string literal.
- `release` job had no `if` guard — when `push-release-tag` is skipped (all non-release commits), GitHub evaluates whether to run the reusable workflow call with an ambiguous upstream state. Added `if: needs.push-release-tag.result == 'success'` so it only fires on actual releases.

https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL)_