### PR TITLE
ci: run tests on main only for release commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,7 @@ jobs:
   push-release-tag:
     name: Push Release Tag
     runs-on: ubuntu-latest
+    needs: [build-and-test, smoke-test, tutorials-test]
     if: "startsWith(github.event.head_commit.message, 'chore(release): publish packages')"
     permissions:
       contents: write
@@ -156,7 +157,7 @@ jobs:
 
   publish-docker:
     name: Publish Docker Image
-    needs: release
+    needs: push-release-tag
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'chore(release):') && github.ref_type != 'tag' }}
+    if: "startsWith(github.event.head_commit.message, 'chore(release): publish packages')"
 
     steps:
       - uses: actions/checkout@v6
@@ -42,7 +42,7 @@ jobs:
   smoke-test:
     name: Smoke Tests
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'chore(release):') && github.ref_type != 'tag' }}
+    if: "startsWith(github.event.head_commit.message, 'chore(release): publish packages')"
 
     steps:
       - uses: actions/checkout@v6
@@ -203,7 +203,7 @@ jobs:
   tutorials-test:
     name: Tutorials Tests
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'chore(release):') && github.ref_type != 'tag' }}
+    if: "startsWith(github.event.head_commit.message, 'chore(release): publish packages')"
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- `build-and-test`, `smoke-test`, and `tutorials-test` in `main.yml` now only run when the commit message starts with `chore(release): publish packages`
- Regular pushes to `main` (feature merges, fixes, etc.) no longer trigger these expensive jobs since they have no effect outside of a release

## Test plan

- [ ] Merge a regular commit to `main` and confirm those three jobs are skipped
- [ ] Trigger a release (`pnpm lerna version`) and confirm the jobs run as expected before tagging/publishing

https://claude.ai/code/session_01MdPaP7uoyk1BLiAxwC4CBu

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdPaP7uoyk1BLiAxwC4CBu)_