### PR TITLE
chore(release): publish packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.9](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.9) (2026-06-08)
+
+### Bug Fixes
+
+* accept string values for tool_choice in agents and formations ([#151](https://github.com/ttoss/soat/issues/151)) ([322bf45](https://github.com/ttoss/soat/commit/322bf4538d42aca7dfba1de3f60b1be4d0f22cd9))
+* use branch ref for workflow_dispatch trigger ([#165](https://github.com/ttoss/soat/issues/165)) ([a4b3877](https://github.com/ttoss/soat/commit/a4b3877967fe53ea906a46d1b032ceb530c0891f)), closes [#164](https://github.com/ttoss/soat/issues/164)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://github.com/ttoss/soat/issues/148)) ([1406654](https://github.com/ttoss/soat/commit/1406654ac85a2971220358591cfb73e9a96c1e51))
+
 ## [0.6.8](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.8) (2026-06-08)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "npmClient": "pnpm",
   "stream": true,
   "command": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.9](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.9) (2026-06-08)
+
+**Note:** Version bump only for package @soat/cli
+
+## [0.6.9](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.9) (2026-06-08)
+
+**Note:** Version bump only for package @soat/cli
+
 ## [0.6.8](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.8) (2026-06-08)
 
 **Note:** Version bump only for package @soat/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/cli",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "type": "module",
   "scripts": {
     "generate": "tsx scripts/generate.ts",

--- a/packages/postgresdb/CHANGELOG.md
+++ b/packages/postgresdb/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.9](https://127.0.0.1/45289/git/ttoss/compare/v0.6.6...v0.6.9) (2026-06-08)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/45289/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/45289/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.9](https://127.0.0.1/45289/git/ttoss/compare/v0.6.6...v0.6.9) (2026-06-08)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/45289/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/45289/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
 ## [0.6.8](https://127.0.0.1/41727/git/ttoss/compare/v0.6.6...v0.6.8) (2026-06-08)
 
 ### Features

--- a/packages/postgresdb/package.json
+++ b/packages/postgresdb/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@soat/postgresdb",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Database models and operations for SOAT packages",
   "type": "module",
   "exports": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.9](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.9) (2026-06-08)
+
+**Note:** Version bump only for package @soat/sdk
+
+## [0.6.9](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.9) (2026-06-08)
+
+**Note:** Version bump only for package @soat/sdk
+
 ## [0.6.8](https://github.com/ttoss/soat/compare/v0.6.6...v0.6.8) (2026-06-08)
 
 **Note:** Version bump only for package @soat/sdk

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/sdk",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "TypeScript SDK for the SOAT API",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.9](https://127.0.0.1/45289/git/ttoss/compare/v0.6.6...v0.6.9) (2026-06-08)
+
+### Bug Fixes
+
+* accept string values for tool_choice in agents and formations ([#151](https://127.0.0.1/45289/git/ttoss/issues/151)) ([322bf45](https://127.0.0.1/45289/git/ttoss/commits/322bf4538d42aca7dfba1de3f60b1be4d0f22cd9))
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/45289/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/45289/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.9](https://127.0.0.1/45289/git/ttoss/compare/v0.6.6...v0.6.9) (2026-06-08)
+
+### Bug Fixes
+
+* accept string values for tool_choice in agents and formations ([#151](https://127.0.0.1/45289/git/ttoss/issues/151)) ([322bf45](https://127.0.0.1/45289/git/ttoss/commits/322bf4538d42aca7dfba1de3f60b1be4d0f22cd9))
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/45289/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/45289/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
 ## [0.6.8](https://127.0.0.1/41727/git/ttoss/compare/v0.6.6...v0.6.8) (2026-06-08)
 
 ### Bug Fixes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/server",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "main": "dist/server.mjs",
   "scripts": {
     "build": "tsdown",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.9](https://127.0.0.1/45289/git/ttoss/compare/v0.6.6...v0.6.9) (2026-06-08)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/45289/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/45289/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
+## [0.6.9](https://127.0.0.1/45289/git/ttoss/compare/v0.6.6...v0.6.9) (2026-06-08)
+
+### Features
+
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/45289/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/45289/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+
 ## [0.6.8](https://127.0.0.1/41727/git/ttoss/compare/v0.6.6...v0.6.8) (2026-06-08)
 
 ### Features

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/website",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
Bumps all packages from `0.6.8` → `0.6.9`.

Packages changed:
- `@soat/cli`
- `@soat/sdk`
- `@soat/server`
- `@soat/postgresdb` (private)
- `@soat/website` (private)

Merging this PR will trigger the `push-release-tag` job in `main.yml`, which will:
1. Push the `v0.6.9` tag
2. Trigger `tag.yml` via `gh workflow run tag.yml --ref main`
3. Publish `@soat/sdk` and `@soat/cli` to npm
4. Push the Docker image to Docker Hub
5. Deploy the website

https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tww1ybLMoSXtwQSTe4aspL)_