### PR TITLE
docs: replace SOAT_API_KEY with SOAT_TOKEN in traces example

### DIFF
--- a/packages/website/docs/modules/traces.md
+++ b/packages/website/docs/modules/traces.md
@@ -237,7 +237,7 @@ soat get-trace-tree --trace-id trc_abc123
 ```ts
 import { createSoatClient } from '@soat/sdk';
 
-const client = createSoatClient({ apiKey: process.env.SOAT_API_KEY });
+const client = createSoatClient({ apiKey: process.env.SOAT_TOKEN });
 
 // List traces
 const { data: traces } = await client.GET('/api/v1/traces', {


### PR DESCRIPTION
## Summary

- Replaces `process.env.SOAT_API_KEY` with `process.env.SOAT_TOKEN` in `packages/website/docs/modules/traces.md`
- The CLI and SDK both use `SOAT_TOKEN`; the old example caused silent `undefined` API keys for users copying the snippet

Fixes #182

https://claude.ai/code/session_0117teoWZ21R9XuLkiYuTqgi

---
_Generated by [Claude Code](https://claude.ai/code/session_0117teoWZ21R9XuLkiYuTqgi)_