### PR TITLE
fix: persist responseMessages metadata after tool-output submission

### DIFF
--- a/packages/server/src/lib/sessionGenerationHelpers.ts
+++ b/packages/server/src/lib/sessionGenerationHelpers.ts
@@ -75,11 +75,16 @@ export const processToolOutputResult = async (args: {
   agentPublicId: string;
 }) => {
   if (args.result.status === 'completed' && args.result.output?.content) {
+    const responseMessages = args.result.output.responseMessages;
     await addConversationMessage({
       conversationId: args.conversation.publicId,
       message: args.result.output.content,
       role: 'assistant',
       agentId: args.agentPublicId,
+      metadata:
+        responseMessages && responseMessages.length > 0
+          ? { responseMessages }
+          : undefined,
     });
   }
 

--- a/packages/server/tests/unit/tests/rest/sessions.test.ts
+++ b/packages/server/tests/unit/tests/rest/sessions.test.ts
@@ -1414,6 +1414,47 @@ describe('Sessions', () => {
       );
     });
 
+    test('persists response_messages in metadata after tool-output completion', async () => {
+      const responseMessages = [
+        { role: 'assistant', content: [{ type: 'tool-call', toolCallId: 'tc_meta_01', toolName: 'get_weather', args: { city: 'Paris' } }] },
+        { role: 'tool', content: [{ type: 'tool-result', toolCallId: 'tc_meta_01', result: '18C' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'Weather in Paris: 18C' }] },
+      ];
+
+      submitToolOutputsSpy.mockResolvedValueOnce({
+        id: 'gen_meta_done_01',
+        traceId: 'trc_meta_done_01',
+        status: 'completed',
+        output: {
+          model: 'test-model',
+          content: 'Weather in Paris: 18C',
+          finishReason: 'stop',
+          responseMessages,
+        },
+      });
+
+      await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions/${sessionId}/tool-outputs`)
+        .send({
+          generationId: 'gen_meta_done_01',
+          toolOutputs: [{ toolCallId: 'tc_meta_01', output: '18C' }],
+        });
+
+      const messagesResponse = await authenticatedTestClient(userToken).get(
+        `/api/v1/agents/${agentId}/sessions/${sessionId}/messages`
+      );
+
+      expect(messagesResponse.status).toBe(200);
+      const assistantMsg = messagesResponse.body.data.find(
+        (m: { role: string; content: string }) =>
+          m.role === 'assistant' && m.content === 'Weather in Paris: 18C'
+      );
+      expect(assistantMsg).toBeDefined();
+      expect(assistantMsg.metadata).not.toBeNull();
+      expect(assistantMsg.metadata.response_messages).toBeDefined();
+      expect(assistantMsg.metadata.response_messages).toHaveLength(3);
+    });
+
     test('returns requires_action result when more tool outputs are needed', async () => {
       submitToolOutputsSpy.mockResolvedValueOnce({
         id: 'gen_submit_req_01',

--- a/packages/server/tests/unit/tests/rest/sessions.test.ts
+++ b/packages/server/tests/unit/tests/rest/sessions.test.ts
@@ -1427,7 +1427,7 @@ describe('Sessions', () => {
         status: 'completed',
         output: {
           model: 'test-model',
-          content: 'Weather in Paris: 18C',
+          content: 'Unique metadata regression reply',
           finishReason: 'stop',
           responseMessages,
         },
@@ -1447,7 +1447,8 @@ describe('Sessions', () => {
       expect(messagesResponse.status).toBe(200);
       const assistantMsg = messagesResponse.body.data.find(
         (m: { role: string; content: string }) =>
-          m.role === 'assistant' && m.content === 'Weather in Paris: 18C'
+          m.role === 'assistant' &&
+          m.content === 'Unique metadata regression reply'
       );
       expect(assistantMsg).toBeDefined();
       expect(assistantMsg.metadata).not.toBeNull();


### PR DESCRIPTION
## Summary

- `processToolOutputResult` in `sessionGenerationHelpers.ts` was calling `addConversationMessage` without passing `metadata`, so `response_messages` were never stored for assistant turns produced by the tool-output submission path
- Fix mirrors the identical conditional already used in `conversationGeneration.ts`: pass `responseMessages` from the generation result as `metadata.responseMessages` when the array is non-empty

## Root Cause

Two code paths produce assistant messages after generation:

1. **Direct generation** (`conversationGeneration.ts`) — correctly stores `metadata.responseMessages`
2. **Tool-output submission** (`sessionGenerationHelpers.ts` → `processToolOutputResult`) — did **not** pass metadata, always resulting in `metadata: null`

The affected turns in the bug report (positions 1, 5, 31) were all produced by the tool-output path.

## Test plan

- [ ] New regression test added: `persists response_messages in metadata after tool-output completion` — mocks `submitToolOutputs` with a result containing `responseMessages`, then asserts the stored assistant message has non-null `metadata.response_messages` with the correct length
- [ ] Existing tool-output tests still pass (no behavior changed for the happy path, 404, or `requires_action` cases)

https://claude.ai/code/session_01Qbr19qUXaG73W67ehU4qpb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qbr19qUXaG73W67ehU4qpb)_