### PR TITLE
ci: fix YAML parse error in push-release-tag if condition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
     name: Push Release Tag
     runs-on: ubuntu-latest
 
-    if: github.event.head_commit.message == 'chore(release): publish packages'
+    if: "github.event.head_commit.message == 'chore(release): publish packages'"
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Root cause

All three previous PRs failed with `conclusion: failure, total_jobs: 0` — GitHub rejected the workflow at parse time before running any jobs.

The `if` condition contained `': '` (colon followed by space) in an **unquoted** YAML scalar:

```yaml
# BROKEN — ': ' in unquoted value is a YAML mapping indicator
if: github.event.head_commit.message == 'chore(release): publish packages'
```

YAML treats `: ` as a mapping separator, so the parser misreads the value and produces invalid YAML.

The original `contains(github.event.head_commit.message, 'chore(release):')` was fine because the colon appeared at the **end** of the string with no trailing space.

## Fix

Wrap in double quotes so YAML treats the entire value as a string:

```yaml
if: "github.event.head_commit.message == 'chore(release): publish packages'"
```

https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL)_