### PR TITLE
ci: replace workflow_call with gh workflow run to trigger release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,13 +94,10 @@ jobs:
           git tag "v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
 
-
-  release:
-    name: Release
-    needs: push-release-tag
-    if: needs.push-release-tag.result == 'success'
-    uses: ./.github/workflows/tag.yml
-    secrets: inherit
+      - name: Trigger release workflow
+        run: gh workflow run tag.yml --ref "v${{ steps.version.outputs.version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   tutorials-test:
     name: Tutorials Tests

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - '**'
-  workflow_call:
+  workflow_dispatch:
 
 concurrency:
   group: tag


### PR DESCRIPTION
## Summary

`workflow_call` in `main.yml` caused GitHub to reject the entire workflow at parse time (0 jobs, `conclusion: failure`). Root cause is unclear but may be related to mixing reusable workflow call jobs with regular jobs under certain `if`/`needs` conditions.

**New approach:**
- Replace `workflow_call` in `tag.yml` with `workflow_dispatch`
- Remove the `release` job from `main.yml`
- After pushing the tag, explicitly trigger `tag.yml` via `gh workflow run tag.yml --ref "v<version>"`

`workflow_dispatch` is triggered by the GitHub CLI using `GITHUB_TOKEN`, which is allowed to trigger workflows (unlike pushing tags with `GITHUB_TOKEN`).

https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL)_