### PR TITLE
fix: increase Ollama context window to prevent prompt truncation

### DIFF
--- a/tests/docker-compose.smoke.yml
+++ b/tests/docker-compose.smoke.yml
@@ -17,6 +17,8 @@ services:
     image: ollama/ollama:0.20.6
     volumes:
       - ${HOME}/.ollama:/root/.ollama
+    environment:
+      OLLAMA_NUM_CTX: '16384'
     entrypoint:
       - /bin/sh
       - -c

--- a/tests/docker-compose.tutorials.yml
+++ b/tests/docker-compose.tutorials.yml
@@ -19,6 +19,8 @@ services:
     image: ollama/ollama:0.20.6
     volumes:
       - ${HOME}/.ollama:/root/.ollama
+    environment:
+      OLLAMA_NUM_CTX: '16384'
     entrypoint:
       - /bin/sh
       - -c


### PR DESCRIPTION
## Summary

- Adds `OLLAMA_NUM_CTX: '16384'` to the `ollama` service in both `tests/docker-compose.smoke.yml` and `tests/docker-compose.tutorials.yml`
- The default Ollama context window is 4096 tokens; smoke/tutorial test prompts were exceeding that (observed at 12349 tokens), causing silent truncation
- 16384 tokens provides enough headroom for current test prompts

## Test plan

- [ ] Run smoke tests and verify no more `truncating input prompt` warnings from Ollama
- [ ] Run tutorials tests and verify same

https://claude.ai/code/session_01AGWUg5rkDSVAcKiLSQZ1Jq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGWUg5rkDSVAcKiLSQZ1Jq)_