### PR TITLE
feat: surface upstream AI provider errors and expose generation records

### DIFF
--- a/packages/postgresdb/src/models/Generation.ts
+++ b/packages/postgresdb/src/models/Generation.ts
@@ -138,6 +138,11 @@ export class Generation extends Model {
   @Column({ type: DataType.STRING(64), allowNull: true })
   declare stopReason: string | null;
 
+  // Structured error payload recorded when the generation fails
+  // (e.g. upstream AI provider errors).
+  @Column({ type: DataType.JSONB, allowNull: true })
+  declare error: Record<string, unknown> | null;
+
   @Column({ type: DataType.JSONB, allowNull: true })
   declare metadata: Record<string, unknown> | null;
 

--- a/packages/postgresdb/src/models/Trace.ts
+++ b/packages/postgresdb/src/models/Trace.ts
@@ -109,6 +109,11 @@ export class Trace extends Model {
   @Column({ type: DataType.INTEGER, allowNull: false, defaultValue: 0 })
   declare stepCount: number;
 
+  // Structured error payload recorded when a generation in this trace fails
+  // (e.g. upstream AI provider errors).
+  @Column({ type: DataType.JSONB, allowNull: true })
+  declare error: Record<string, unknown> | null;
+
   @Column({ type: DataType.DATE })
   declare createdAt: Date;
 

--- a/packages/server/src/errors/codes.ts
+++ b/packages/server/src/errors/codes.ts
@@ -23,6 +23,11 @@ export const ERROR_CODES = {
     httpStatus: 400,
     description: 'A referenced AI provider does not exist.',
   },
+  AI_PROVIDER_ERROR: {
+    httpStatus: 502,
+    description:
+      'The upstream AI provider returned an error (e.g. insufficient credits, rate limit, or the provider is unreachable).',
+  },
   GENERATION_NOT_FOUND: {
     httpStatus: 404,
     description:

--- a/packages/server/src/lib/agentGeneration.ts
+++ b/packages/server/src/lib/agentGeneration.ts
@@ -1,6 +1,5 @@
 import { generatePublicId, PUBLIC_ID_PREFIXES } from '@soat/postgresdb';
-import type { LanguageModel, ModelMessage, Tool } from 'ai';
-import { generateText, stepCountIs } from 'ai';
+import type { LanguageModel, Tool } from 'ai';
 import createDebug from 'debug';
 import type { AuthUser } from 'src/Context';
 import { resolveAiProviderSecret } from 'src/lib/aiProviders';
@@ -21,18 +20,20 @@ import {
 import { buildKnowledgeMessages, buildWriteMemoryTool } from './agentKnowledge';
 import { buildModel } from './agentModel';
 import {
-  buildPrepareStep,
   buildToolResultMessages as buildToolResultMessagesFromOutputs,
   runNonStreamGeneration,
+  runToolOutputsGeneration,
 } from './agentNonStreamGeneration';
 import { resolveAgentTools } from './agentToolResolver';
-import { emitEvent, resolveProjectPublicId } from './eventBus';
 import {
   type GenerationInputMessage,
   resolveGenerationInputMessages,
 } from './generationInputMessages';
-import { createGenerationRecord, updateGenerationRecord } from './generations';
-import { saveTrace, serializeSteps } from './traces';
+import {
+  fireCompletionSideEffects,
+  recordGenerationFailure,
+} from './generationLifecycle';
+import { createGenerationRecord } from './generations';
 
 const log = createDebug('soat:generation');
 
@@ -241,7 +242,9 @@ const resolveContextAndRecord = async (args: {
     remainingDepth: args.remainingDepth,
   });
 
-  createGenerationRecord({
+  // Awaited so the record reliably exists before the generation runs and a
+  // failure can be persisted on it. Creation failures are non-fatal.
+  await createGenerationRecord({
     publicId: ctx.generationId,
     projectId: ctx.typedAgent.project.id as number,
     agentId: args.agentId,
@@ -249,7 +252,13 @@ const resolveContextAndRecord = async (args: {
     initiatorGenerationId: args.initiatorGenerationId ?? null,
     startedByPrincipalType: null,
     startedByPrincipalId: null,
-  }).catch(() => {});
+  }).catch((error) => {
+    log(
+      'resolveContextAndRecord: failed to create generation record generationId=%s error=%s',
+      ctx.generationId,
+      error instanceof Error ? error.message : String(error)
+    );
+  });
 
   return ctx;
 };
@@ -311,56 +320,26 @@ export const createGeneration = async (args: {
 
   log('createGeneration: agentId=%s stream=%s', args.agentId, args.stream);
 
-  return dispatchGeneration({
-    stream: args.stream,
-    ctx,
-    traceId,
-    agentId: args.agentId,
-    parentTraceId: args.parentTraceId,
-    rootTraceId: args.rootTraceId,
-    abortSignal: args.abortSignal,
-  });
+  try {
+    return await dispatchGeneration({
+      stream: args.stream,
+      ctx,
+      traceId,
+      agentId: args.agentId,
+      parentTraceId: args.parentTraceId,
+      rootTraceId: args.rootTraceId,
+      abortSignal: args.abortSignal,
+    });
+  } catch (error) {
+    throw await recordGenerationFailure({
+      generationId: ctx.generationId,
+      traceId,
+      error,
+    });
+  }
 };
 
 // ── Submit Tool Outputs ───────────────────────────────────────────────────
-
-const fireCompletionSideEffects = (args: {
-  generationId: string;
-  pending: NonNullable<ReturnType<typeof pendingGenerations.get>>;
-  result: { steps: unknown[]; finishReason: string };
-  completedResult: GenerationResult;
-}): void => {
-  const prevSteps = args.pending.steps ?? [];
-  const allSteps = [...prevSteps, ...serializeSteps(args.result.steps)];
-  saveTrace({
-    traceId: args.pending.traceId,
-    projectId: args.pending.projectId,
-    projectPublicId: args.pending.projectPublicId,
-    agentId: args.pending.agentId,
-    steps: allSteps,
-    parentTraceId: args.pending.parentTraceId ?? undefined,
-    rootTraceId: args.pending.rootTraceId ?? undefined,
-  }).catch(() => {});
-  updateGenerationRecord({
-    publicId: args.generationId,
-    status: 'completed',
-    completedAt: new Date(),
-    stopReason: args.result.finishReason,
-  }).catch(() => {});
-  resolveProjectPublicId({ projectId: args.pending.projectId }).then(
-    (projectPublicId) => {
-      emitEvent({
-        type: 'agents.generation.completed',
-        projectId: args.pending.projectId,
-        projectPublicId,
-        resourceType: 'generation',
-        resourceId: args.generationId,
-        data: args.completedResult as unknown as Record<string, unknown>,
-        timestamp: new Date().toISOString(),
-      });
-    }
-  );
-};
 
 export const submitToolOutputs = async (args: {
   projectIds?: number[];
@@ -403,20 +382,11 @@ export const submitToolOutputs = async (args: {
     return (m as { role?: string }).role !== 'system';
   });
 
-  const result = await generateText({
-    model: pending.resolvedModel,
+  const result = await runToolOutputsGeneration({
+    generationId: args.generationId,
+    pending,
     system,
-    messages: nonSystemMessages as ModelMessage[],
-    tools:
-      Object.keys(pending.resolvedTools).length > 0
-        ? pending.resolvedTools
-        : undefined,
-    prepareStep: buildPrepareStep({
-      stepRules: pending.agentConfig.stepRules,
-      logContext: 'non_stream',
-    }),
-    stopWhen: stepCountIs(pending.agentConfig.maxSteps),
-    temperature: pending.agentConfig.temperature ?? undefined,
+    nonSystemMessages,
   });
 
   const completedResult: GenerationResult = {

--- a/packages/server/src/lib/agentNonStreamGeneration.ts
+++ b/packages/server/src/lib/agentNonStreamGeneration.ts
@@ -10,6 +10,8 @@ import {
   savePendingGeneration,
   type TypedAgent,
 } from './agentGenerationHelpers';
+import { recordGenerationFailure } from './generationLifecycle';
+import { toProviderDomainError } from './providerError';
 
 const log = createDebug('soat:generation');
 
@@ -102,7 +104,7 @@ const callGenerateText = async (args: {
       error instanceof Error ? error.message : String(error),
       error instanceof Error ? error.stack : ''
     );
-    throw error;
+    throw toProviderDomainError(error) ?? error;
   }
 };
 
@@ -237,6 +239,37 @@ export const runNonStreamGeneration = async (args: {
     ...args,
     result: result as GenerateTextResult,
   });
+};
+
+export const runToolOutputsGeneration = async (args: {
+  generationId: string;
+  pending: PendingGeneration;
+  system: string | undefined;
+  nonSystemMessages: unknown[];
+}): Promise<GenerateTextResult> => {
+  try {
+    return await generateText({
+      model: args.pending.resolvedModel,
+      system: args.system,
+      messages: args.nonSystemMessages as ModelMessage[],
+      tools:
+        Object.keys(args.pending.resolvedTools).length > 0
+          ? args.pending.resolvedTools
+          : undefined,
+      prepareStep: buildPrepareStep({
+        stepRules: args.pending.agentConfig.stepRules,
+        logContext: 'non_stream',
+      }),
+      stopWhen: stepCountIs(args.pending.agentConfig.maxSteps),
+      temperature: args.pending.agentConfig.temperature ?? undefined,
+    });
+  } catch (error) {
+    throw await recordGenerationFailure({
+      generationId: args.generationId,
+      traceId: args.pending.traceId,
+      error: toProviderDomainError(error) ?? error,
+    });
+  }
 };
 
 export const buildToolResultMessages = (args: {

--- a/packages/server/src/lib/generationLifecycle.ts
+++ b/packages/server/src/lib/generationLifecycle.ts
@@ -1,0 +1,98 @@
+import createDebug from 'debug';
+
+import { DomainError } from '../errors';
+import type {
+  GenerationResult,
+  pendingGenerations,
+} from './agentGenerationHelpers';
+import { emitEvent, resolveProjectPublicId } from './eventBus';
+import { updateGenerationRecord } from './generations';
+import { buildGenerationErrorPayload } from './providerError';
+import { recordTraceError, saveTrace, serializeSteps } from './traces';
+
+const log = createDebug('soat:generation');
+
+/**
+ * Persists a generation failure (status 'failed' + structured error payload
+ * on both the generation record and the trace) and returns the error to
+ * rethrow. DomainErrors are enriched with the generation and trace IDs so
+ * callers can debug the failure post-mortem.
+ */
+export const recordGenerationFailure = async (args: {
+  generationId: string;
+  traceId: string;
+  error: unknown;
+}): Promise<unknown> => {
+  const errorPayload = buildGenerationErrorPayload(args.error);
+
+  log(
+    'recordGenerationFailure: generationId=%s traceId=%s error=%o',
+    args.generationId,
+    args.traceId,
+    errorPayload
+  );
+
+  await Promise.all([
+    updateGenerationRecord({
+      publicId: args.generationId,
+      status: 'failed',
+      completedAt: new Date(),
+      stopReason: 'error',
+      error: errorPayload,
+    }).catch(() => {}),
+    recordTraceError({
+      traceId: args.traceId,
+      error: errorPayload,
+    }).catch(() => {}),
+  ]);
+
+  if (args.error instanceof DomainError) {
+    // Error responses bypass the caseTransform middleware, so meta keys are
+    // written in snake_case to match the external REST contract.
+    return new DomainError(args.error.code, args.error.message, {
+      ...args.error.meta,
+      generation_id: args.generationId,
+      trace_id: args.traceId,
+    });
+  }
+
+  return args.error;
+};
+
+export const fireCompletionSideEffects = (args: {
+  generationId: string;
+  pending: NonNullable<ReturnType<typeof pendingGenerations.get>>;
+  result: { steps: unknown[]; finishReason: string };
+  completedResult: GenerationResult;
+}): void => {
+  const prevSteps = args.pending.steps ?? [];
+  const allSteps = [...prevSteps, ...serializeSteps(args.result.steps)];
+  saveTrace({
+    traceId: args.pending.traceId,
+    projectId: args.pending.projectId,
+    projectPublicId: args.pending.projectPublicId,
+    agentId: args.pending.agentId,
+    steps: allSteps,
+    parentTraceId: args.pending.parentTraceId ?? undefined,
+    rootTraceId: args.pending.rootTraceId ?? undefined,
+  }).catch(() => {});
+  updateGenerationRecord({
+    publicId: args.generationId,
+    status: 'completed',
+    completedAt: new Date(),
+    stopReason: args.result.finishReason,
+  }).catch(() => {});
+  resolveProjectPublicId({ projectId: args.pending.projectId }).then(
+    (projectPublicId) => {
+      emitEvent({
+        type: 'agents.generation.completed',
+        projectId: args.pending.projectId,
+        projectPublicId,
+        resourceType: 'generation',
+        resourceId: args.generationId,
+        data: args.completedResult as unknown as Record<string, unknown>,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  );
+};

--- a/packages/server/src/lib/generationLifecycle.ts
+++ b/packages/server/src/lib/generationLifecycle.ts
@@ -32,18 +32,19 @@ export const recordGenerationFailure = async (args: {
     errorPayload
   );
 
-  await Promise.all([
+  // Persistence failures must not mask the original generation error.
+  await Promise.allSettled([
     updateGenerationRecord({
       publicId: args.generationId,
       status: 'failed',
       completedAt: new Date(),
       stopReason: 'error',
       error: errorPayload,
-    }).catch(() => {}),
+    }),
     recordTraceError({
       traceId: args.traceId,
       error: errorPayload,
-    }).catch(() => {}),
+    }),
   ]);
 
   if (args.error instanceof DomainError) {
@@ -59,40 +60,65 @@ export const recordGenerationFailure = async (args: {
   return args.error;
 };
 
-export const fireCompletionSideEffects = (args: {
+type CompletionSideEffectsArgs = {
   generationId: string;
   pending: NonNullable<ReturnType<typeof pendingGenerations.get>>;
   result: { steps: unknown[]; finishReason: string };
   completedResult: GenerationResult;
-}): void => {
+};
+
+const runCompletionSideEffects = async (
+  args: CompletionSideEffectsArgs
+): Promise<void> => {
   const prevSteps = args.pending.steps ?? [];
   const allSteps = [...prevSteps, ...serializeSteps(args.result.steps)];
-  saveTrace({
-    traceId: args.pending.traceId,
-    projectId: args.pending.projectId,
-    projectPublicId: args.pending.projectPublicId,
-    agentId: args.pending.agentId,
-    steps: allSteps,
-    parentTraceId: args.pending.parentTraceId ?? undefined,
-    rootTraceId: args.pending.rootTraceId ?? undefined,
-  }).catch(() => {});
-  updateGenerationRecord({
-    publicId: args.generationId,
-    status: 'completed',
-    completedAt: new Date(),
-    stopReason: args.result.finishReason,
-  }).catch(() => {});
-  resolveProjectPublicId({ projectId: args.pending.projectId }).then(
-    (projectPublicId) => {
-      emitEvent({
-        type: 'agents.generation.completed',
-        projectId: args.pending.projectId,
-        projectPublicId,
-        resourceType: 'generation',
-        resourceId: args.generationId,
-        data: args.completedResult as unknown as Record<string, unknown>,
-        timestamp: new Date().toISOString(),
-      });
-    }
-  );
+
+  await Promise.allSettled([
+    saveTrace({
+      traceId: args.pending.traceId,
+      projectId: args.pending.projectId,
+      projectPublicId: args.pending.projectPublicId,
+      agentId: args.pending.agentId,
+      steps: allSteps,
+      parentTraceId: args.pending.parentTraceId ?? undefined,
+      rootTraceId: args.pending.rootTraceId ?? undefined,
+    }),
+    updateGenerationRecord({
+      publicId: args.generationId,
+      status: 'completed',
+      completedAt: new Date(),
+      stopReason: args.result.finishReason,
+    }),
+  ]);
+
+  try {
+    const projectPublicId = await resolveProjectPublicId({
+      projectId: args.pending.projectId,
+    });
+    emitEvent({
+      type: 'agents.generation.completed',
+      projectId: args.pending.projectId,
+      projectPublicId,
+      resourceType: 'generation',
+      resourceId: args.generationId,
+      data: args.completedResult as unknown as Record<string, unknown>,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    log(
+      'runCompletionSideEffects: failed to emit completion event generationId=%s error=%s',
+      args.generationId,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+};
+
+/**
+ * Fire-and-forget completion side effects: persists the trace, marks the
+ * generation completed, and emits the completion event. Never throws.
+ */
+export const fireCompletionSideEffects = (
+  args: CompletionSideEffectsArgs
+): void => {
+  void runCompletionSideEffects(args);
 };

--- a/packages/server/src/lib/generations.ts
+++ b/packages/server/src/lib/generations.ts
@@ -3,7 +3,7 @@ import { DomainError } from '../errors';
 
 export type PersistedGeneration = {
   id: string;
-  projectId: number;
+  projectId: string;
   agentId: string;
   traceId: string;
   initiatorGenerationId: string | null;
@@ -14,6 +14,7 @@ export type PersistedGeneration = {
   completedAt: Date | null;
   lastActivityAt: Date | null;
   stopReason: string | null;
+  error: Record<string, unknown> | null;
   metadata: Record<string, unknown> | null;
   createdAt: Date;
   updatedAt: Date;
@@ -21,18 +22,19 @@ export type PersistedGeneration = {
 
 const mapGeneration = (
   gen: InstanceType<(typeof db)['Generation']> & {
+    project?: InstanceType<(typeof db)['Project']>;
     agent?: InstanceType<(typeof db)['Agent']>;
     trace?: InstanceType<(typeof db)['Trace']>;
     initiatorGeneration?: InstanceType<(typeof db)['Generation']> | null;
   }
 ): PersistedGeneration => {
-  if (!gen.agent || !gen.trace) {
+  if (!gen.project || !gen.agent || !gen.trace) {
     throw new Error('Generation associations are required for serialization.');
   }
 
   return {
     id: gen.publicId,
-    projectId: gen.projectId,
+    projectId: gen.project.publicId,
     agentId: gen.agent.publicId,
     traceId: gen.trace.publicId,
     initiatorGenerationId: gen.initiatorGeneration?.publicId ?? null,
@@ -43,6 +45,7 @@ const mapGeneration = (
     completedAt: gen.completedAt,
     lastActivityAt: gen.lastActivityAt,
     stopReason: gen.stopReason,
+    error: gen.error,
     metadata: gen.metadata,
     createdAt: gen.createdAt,
     updatedAt: gen.updatedAt,
@@ -143,11 +146,13 @@ export const createGenerationRecord = async (args: {
     completedAt: null,
     lastActivityAt: null,
     stopReason: null,
+    error: null,
     metadata: null,
   });
 
   const fullGeneration = await db.Generation.findByPk(gen.id, {
     include: [
+      { model: db.Project, as: 'project' },
       { model: db.Agent, as: 'agent' },
       { model: db.Trace, as: 'trace' },
       { model: db.Generation, as: 'initiatorGeneration' },
@@ -170,6 +175,7 @@ export const updateGenerationRecord = async (args: {
   completedAt?: Date | null;
   lastActivityAt?: Date | null;
   stopReason?: string | null;
+  error?: Record<string, unknown> | null;
   metadata?: Record<string, unknown> | null;
 }) => {
   const gen = await db.Generation.findOne({
@@ -183,12 +189,14 @@ export const updateGenerationRecord = async (args: {
   if (args.lastActivityAt !== undefined)
     updates.lastActivityAt = args.lastActivityAt;
   if (args.stopReason !== undefined) updates.stopReason = args.stopReason;
+  if (args.error !== undefined) updates.error = args.error;
   if (args.metadata !== undefined) updates.metadata = args.metadata;
 
   await gen.update(updates);
 
   const fullGeneration = await db.Generation.findByPk(gen.id, {
     include: [
+      { model: db.Project, as: 'project' },
       { model: db.Agent, as: 'agent' },
       { model: db.Trace, as: 'trace' },
       { model: db.Generation, as: 'initiatorGeneration' },
@@ -233,6 +241,7 @@ export const listGenerations = async (args: {
   const { count, rows } = await db.Generation.findAndCountAll({
     where: Object.keys(where).length > 0 ? where : undefined,
     include: [
+      { model: db.Project, as: 'project' },
       { model: db.Agent, as: 'agent' },
       { model: db.Trace, as: 'trace' },
       { model: db.Generation, as: 'initiatorGeneration' },
@@ -255,6 +264,7 @@ export const getGeneration = async (args: {
   const gen = await db.Generation.findOne({
     where,
     include: [
+      { model: db.Project, as: 'project' },
       { model: db.Agent, as: 'agent' },
       { model: db.Trace, as: 'trace' },
       { model: db.Generation, as: 'initiatorGeneration' },

--- a/packages/server/src/lib/providerError.ts
+++ b/packages/server/src/lib/providerError.ts
@@ -1,0 +1,91 @@
+import { APICallError, RetryError } from 'ai';
+
+import { DomainError } from '../errors';
+
+const unwrapProviderError = (error: unknown): unknown => {
+  if (RetryError.isInstance(error)) {
+    return error.lastError ?? error;
+  }
+  return error;
+};
+
+/**
+ * Detects network-level fetch failures (e.g. ECONNREFUSED, DNS errors).
+ * Checked structurally rather than via `instanceof TypeError` because the
+ * error may originate from a different JS realm (undici internals).
+ */
+const isFetchFailure = (
+  error: unknown
+): error is { name: string; message: string } => {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const candidate = error as { name?: unknown; message?: unknown };
+  return (
+    candidate.name === 'TypeError' &&
+    typeof candidate.message === 'string' &&
+    /fetch failed|failed to fetch/i.test(candidate.message)
+  );
+};
+
+/**
+ * Maps an upstream AI provider failure (an `APICallError` thrown by the AI
+ * SDK, possibly wrapped in a `RetryError`) to a `AI_PROVIDER_ERROR`
+ * `DomainError` (HTTP 502). Returns `null` for errors that did not originate
+ * from the provider call, so callers can rethrow them unchanged.
+ */
+export const toProviderDomainError = (error: unknown): DomainError | null => {
+  const unwrapped = unwrapProviderError(error);
+
+  if (APICallError.isInstance(unwrapped)) {
+    const statusCode = unwrapped.statusCode;
+    const message = statusCode
+      ? `Provider returned ${statusCode}: ${unwrapped.message}`
+      : `Provider request failed: ${unwrapped.message}`;
+
+    return new DomainError('AI_PROVIDER_ERROR', message, {
+      ...(statusCode !== undefined && { providerStatusCode: statusCode }),
+      ...(unwrapped.responseBody !== undefined && {
+        providerResponseBody: unwrapped.responseBody,
+      }),
+    });
+  }
+
+  if (RetryError.isInstance(error)) {
+    return new DomainError(
+      'AI_PROVIDER_ERROR',
+      `Provider request failed: ${error.message}`
+    );
+  }
+
+  if (isFetchFailure(unwrapped)) {
+    return new DomainError(
+      'AI_PROVIDER_ERROR',
+      `Provider request failed: ${unwrapped.message}`
+    );
+  }
+
+  return null;
+};
+
+/**
+ * Builds the structured error payload persisted on failed generations and
+ * traces.
+ */
+export const buildGenerationErrorPayload = (
+  error: unknown
+): Record<string, unknown> => {
+  if (error instanceof DomainError) {
+    return {
+      code: error.code,
+      message: error.message,
+      ...(error.meta !== undefined && { meta: error.meta }),
+    };
+  }
+
+  if (error instanceof Error) {
+    return { message: error.message, name: error.name };
+  }
+
+  return { message: String(error) };
+};

--- a/packages/server/src/lib/traces.ts
+++ b/packages/server/src/lib/traces.ts
@@ -15,6 +15,7 @@ export type Trace = {
   stepCount: number;
   parentTraceId: string | null;
   rootTraceId: string | null;
+  error: Record<string, unknown> | null;
   createdAt: Date;
 };
 
@@ -68,8 +69,23 @@ const mapTrace = (
     stepCount: row.stepCount,
     parentTraceId: row.parentTrace?.publicId ?? null,
     rootTraceId: row.rootTrace?.publicId ?? null,
+    error: row.error,
     createdAt: row.createdAt,
   };
+};
+
+/**
+ * Records a structured error payload on a trace so failed generations are
+ * distinguishable from pending ones. Fire-and-forget safe.
+ */
+export const recordTraceError = async (args: {
+  traceId: string;
+  error: Record<string, unknown>;
+}): Promise<void> => {
+  log('recordTraceError: traceId=%s', args.traceId);
+  const trace = await db.Trace.findOne({ where: { publicId: args.traceId } });
+  if (!trace) return;
+  await trace.update({ error: args.error });
 };
 
 const findTraceId = async (

--- a/packages/server/src/permissions/generations.json
+++ b/packages/server/src/permissions/generations.json
@@ -1,0 +1,10 @@
+{
+  "module": "generations",
+  "operations": [
+    {
+      "operationId": "getGeneration",
+      "action": "generations:GetGeneration",
+      "description": "Get a generation record by ID"
+    }
+  ]
+}

--- a/packages/server/src/rest/openapi/v1/agents.yaml
+++ b/packages/server/src/rest/openapi/v1/agents.yaml
@@ -317,6 +317,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: >
+            Upstream AI provider error (AI_PROVIDER_ERROR). The error `meta`
+            includes the `generation_id` and `trace_id` of the failed
+            generation for post-mortem debugging via GET /api/v1/generations/{generation_id}.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/v1/agents/{agent_id}/generate/{generation_id}/tool-outputs:
     post:
@@ -877,5 +886,18 @@ components:
         - error
       properties:
         error:
-          type: string
-          example: Unauthorized
+          oneOf:
+            - type: string
+              description: Generic error message (e.g. "Unauthorized" or "Internal Server Error")
+              example: Unauthorized
+            - type: object
+              description: Structured domain error
+              properties:
+                code:
+                  type: string
+                  example: AI_PROVIDER_ERROR
+                message:
+                  type: string
+                  example: 'Provider returned 402: insufficient credits'
+                meta:
+                  type: object

--- a/packages/server/src/rest/openapi/v1/generations.yaml
+++ b/packages/server/src/rest/openapi/v1/generations.yaml
@@ -1,0 +1,172 @@
+openapi: 3.0.3
+info:
+  title: Generations API
+  version: 1.0.0
+  description: >
+    Generation records track individual LLM generation runs started by agents.
+    Each record carries the lifecycle status ('in_progress', 'requires_action',
+    'completed', or 'failed'), the stop reason, and — when the generation
+    failed — a structured error payload for post-mortem debugging. Generation
+    IDs for a trace can be listed via GET /api/v1/traces/{trace_id}/generations.
+  contact:
+    name: SOAT API Support
+
+servers:
+  - url: '{baseUrl}'
+    description: Base URL of your SOAT deployment (e.g. https://your-soat.com or http://localhost:5047)
+    variables:
+      baseUrl:
+        description: The base URL of your SOAT deployment
+        default: http://localhost:5047
+
+tags:
+  - name: Generations
+    description: Inspect generation records
+
+security:
+  - bearerAuth: []
+
+paths:
+  /api/v1/generations/{generation_id}:
+    get:
+      tags:
+        - Generations
+      summary: Get a generation
+      description: >
+        Returns a single generation record by ID, including its status and the
+        structured `error` payload when the generation failed (e.g. because the
+        upstream AI provider returned an error).
+      operationId: getGeneration
+      parameters:
+        - name: generation_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Public ID of the generation
+      responses:
+        '200':
+          description: Generation details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Generation'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Generation not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    Generation:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Public ID of the generation
+          example: gen_V1StGXR8Z5jdHi6B
+        project_id:
+          type: string
+          description: Public ID of the project
+        agent_id:
+          type: string
+          description: Public ID of the agent that ran this generation
+        trace_id:
+          type: string
+          description: Public ID of the trace this generation belongs to
+        initiator_generation_id:
+          type: string
+          nullable: true
+          description: >
+            Public ID of the generation that triggered this one via a
+            sub-agent call. Null for top-level generations.
+        started_by_principal_type:
+          type: string
+          nullable: true
+          description: Type of the principal that started the generation
+        started_by_principal_id:
+          type: string
+          nullable: true
+          description: ID of the principal that started the generation
+        status:
+          type: string
+          description: Lifecycle status of the generation
+          enum: [in_progress, requires_action, completed, failed]
+          example: failed
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the generation reached a terminal state
+        last_activity_at:
+          type: string
+          format: date-time
+          nullable: true
+        stop_reason:
+          type: string
+          nullable: true
+          description: Why the generation stopped (e.g. 'stop', 'error')
+          example: error
+        error:
+          type: object
+          nullable: true
+          description: >
+            Structured error payload recorded when the generation failed.
+            Contains at least `message`; `code` is set for mapped errors
+            (e.g. AI_PROVIDER_ERROR for upstream provider failures).
+          properties:
+            code:
+              type: string
+              example: AI_PROVIDER_ERROR
+            message:
+              type: string
+              example: 'Provider returned 402: insufficient credits'
+            meta:
+              type: object
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          oneOf:
+            - type: string
+              description: Generic error message (e.g. "Internal Server Error")
+            - type: object
+              description: Structured domain error
+              properties:
+                code:
+                  type: string
+                  example: RESOURCE_NOT_FOUND
+                message:
+                  type: string
+                meta:
+                  type: object

--- a/packages/server/src/rest/openapi/v1/sessions.yaml
+++ b/packages/server/src/rest/openapi/v1/sessions.yaml
@@ -341,6 +341,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: >
+            Upstream AI provider error (AI_PROVIDER_ERROR). The error `meta`
+            includes the `generation_id` and `trace_id` of the failed
+            generation for post-mortem debugging via GET /api/v1/generations/{generation_id}.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/v1/agents/{agent_id}/sessions/{session_id}/tool-outputs:
     post:

--- a/packages/server/src/rest/openapi/v1/traces.yaml
+++ b/packages/server/src/rest/openapi/v1/traces.yaml
@@ -254,6 +254,22 @@ components:
           description: >
             Public ID of the root trace for the entire execution tree.
             Null if this trace is itself the root.
+        error:
+          type: object
+          nullable: true
+          description: >
+            Structured error payload recorded when a generation in this trace
+            failed (e.g. an upstream AI provider error). Null if no failure
+            has been recorded.
+          properties:
+            code:
+              type: string
+              example: AI_PROVIDER_ERROR
+            message:
+              type: string
+              example: 'Provider returned 402: insufficient credits'
+            meta:
+              type: object
         created_at:
           type: string
           format: date-time
@@ -280,6 +296,10 @@ components:
         root_trace_id:
           type: string
           nullable: true
+        error:
+          type: object
+          nullable: true
+          description: Structured error payload recorded when a generation in this trace failed
         created_at:
           type: string
           format: date-time
@@ -307,4 +327,16 @@ components:
       type: object
       properties:
         error:
-          type: string
+          oneOf:
+            - type: string
+              description: Generic error message (e.g. "Internal Server Error")
+            - type: object
+              description: Structured domain error
+              properties:
+                code:
+                  type: string
+                  example: RESOURCE_NOT_FOUND
+                message:
+                  type: string
+                meta:
+                  type: object

--- a/packages/server/src/rest/v1/generations.ts
+++ b/packages/server/src/rest/v1/generations.ts
@@ -1,0 +1,54 @@
+import { Router } from '@ttoss/http-server';
+import type { Context } from 'src/Context';
+import { DomainError } from 'src/errors';
+import { getGeneration } from 'src/lib/generations';
+
+export const generationsRouter = new Router<Context>();
+
+/**
+ * @openapi
+ * GET /api/v1/generations/{generation_id}
+ * operationId: getGeneration
+ * Returns a single generation record by public ID, including its status
+ * ('in_progress', 'requires_action', 'completed', or 'failed') and the
+ * structured error payload when the generation failed.
+ */
+generationsRouter.get('/generations/:generation_id', async (ctx: Context) => {
+  if (!ctx.authUser) {
+    ctx.status = 401;
+    ctx.body = { error: 'Unauthorized' };
+    return;
+  }
+
+  const projectIds = await ctx.authUser.resolveProjectIds({
+    action: 'generations:GetGeneration',
+  });
+
+  if (
+    projectIds === null ||
+    (Array.isArray(projectIds) && projectIds.length === 0)
+  ) {
+    ctx.status = 403;
+    ctx.body = { error: 'Forbidden' };
+    return;
+  }
+
+  const generation = await getGeneration({
+    publicId: ctx.params.generation_id,
+    projectIds,
+  });
+
+  if (!generation) {
+    throw new DomainError(
+      'RESOURCE_NOT_FOUND',
+      `Generation '${ctx.params.generation_id}' not found.`
+    );
+  }
+
+  // `metadata` holds internal pending-generation state (messages, tool
+  // context) and is intentionally not exposed.
+  const { metadata, ...publicGeneration } = generation;
+  void metadata;
+
+  ctx.body = publicGeneration;
+});

--- a/packages/server/src/rest/v1/index.ts
+++ b/packages/server/src/rest/v1/index.ts
@@ -10,6 +10,7 @@ import { conversationsRouter } from './conversations';
 import { documentsRouter } from './documents';
 import { filesRouter } from './files';
 import { formationsRouter } from './formations';
+import { generationsRouter } from './generations';
 import { knowledgeRouter } from './knowledge';
 import { memoriesRouter } from './memories';
 import { orchestrationsRouter } from './orchestrations';
@@ -24,6 +25,7 @@ import { webhooksRouter } from './webhooks';
 const v1Router = new Router();
 
 v1Router.use(formationsRouter.routes());
+v1Router.use(generationsRouter.routes());
 v1Router.use(agentsRouter.routes());
 v1Router.use(chatsRouter.routes());
 v1Router.use(actorsRouter.routes());

--- a/packages/server/tests/unit/tests/lib/agentGeneration.test.ts
+++ b/packages/server/tests/unit/tests/lib/agentGeneration.test.ts
@@ -174,7 +174,13 @@ describe('submitToolOutputs', () => {
     });
     expect(pendingGenerations.has('gen_pending_1')).toBe(false);
 
-    await Promise.resolve();
+    // Completion side effects run fire-and-forget after trace/generation
+    // persistence settles — wait until the event pipeline has been invoked.
+    for (let i = 0; i < 50 && resolveProjectSpy.mock.calls.length === 0; i++) {
+      await new Promise((resolve) => {
+        return setImmediate(resolve);
+      });
+    }
     expect(resolveProjectSpy).toHaveBeenCalledWith({ projectId: 1 });
     expect(emitEventSpy).toHaveBeenCalled();
   });
@@ -259,10 +265,20 @@ describe('resolveGenerationInputMessages', () => {
       await loadGenerationInputMessagesModule();
 
     const toolCallContent = [
-      { type: 'tool-call', toolCallId: 'tc_1', toolName: 'create-account', args: {} },
+      {
+        type: 'tool-call',
+        toolCallId: 'tc_1',
+        toolName: 'create-account',
+        args: {},
+      },
     ];
     const toolResultContent = [
-      { type: 'tool-result', toolCallId: 'tc_1', toolName: 'create-account', result: 'ok' },
+      {
+        type: 'tool-result',
+        toolCallId: 'tc_1',
+        toolName: 'create-account',
+        result: 'ok',
+      },
     ];
 
     const result = await resolveGenerationInputMessages({

--- a/packages/server/tests/unit/tests/lib/generationLifecycle.test.ts
+++ b/packages/server/tests/unit/tests/lib/generationLifecycle.test.ts
@@ -1,0 +1,153 @@
+import { db } from 'src/db';
+import { buildModel } from 'src/lib/agentModel';
+import {
+  fireCompletionSideEffects,
+  recordGenerationFailure,
+} from 'src/lib/generationLifecycle';
+import { createGenerationRecord, getGeneration } from 'src/lib/generations';
+
+const waitFor = async (predicate: () => Promise<boolean>): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (await predicate()) return;
+    await new Promise((resolve) => {
+      return setTimeout(resolve, 50);
+    });
+  }
+  throw new Error('waitFor: condition not met in time');
+};
+
+describe('generationLifecycle', () => {
+  let projectId: number;
+  let projectPublicId: string;
+  let agentPublicId: string;
+
+  const buildPending = (traceId: string) => {
+    return {
+      agentId: agentPublicId,
+      projectId,
+      traceId,
+      parentTraceId: null,
+      rootTraceId: null,
+      generationId: 'gen_lifecycle_001',
+      pendingToolCalls: [],
+      messages: [],
+      steps: [],
+      resolvedModel: buildModel({
+        provider: 'ollama',
+        secretValue: null,
+        model: 'test-model',
+      }),
+      agentConfig: {
+        instructions: null,
+        maxSteps: 5,
+        toolChoice: null,
+        stopConditions: null,
+        activeToolIds: null,
+        stepRules: null,
+        temperature: null,
+      },
+      resolvedTools: {},
+      initiatorGenerationId: null,
+      projectPublicId,
+    };
+  };
+
+  beforeAll(async () => {
+    const project = await db.Project.create({
+      name: 'GenerationLifecycle Lib Test',
+    });
+    projectId = project.id;
+    projectPublicId = project.publicId;
+
+    const aiProvider = await db.AiProvider.create({
+      projectId,
+      name: 'Lifecycle Provider',
+      provider: 'ollama',
+      defaultModel: 'test-model',
+    });
+
+    const agent = await db.Agent.create({
+      projectId,
+      aiProviderId: aiProvider.id,
+      name: 'Lifecycle Agent',
+    });
+    agentPublicId = agent.publicId;
+  });
+
+  test('fireCompletionSideEffects marks the generation completed and saves the trace', async () => {
+    const gen = await createGenerationRecord({
+      publicId: 'gen_lifecycle_001',
+      projectId,
+      agentId: agentPublicId,
+      traceId: 'trc_lifecycle_001',
+    });
+    expect(gen.status).toBe('in_progress');
+
+    fireCompletionSideEffects({
+      generationId: 'gen_lifecycle_001',
+      pending: buildPending('trc_lifecycle_001'),
+      result: { steps: [{ type: 'text', text: 'done' }], finishReason: 'stop' },
+      completedResult: {
+        id: 'gen_lifecycle_001',
+        traceId: 'trc_lifecycle_001',
+        status: 'completed',
+        output: { model: 'test-model', content: 'done', finishReason: 'stop' },
+      },
+    });
+
+    await waitFor(async () => {
+      const updated = await getGeneration({ publicId: 'gen_lifecycle_001' });
+      return updated?.status === 'completed';
+    });
+
+    const updated = await getGeneration({ publicId: 'gen_lifecycle_001' });
+    expect(updated?.status).toBe('completed');
+    expect(updated?.stopReason).toBe('stop');
+    expect(updated?.completedAt).not.toBeNull();
+  });
+
+  test('fireCompletionSideEffects tolerates trace save failures (fire-and-forget)', async () => {
+    const pending = {
+      ...buildPending('trc_lifecycle_missing'),
+      agentId: 'agent_does_not_exist',
+      generationId: 'gen_lifecycle_missing',
+    };
+
+    expect(() => {
+      fireCompletionSideEffects({
+        generationId: 'gen_lifecycle_missing',
+        pending,
+        result: { steps: [], finishReason: 'stop' },
+        completedResult: {
+          id: 'gen_lifecycle_missing',
+          traceId: 'trc_lifecycle_missing',
+          status: 'completed',
+          output: { model: 'test-model', content: '', finishReason: 'stop' },
+        },
+      });
+    }).not.toThrow();
+  });
+
+  test('recordGenerationFailure persists the error and enriches DomainErrors', async () => {
+    await createGenerationRecord({
+      publicId: 'gen_lifecycle_fail01',
+      projectId,
+      agentId: agentPublicId,
+      traceId: 'trc_lifecycle_fail01',
+    });
+
+    const error = await recordGenerationFailure({
+      generationId: 'gen_lifecycle_fail01',
+      traceId: 'trc_lifecycle_fail01',
+      error: new Error('provider exploded'),
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('provider exploded');
+
+    const failed = await getGeneration({ publicId: 'gen_lifecycle_fail01' });
+    expect(failed?.status).toBe('failed');
+    expect(failed?.stopReason).toBe('error');
+    expect(failed?.error?.message).toBe('provider exploded');
+  });
+});

--- a/packages/server/tests/unit/tests/lib/generations.test.ts
+++ b/packages/server/tests/unit/tests/lib/generations.test.ts
@@ -8,6 +8,7 @@ import {
 
 describe('generations', () => {
   let projectId: number;
+  let projectPublicId: string;
   let aiProviderId: number;
   const agentId = 'agt_gen_lib_test_001';
 
@@ -26,6 +27,7 @@ describe('generations', () => {
   beforeAll(async () => {
     const project = await db.Project.create({ name: 'Generations Lib Test' });
     projectId = project.id;
+    projectPublicId = project.publicId;
 
     const aiProvider = await db.AiProvider.create({
       projectId,
@@ -54,7 +56,7 @@ describe('generations', () => {
 
       expect(gen.id).toBe('gen_create_test001');
       expect(gen.status).toBe('in_progress');
-      expect(gen.projectId).toBe(projectId);
+      expect(gen.projectId).toBe(projectPublicId);
       expect(gen.agentId).toBe(agentId);
       expect(gen.traceId).toBe('trc_gen_create_001');
       expect(gen.completedAt).toBeNull();
@@ -249,7 +251,7 @@ describe('generations', () => {
 
       const gen = result.data[0];
       expect(gen.id).toBeDefined();
-      expect(gen.projectId).toBe(projectId);
+      expect(gen.projectId).toBe(projectPublicId);
       expect(gen.agentId).toBe('agt_list_001');
       expect(gen.traceId).toBeDefined();
       expect(gen.status).toBe('in_progress');
@@ -282,7 +284,7 @@ describe('generations', () => {
 
       expect(result).not.toBeNull();
       expect(result?.id).toBe('gen_get_test001');
-      expect(result?.projectId).toBe(projectId);
+      expect(result?.projectId).toBe(projectPublicId);
     });
 
     test('returns null when projectIds does not include the project', async () => {

--- a/packages/server/tests/unit/tests/lib/providerError.test.ts
+++ b/packages/server/tests/unit/tests/lib/providerError.test.ts
@@ -1,0 +1,65 @@
+import { APICallError, RetryError } from 'ai';
+import { DomainError } from 'src/errors';
+import { toProviderDomainError } from 'src/lib/providerError';
+
+describe('toProviderDomainError', () => {
+  const buildApiCallError = () => {
+    return new APICallError({
+      message: 'insufficient credits',
+      url: 'https://api.x.ai/v1/chat/completions',
+      requestBodyValues: {},
+      statusCode: 402,
+      responseBody: '{"error":"insufficient_quota"}',
+    });
+  };
+
+  test('maps APICallError to a 502 AI_PROVIDER_ERROR DomainError', () => {
+    const error = toProviderDomainError(buildApiCallError());
+
+    expect(error).toBeInstanceOf(DomainError);
+    expect(error?.code).toBe('AI_PROVIDER_ERROR');
+    expect(error?.httpStatus).toBe(502);
+    expect(error?.message).toContain('402');
+    expect(error?.message).toContain('insufficient credits');
+    expect(error?.meta?.providerStatusCode).toBe(402);
+  });
+
+  test('unwraps RetryError to the last APICallError', () => {
+    const apiCallError = buildApiCallError();
+    const retryError = new RetryError({
+      message: 'Failed after 3 attempts',
+      reason: 'maxRetriesExceeded',
+      errors: [apiCallError, apiCallError],
+    });
+
+    const error = toProviderDomainError(retryError);
+
+    expect(error?.code).toBe('AI_PROVIDER_ERROR');
+    expect(error?.message).toContain('402');
+  });
+
+  test('maps APICallError without a status code (network failure)', () => {
+    const networkError = new APICallError({
+      message: 'Cannot connect to API',
+      url: 'http://127.0.0.1:9/v1/chat/completions',
+      requestBodyValues: {},
+    });
+
+    const error = toProviderDomainError(networkError);
+
+    expect(error?.code).toBe('AI_PROVIDER_ERROR');
+    expect(error?.message).toContain('Cannot connect to API');
+  });
+
+  test('maps network-level fetch failures', () => {
+    const error = toProviderDomainError(new TypeError('fetch failed'));
+
+    expect(error?.code).toBe('AI_PROVIDER_ERROR');
+    expect(error?.message).toContain('fetch failed');
+  });
+
+  test('returns null for non-provider errors', () => {
+    expect(toProviderDomainError(new Error('boom'))).toBeNull();
+    expect(toProviderDomainError('boom')).toBeNull();
+  });
+});

--- a/packages/server/tests/unit/tests/rest/generations.test.ts
+++ b/packages/server/tests/unit/tests/rest/generations.test.ts
@@ -1,0 +1,164 @@
+import { authenticatedTestClient, loginAs, testClient } from '../../testClient';
+
+/**
+ * Covers issue #179 — error surfacing on generation failure:
+ * - upstream provider errors are mapped to 502 AI_PROVIDER_ERROR
+ * - failed generations are persisted with status 'failed' and an error payload
+ * - traces record the error of failed generations
+ * - GET /api/v1/generations/:generation_id exposes generation records
+ */
+describe('Generations', () => {
+  let adminToken: string;
+  let userToken: string;
+  let noPermToken: string;
+  let agentId: string;
+  let failedGenerationId: string;
+  let failedTraceId: string;
+
+  beforeAll(async () => {
+    const bootstrapRes = await testClient
+      .post('/api/v1/users/bootstrap')
+      .send({ username: 'generationsadmin', password: 'supersecret' });
+
+    if (bootstrapRes.status === 201) {
+      adminToken = await loginAs('generationsadmin', 'supersecret');
+    } else {
+      adminToken = await loginAs('admin', 'supersecret');
+    }
+
+    const userRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/users')
+      .send({ username: 'generationsuser', password: 'generationspass' });
+    userToken = await loginAs('generationsuser', 'generationspass');
+
+    await authenticatedTestClient(adminToken)
+      .post('/api/v1/users')
+      .send({ username: 'generationsnoperm', password: 'generationsnopass' });
+    noPermToken = await loginAs('generationsnoperm', 'generationsnopass');
+
+    const projectRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/projects')
+      .send({ name: 'Generations Test Project' });
+    const projectId = projectRes.body.id;
+
+    const policyRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/policies')
+      .send({
+        document: {
+          statement: [
+            {
+              effect: 'Allow',
+              action: [
+                'agents:CreateAgent',
+                'agents:CreateAgentGeneration',
+                'generations:GetGeneration',
+                'traces:GetTrace',
+              ],
+            },
+          ],
+        },
+      });
+    await authenticatedTestClient(adminToken)
+      .put(`/api/v1/users/${userRes.body.id}/policies`)
+      .send({ policy_ids: [policyRes.body.id] });
+
+    // Provider pointing at an unreachable endpoint so a real generation
+    // attempt fails with an upstream provider (API call) error.
+    const aiProvRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/ai-providers')
+      .send({
+        project_id: projectId,
+        name: 'Unreachable Provider',
+        provider: 'ollama',
+        default_model: 'llama3.2',
+        base_url: 'http://127.0.0.1:9/v1',
+      });
+
+    const agentRes = await authenticatedTestClient(userToken)
+      .post('/api/v1/agents')
+      .send({
+        ai_provider_id: aiProvRes.body.id,
+        project_id: projectId,
+        name: 'Generations Failing Agent',
+      });
+    agentId = agentRes.body.id;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('provider failure surfacing on POST /api/v1/agents/:agent_id/generate', () => {
+    test('returns 502 AI_PROVIDER_ERROR with generation and trace IDs in meta', async () => {
+      const response = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/generate`)
+        .send({ messages: [{ role: 'user', content: 'hello' }] });
+
+      expect(response.status).toBe(502);
+      expect(response.body.error.code).toBe('AI_PROVIDER_ERROR');
+      expect(response.body.error.message).toBeDefined();
+      expect(response.body.error.meta.generation_id).toBeDefined();
+      expect(response.body.error.meta.trace_id).toBeDefined();
+
+      failedGenerationId = response.body.error.meta.generation_id;
+      failedTraceId = response.body.error.meta.trace_id;
+    }, 60000);
+
+    test('persists the failed generation with status failed and an error payload', async () => {
+      const response = await authenticatedTestClient(userToken).get(
+        `/api/v1/generations/${failedGenerationId}`
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.id).toBe(failedGenerationId);
+      expect(response.body.status).toBe('failed');
+      expect(response.body.error).toBeDefined();
+      expect(response.body.error.message).toBeDefined();
+      expect(response.body.trace_id).toBe(failedTraceId);
+      expect(response.body.agent_id).toBe(agentId);
+      expect(response.body.completed_at).toBeDefined();
+    });
+
+    test('records the error on the trace', async () => {
+      const response = await authenticatedTestClient(userToken).get(
+        `/api/v1/traces/${failedTraceId}`
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.error).toBeDefined();
+      expect(response.body.error.message).toBeDefined();
+    });
+  });
+
+  describe('GET /api/v1/generations/:generation_id', () => {
+    test('returns 401 when unauthenticated', async () => {
+      const response = await testClient.get('/api/v1/generations/gen_x');
+      expect(response.status).toBe(401);
+    });
+
+    test('returns 403 when user lacks permission', async () => {
+      const response = await authenticatedTestClient(noPermToken).get(
+        `/api/v1/generations/${failedGenerationId}`
+      );
+      expect(response.status).toBe(403);
+    });
+
+    test('returns 404 when generation does not exist', async () => {
+      const response = await authenticatedTestClient(userToken).get(
+        '/api/v1/generations/gen_does_not_exist'
+      );
+      expect(response.status).toBe(404);
+      expect(response.body.error.code).toBe('RESOURCE_NOT_FOUND');
+    });
+
+    test('does not expose internal metadata or numeric IDs', async () => {
+      const response = await authenticatedTestClient(userToken).get(
+        `/api/v1/generations/${failedGenerationId}`
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.metadata).toBeUndefined();
+      expect(typeof response.body.project_id).toBe('string');
+    });
+  });
+});

--- a/packages/website/docs/modules/generations.md
+++ b/packages/website/docs/modules/generations.md
@@ -1,0 +1,83 @@
+# Generations
+
+Generation records track individual LLM generation runs started by agents, including their lifecycle status and any failure details.
+
+## Overview
+
+Every agent generation (`POST /agents/:id/generate`, session generation, sub-agent calls) creates a generation record before the model is called. The record tracks the run through its lifecycle and — when the run fails — stores a structured error payload so failed generations are distinguishable from pending ones and can be debugged post-mortem.
+
+Generation IDs for a trace can be listed via `GET /traces/:trace_id/generations`, and each record can be retrieved via `GET /generations/:generation_id`.
+
+> See the [Permissions Reference](../permissions.md) for the IAM action strings for this module.
+
+## Data Model
+
+| Field                       | Type           | Description                                                                                          |
+| --------------------------- | -------------- | ---------------------------------------------------------------------------------------------------- |
+| `id`                        | string         | Public identifier for the generation                                                                 |
+| `project_id`                | string         | Project the generation belongs to                                                                    |
+| `agent_id`                  | string         | Agent that ran the generation                                                                        |
+| `trace_id`                  | string         | Trace this generation belongs to                                                                     |
+| `initiator_generation_id`   | string \| null | Generation that triggered this one via a sub-agent call; `null` for top-level generations            |
+| `started_by_principal_type` | string \| null | Type of the principal that started the generation                                                    |
+| `started_by_principal_id`   | string \| null | ID of the principal that started the generation                                                      |
+| `status`                    | string         | Lifecycle status: `in_progress`, `requires_action`, `completed`, or `failed`                         |
+| `started_at`                | string         | When the generation started                                                                          |
+| `completed_at`              | string \| null | When the generation reached a terminal state                                                         |
+| `last_activity_at`          | string \| null | Last activity timestamp                                                                              |
+| `stop_reason`               | string \| null | Why the generation stopped (e.g. `stop`, `error`, `depth_guard`)                                     |
+| `error`                     | object \| null | Structured error payload recorded when the generation failed (see [Error Recording](#error-recording)) |
+| `created_at`                | string         | ISO 8601 creation timestamp                                                                          |
+| `updated_at`                | string         | ISO 8601 last-update timestamp                                                                       |
+
+## Key Concepts
+
+### Lifecycle
+
+A generation starts as `in_progress`. It transitions to:
+
+- `requires_action` when a client tool call pauses the run and the caller must submit tool outputs.
+- `completed` when the model finishes (the `stop_reason` carries the finish reason).
+- `failed` when the run errors — for example when the upstream AI provider returns an error or is unreachable. `stop_reason` is set to `error` and the `error` field carries the failure details.
+
+### Error Recording
+
+When a generation fails, the failure is persisted on both the generation record and its trace:
+
+```json
+{
+  "id": "gen_abc123",
+  "status": "failed",
+  "stop_reason": "error",
+  "error": {
+    "code": "AI_PROVIDER_ERROR",
+    "message": "Provider returned 402: insufficient credits"
+  }
+}
+```
+
+The `error` object always contains `message`. `code` is set for mapped errors — most notably `AI_PROVIDER_ERROR`, which is used when the upstream AI provider returns an error (e.g. exhausted credits, rate limit) or is unreachable.
+
+### Provider Error Surfacing (`AI_PROVIDER_ERROR`)
+
+Generation endpoints return HTTP `502` with the `AI_PROVIDER_ERROR` code when the upstream AI provider fails:
+
+```json
+{
+  "error": {
+    "code": "AI_PROVIDER_ERROR",
+    "message": "Provider returned 402: insufficient credits",
+    "meta": {
+      "provider_status_code": 402,
+      "generation_id": "gen_abc123",
+      "trace_id": "trace_xyz789"
+    }
+  }
+}
+```
+
+The `meta` field includes the `generation_id` and `trace_id` of the failed run so the failure can be inspected post-mortem via `GET /generations/:generation_id` and `GET /traces/:trace_id`.
+
+### Internal Metadata
+
+Generation records carry internal coordination state (e.g. pending tool-call context used to resume `requires_action` runs). This state is not exposed through the API.

--- a/packages/website/docs/modules/traces.md
+++ b/packages/website/docs/modules/traces.md
@@ -30,6 +30,7 @@ Traces support **parent-child relationships**: when an agent spawns a sub-agent 
 | `step_count`      | number         | Number of reasoning steps recorded                                                     |
 | `parent_trace_id` | string \| null | ID of the immediate parent trace; `null` when this trace is itself the root            |
 | `root_trace_id`   | string \| null | ID of the root trace in a multi-agent chain; `null` when this trace is itself the root |
+| `error`           | object \| null | Structured error payload recorded when a generation in this trace failed; `null` otherwise |
 | `created_at`      | string         | ISO 8601 creation timestamp                                                            |
 
 ## Key Concepts
@@ -37,6 +38,10 @@ Traces support **parent-child relationships**: when an agent spawns a sub-agent 
 ### Trace Tree
 
 When agents call other agents (via SOAT tools), each nested generation creates its own trace. All traces in one chain share the same `root_trace_id`. The `GET /traces/:id/tree` endpoint returns the entire tree — the root node with all its descendants nested under `children` — from any trace ID in the chain.
+
+### Generation Failures
+
+When a generation in a trace fails (e.g. the upstream AI provider returns an error), the structured error payload is recorded on the trace's `error` field and on the corresponding generation record (`GET /generations/:generation_id`). This makes failed runs distinguishable from runs that have not started yet (which also have `step_count: 0`).
 
 ### Step Serialization
 

--- a/tests/smoke-tests.sh
+++ b/tests/smoke-tests.sh
@@ -1142,6 +1142,25 @@ if [ -n "$CLIENT_TRACE_ID" ] && [ "$CLIENT_TRACE_ID" != "null" ]; then
     exit 1
   fi
   echo "Trace tree endpoint: OK"
+
+  TRACE_GENS_RESP=$($SOAT_CLI get-trace-generations --trace-id "$CLIENT_TRACE_ID")
+  FIRST_GENERATION_ID=$(printf '%s\n' "$TRACE_GENS_RESP" | jq -r '.generation_ids[0] // empty')
+  if [ -z "$FIRST_GENERATION_ID" ]; then
+    echo "ERROR: get-trace-generations returned no generation IDs for '$CLIENT_TRACE_ID'" >&2
+    echo "$TRACE_GENS_RESP" >&2
+    exit 1
+  fi
+  echo "Trace generations endpoint: OK"
+
+  GENERATION_GET_RESP=$($SOAT_CLI get-generation --generation-id "$FIRST_GENERATION_ID")
+  GENERATION_RETURNED_ID=$(printf '%s\n' "$GENERATION_GET_RESP" | jq -r '.id // empty')
+  GENERATION_RETURNED_STATUS=$(printf '%s\n' "$GENERATION_GET_RESP" | jq -r '.status // empty')
+  if [ "$GENERATION_RETURNED_ID" != "$FIRST_GENERATION_ID" ] || [ -z "$GENERATION_RETURNED_STATUS" ]; then
+    echo "ERROR: get-generation returned mismatched id or missing status for '$FIRST_GENERATION_ID'" >&2
+    echo "$GENERATION_GET_RESP" >&2
+    exit 1
+  fi
+  echo "Generation retrieval endpoint: OK (status: $GENERATION_RETURNED_STATUS)"
 else
   echo "ERROR: Generation response did not include trace_id" >&2
   exit 1


### PR DESCRIPTION
Fixes #179.

## Problem

When agent generation failed due to an upstream AI provider error (e.g. exhausted credits, 402), SOAT returned a bare `{"error": "Internal Server Error"}`, the trace showed nothing, and generation IDs from `get-trace-generations` could not be inspected anywhere.

## Changes

### 1. Provider errors are mapped to 502 `AI_PROVIDER_ERROR`
- New `AI_PROVIDER_ERROR` code (HTTP 502) in the error registry.
- New `src/lib/providerError.ts` maps `APICallError` (optionally wrapped in `RetryError`) and network-level fetch failures to a `DomainError` at the AI SDK call boundary (`callGenerateText`, tool-outputs continuation). Upstream status code and response body are carried in `meta`.
- The error response `meta` also includes `generation_id` and `trace_id` of the failed run:

```json
{
  "error": {
    "code": "AI_PROVIDER_ERROR",
    "message": "Provider returned 402: insufficient credits",
    "meta": { "provider_status_code": 402, "generation_id": "gen_...", "trace_id": "trace_..." }
  }
}
```

### 2. Failures are persisted
- `Generation` and `Trace` models gain a nullable `error` JSONB column.
- On failure, the generation is updated to `status: 'failed'`, `stop_reason: 'error'`, with the structured error payload; the trace records the same payload (`src/lib/generationLifecycle.ts`).
- The generation record is now created (awaited) before the model call, and creation failures are logged instead of silently swallowed.

### 3. `GET /api/v1/generations/:generation_id`
- New generations module: route, OpenAPI spec, `generations:GetGeneration` permission action, and module docs page. Internal `metadata` (pending tool-call state) is not exposed, and `project_id` now maps to the project public ID instead of the internal numeric ID.

### Also
- `agents.yaml` / `traces.yaml` `ErrorResponse` schemas now document the structured `{ code, message, meta }` error object (matching `sessions.yaml`); 502 responses added to the generate endpoints.
- Smoke-test steps added for `get-trace-generations` + `get-generation`.
- Permissions reference page regenerated; SDK/CLI regenerate cleanly from the new spec (generated files are gitignored).

## Testing

- New `tests/unit/tests/lib/providerError.test.ts` (error mapping) and `tests/unit/tests/rest/generations.test.ts` (mock-free end-to-end: real generation against an unreachable provider → 502 with IDs in meta → failed generation and trace error retrievable; 401/403/404 coverage). Written red-first per TDD.
- Full server unit suite: 1438 tests passing locally (against a local Postgres; this environment has no Docker, so testcontainers-based parallel runs and the docker-compose smoke tests could not be executed here — CI will run them).
- `pnpm typecheck` and `pnpm eslint` clean.

https://claude.ai/code/session_012GLAudfBiaSJ8i1gZeEJaT

---
_Generated by [Claude Code](https://claude.ai/code/session_012GLAudfBiaSJ8i1gZeEJaT)_