### PR TITLE
ci: use startsWith for release commit detection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
     name: Push Release Tag
     runs-on: ubuntu-latest
 
-    if: "github.event.head_commit.message == 'chore(release): publish packages'"
+    if: "startsWith(github.event.head_commit.message, 'chore(release): publish packages')"
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Problem

`push-release-tag` was skipped even on a release merge. GitHub appends the PR number to merge commit messages:

```
chore(release): publish packages (#162)
```

The exact match `== 'chore(release): publish packages'` fails because of the trailing ` (#162)`.

## Fix

Use `startsWith(...)` instead — matches the lerna commit prefix while remaining specific enough to avoid false positives.

https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL)_