### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.9.0 (2026-06-10)
+
+### Bug Fixes
+
+* accept string values for tool_choice in agents and formations ([#151](https://github.com/ttoss/soat/issues/151)) ([322bf45](https://github.com/ttoss/soat/commit/322bf4538d42aca7dfba1de3f60b1be4d0f22cd9))
+* add shell-safe @VAR_NAME and bare-key syntax to --parameter for --env-file integration ([#114](https://github.com/ttoss/soat/issues/114)) ([906dd0c](https://github.com/ttoss/soat/commit/906dd0cf79a1d5b6cd312e7489ac6a549c3e011b))
+* add single_session_per_actor and max_context_messages to formation agent validator ([#141](https://github.com/ttoss/soat/issues/141)) ([a644d95](https://github.com/ttoss/soat/commit/a644d95e31dda50ea0f4660bdebd0de8af05848e)), closes [#140](https://github.com/ttoss/soat/issues/140) [#135](https://github.com/ttoss/soat/issues/135) [#129](https://github.com/ttoss/soat/issues/129)
+* await saveTrace in sync generation so trace file_id is immediately available ([#130](https://github.com/ttoss/soat/issues/130)) ([862b981](https://github.com/ttoss/soat/commit/862b981bfb70ece71d2c59b597537580ec3a9850))
+* deploy website ([67eeaac](https://github.com/ttoss/soat/commit/67eeaacc09430188ddce1e07bed26720967bfef2))
+* expire stale sessions during singleSessionPerActor conflict check ([#185](https://github.com/ttoss/soat/issues/185)) ([1b4dece](https://github.com/ttoss/soat/commit/1b4dece66cf4eb26fe39b1aebe48b8f1e0924fe6))
+* HTTP tool DELETE requests now send body and preserve Content-Type header ([#131](https://github.com/ttoss/soat/issues/131)) ([a536f29](https://github.com/ttoss/soat/commit/a536f29e32a79443f9a87ed2f5f4dbc5fbab22a7)), closes [#128](https://github.com/ttoss/soat/issues/128)
+* increase Ollama context window to 16384 to prevent prompt truncation ([#174](https://github.com/ttoss/soat/issues/174)) ([6354f9e](https://github.com/ttoss/soat/commit/6354f9ee158d2068152e79a6bb481247999f1166))
+* persist responseMessages metadata after tool-output submission ([#177](https://github.com/ttoss/soat/issues/177)) ([a2f963a](https://github.com/ttoss/soat/commit/a2f963a0f58e4419508c0e4e40888c192fcfd71b))
+* preserve tool call/result messages in conversation history ([#175](https://github.com/ttoss/soat/issues/175)) ([459d419](https://github.com/ttoss/soat/commit/459d4194c12c6b4b941b1146182e16ef70b78e6a)), closes [#147](https://github.com/ttoss/soat/issues/147) [#147](https://github.com/ttoss/soat/issues/147)
+* use branch ref for workflow_dispatch trigger ([#165](https://github.com/ttoss/soat/issues/165)) ([a4b3877](https://github.com/ttoss/soat/commit/a4b3877967fe53ea906a46d1b032ceb530c0891f)), closes [#164](https://github.com/ttoss/soat/issues/164)
+
+### Features
+
+* **agents:** single_session_per_actor — enforce one open session per actor ([#137](https://github.com/ttoss/soat/issues/137)) ([a72549b](https://github.com/ttoss/soat/commit/a72549beb78eb7381156c8a355dd86f7bca94a31)), closes [#135](https://github.com/ttoss/soat/issues/135)
+* context window limiting and trace lifecycle fix (issue [#129](https://github.com/ttoss/soat/issues/129)) ([#134](https://github.com/ttoss/soat/issues/134)) ([2688612](https://github.com/ttoss/soat/commit/268861201365de568d62ee16c51c33bfc7b41206))
+* **sessions:** add expired status with lazy TTL update ([#138](https://github.com/ttoss/soat/issues/138)) ([2fc6a0c](https://github.com/ttoss/soat/commit/2fc6a0cdc6f5dea7b10c4737a2bf3d1eea723b22))
+* **sessions:** add idempotency_key to addSessionMessage ([#144](https://github.com/ttoss/soat/issues/144)) ([b242655](https://github.com/ttoss/soat/commit/b242655848ca9f3356ee6aa63bc13b9473bf787b))
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://github.com/ttoss/soat/issues/148)) ([1406654](https://github.com/ttoss/soat/commit/1406654ac85a2971220358591cfb73e9a96c1e51))
+* **sessions:** session auto-expiry via inactivity TTL ([#133](https://github.com/ttoss/soat/issues/133)) ([1c25329](https://github.com/ttoss/soat/commit/1c253291a94a5e9d27b537842ac57c9bde5a467e)), closes [#129](https://github.com/ttoss/soat/issues/129) [#132](https://github.com/ttoss/soat/issues/132)
+* surface upstream AI provider errors and expose generation records ([#180](https://github.com/ttoss/soat/issues/180)) ([dde9578](https://github.com/ttoss/soat/commit/dde9578eed754cd4858ac45d25117ca13f1bc143))
+
 # 0.8.0 (2026-06-10)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "npmClient": "pnpm",
   "stream": true,
   "command": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.9.0 (2026-06-10)
+
+### Bug Fixes
+
+* add shell-safe @VAR_NAME and bare-key syntax to --parameter for --env-file integration ([#114](https://github.com/ttoss/soat/issues/114)) ([906dd0c](https://github.com/ttoss/soat/commit/906dd0cf79a1d5b6cd312e7489ac6a549c3e011b))
+* HTTP tool DELETE requests now send body and preserve Content-Type header ([#131](https://github.com/ttoss/soat/issues/131)) ([a536f29](https://github.com/ttoss/soat/commit/a536f29e32a79443f9a87ed2f5f4dbc5fbab22a7)), closes [#128](https://github.com/ttoss/soat/issues/128)
+
+### Features
+
+* **sessions:** add idempotency_key to addSessionMessage ([#144](https://github.com/ttoss/soat/issues/144)) ([b242655](https://github.com/ttoss/soat/commit/b242655848ca9f3356ee6aa63bc13b9473bf787b))
+
 # 0.8.0 (2026-06-10)
 
 ### Bug Fixes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "generate": "tsx scripts/generate.ts",

--- a/packages/postgresdb/CHANGELOG.md
+++ b/packages/postgresdb/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.9.0 (2026-06-10)
+
+### Bug Fixes
+
+* expire stale sessions during singleSessionPerActor conflict check ([#185](https://127.0.0.1/46757/git/ttoss/issues/185)) ([1b4dece](https://127.0.0.1/46757/git/ttoss/commits/1b4dece66cf4eb26fe39b1aebe48b8f1e0924fe6))
+* HTTP tool DELETE requests now send body and preserve Content-Type header ([#131](https://127.0.0.1/46757/git/ttoss/issues/131)) ([a536f29](https://127.0.0.1/46757/git/ttoss/commits/a536f29e32a79443f9a87ed2f5f4dbc5fbab22a7)), closes [#128](https://127.0.0.1/46757/git/ttoss/issues/128)
+
+### Features
+
+* **agents:** single_session_per_actor — enforce one open session per actor ([#137](https://127.0.0.1/46757/git/ttoss/issues/137)) ([a72549b](https://127.0.0.1/46757/git/ttoss/commits/a72549beb78eb7381156c8a355dd86f7bca94a31)), closes [#135](https://127.0.0.1/46757/git/ttoss/issues/135)
+* **sessions:** add idempotency_key to addSessionMessage ([#144](https://127.0.0.1/46757/git/ttoss/issues/144)) ([b242655](https://127.0.0.1/46757/git/ttoss/commits/b242655848ca9f3356ee6aa63bc13b9473bf787b))
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/46757/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/46757/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+* **sessions:** session auto-expiry via inactivity TTL ([#133](https://127.0.0.1/46757/git/ttoss/issues/133)) ([1c25329](https://127.0.0.1/46757/git/ttoss/commits/1c253291a94a5e9d27b537842ac57c9bde5a467e)), closes [#129](https://127.0.0.1/46757/git/ttoss/issues/129) [#132](https://127.0.0.1/46757/git/ttoss/issues/132)
+* surface upstream AI provider errors and expose generation records ([#180](https://127.0.0.1/46757/git/ttoss/issues/180)) ([dde9578](https://127.0.0.1/46757/git/ttoss/commits/dde9578eed754cd4858ac45d25117ca13f1bc143))
+
 # 0.8.0 (2026-06-10)
 
 ### Bug Fixes

--- a/packages/postgresdb/package.json
+++ b/packages/postgresdb/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@soat/postgresdb",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Database models and operations for SOAT packages",
   "type": "module",
   "exports": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.9.0 (2026-06-10)
+
+### Bug Fixes
+
+* HTTP tool DELETE requests now send body and preserve Content-Type header ([#131](https://github.com/ttoss/soat/issues/131)) ([a536f29](https://github.com/ttoss/soat/commit/a536f29e32a79443f9a87ed2f5f4dbc5fbab22a7)), closes [#128](https://github.com/ttoss/soat/issues/128)
+
 # 0.8.0 (2026-06-10)
 
 ### Bug Fixes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "TypeScript SDK for the SOAT API",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.9.0 (2026-06-10)
+
+### Bug Fixes
+
+* accept string values for tool_choice in agents and formations ([#151](https://127.0.0.1/46757/git/ttoss/issues/151)) ([322bf45](https://127.0.0.1/46757/git/ttoss/commits/322bf4538d42aca7dfba1de3f60b1be4d0f22cd9))
+* add single_session_per_actor and max_context_messages to formation agent validator ([#141](https://127.0.0.1/46757/git/ttoss/issues/141)) ([a644d95](https://127.0.0.1/46757/git/ttoss/commits/a644d95e31dda50ea0f4660bdebd0de8af05848e)), closes [#140](https://127.0.0.1/46757/git/ttoss/issues/140) [#135](https://127.0.0.1/46757/git/ttoss/issues/135) [#129](https://127.0.0.1/46757/git/ttoss/issues/129)
+* await saveTrace in sync generation so trace file_id is immediately available ([#130](https://127.0.0.1/46757/git/ttoss/issues/130)) ([862b981](https://127.0.0.1/46757/git/ttoss/commits/862b981bfb70ece71d2c59b597537580ec3a9850))
+* expire stale sessions during singleSessionPerActor conflict check ([#185](https://127.0.0.1/46757/git/ttoss/issues/185)) ([1b4dece](https://127.0.0.1/46757/git/ttoss/commits/1b4dece66cf4eb26fe39b1aebe48b8f1e0924fe6))
+* HTTP tool DELETE requests now send body and preserve Content-Type header ([#131](https://127.0.0.1/46757/git/ttoss/issues/131)) ([a536f29](https://127.0.0.1/46757/git/ttoss/commits/a536f29e32a79443f9a87ed2f5f4dbc5fbab22a7)), closes [#128](https://127.0.0.1/46757/git/ttoss/issues/128)
+* persist responseMessages metadata after tool-output submission ([#177](https://127.0.0.1/46757/git/ttoss/issues/177)) ([a2f963a](https://127.0.0.1/46757/git/ttoss/commits/a2f963a0f58e4419508c0e4e40888c192fcfd71b))
+* preserve tool call/result messages in conversation history ([#175](https://127.0.0.1/46757/git/ttoss/issues/175)) ([459d419](https://127.0.0.1/46757/git/ttoss/commits/459d4194c12c6b4b941b1146182e16ef70b78e6a)), closes [#147](https://127.0.0.1/46757/git/ttoss/issues/147) [#147](https://127.0.0.1/46757/git/ttoss/issues/147)
+
+### Features
+
+* **agents:** single_session_per_actor — enforce one open session per actor ([#137](https://127.0.0.1/46757/git/ttoss/issues/137)) ([a72549b](https://127.0.0.1/46757/git/ttoss/commits/a72549beb78eb7381156c8a355dd86f7bca94a31)), closes [#135](https://127.0.0.1/46757/git/ttoss/issues/135)
+* context window limiting and trace lifecycle fix (issue [#129](https://127.0.0.1/46757/git/ttoss/issues/129)) ([#134](https://127.0.0.1/46757/git/ttoss/issues/134)) ([2688612](https://127.0.0.1/46757/git/ttoss/commits/268861201365de568d62ee16c51c33bfc7b41206))
+* **sessions:** add expired status with lazy TTL update ([#138](https://127.0.0.1/46757/git/ttoss/issues/138)) ([2fc6a0c](https://127.0.0.1/46757/git/ttoss/commits/2fc6a0cdc6f5dea7b10c4737a2bf3d1eea723b22))
+* **sessions:** add idempotency_key to addSessionMessage ([#144](https://127.0.0.1/46757/git/ttoss/issues/144)) ([b242655](https://127.0.0.1/46757/git/ttoss/commits/b242655848ca9f3356ee6aa63bc13b9473bf787b))
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/46757/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/46757/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+* **sessions:** session auto-expiry via inactivity TTL ([#133](https://127.0.0.1/46757/git/ttoss/issues/133)) ([1c25329](https://127.0.0.1/46757/git/ttoss/commits/1c253291a94a5e9d27b537842ac57c9bde5a467e)), closes [#129](https://127.0.0.1/46757/git/ttoss/issues/129) [#132](https://127.0.0.1/46757/git/ttoss/issues/132)
+* surface upstream AI provider errors and expose generation records ([#180](https://127.0.0.1/46757/git/ttoss/issues/180)) ([dde9578](https://127.0.0.1/46757/git/ttoss/commits/dde9578eed754cd4858ac45d25117ca13f1bc143))
+
 # 0.8.0 (2026-06-10)
 
 ### Bug Fixes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "dist/server.mjs",
   "scripts": {
     "build": "tsdown",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.9.0 (2026-06-10)
+
+### Bug Fixes
+
+* add shell-safe @VAR_NAME and bare-key syntax to --parameter for --env-file integration ([#114](https://127.0.0.1/46757/git/ttoss/issues/114)) ([906dd0c](https://127.0.0.1/46757/git/ttoss/commits/906dd0cf79a1d5b6cd312e7489ac6a549c3e011b))
+* HTTP tool DELETE requests now send body and preserve Content-Type header ([#131](https://127.0.0.1/46757/git/ttoss/issues/131)) ([a536f29](https://127.0.0.1/46757/git/ttoss/commits/a536f29e32a79443f9a87ed2f5f4dbc5fbab22a7)), closes [#128](https://127.0.0.1/46757/git/ttoss/issues/128)
+
+### Features
+
+* **agents:** single_session_per_actor — enforce one open session per actor ([#137](https://127.0.0.1/46757/git/ttoss/issues/137)) ([a72549b](https://127.0.0.1/46757/git/ttoss/commits/a72549beb78eb7381156c8a355dd86f7bca94a31)), closes [#135](https://127.0.0.1/46757/git/ttoss/issues/135)
+* context window limiting and trace lifecycle fix (issue [#129](https://127.0.0.1/46757/git/ttoss/issues/129)) ([#134](https://127.0.0.1/46757/git/ttoss/issues/134)) ([2688612](https://127.0.0.1/46757/git/ttoss/commits/268861201365de568d62ee16c51c33bfc7b41206))
+* **sessions:** add expired status with lazy TTL update ([#138](https://127.0.0.1/46757/git/ttoss/issues/138)) ([2fc6a0c](https://127.0.0.1/46757/git/ttoss/commits/2fc6a0cdc6f5dea7b10c4737a2bf3d1eea723b22))
+* **sessions:** add idempotency_key to addSessionMessage ([#144](https://127.0.0.1/46757/git/ttoss/issues/144)) ([b242655](https://127.0.0.1/46757/git/ttoss/commits/b242655848ca9f3356ee6aa63bc13b9473bf787b))
+* **sessions:** add message_delay_seconds for debounced LLM processing ([#148](https://127.0.0.1/46757/git/ttoss/issues/148)) ([1406654](https://127.0.0.1/46757/git/ttoss/commits/1406654ac85a2971220358591cfb73e9a96c1e51))
+* **sessions:** session auto-expiry via inactivity TTL ([#133](https://127.0.0.1/46757/git/ttoss/issues/133)) ([1c25329](https://127.0.0.1/46757/git/ttoss/commits/1c253291a94a5e9d27b537842ac57c9bde5a467e)), closes [#129](https://127.0.0.1/46757/git/ttoss/issues/129) [#132](https://127.0.0.1/46757/git/ttoss/issues/132)
+* surface upstream AI provider errors and expose generation records ([#180](https://127.0.0.1/46757/git/ttoss/issues/180)) ([dde9578](https://127.0.0.1/46757/git/ttoss/commits/dde9578eed754cd4858ac45d25117ca13f1bc143))
+
 # 0.8.0 (2026-06-10)
 
 ### Bug Fixes

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/website",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Release v0.9.0

Bumps all packages from `0.8.0` → `0.9.0`.

### Included since last release

- fix: expire stale sessions during `singleSessionPerActor` conflict check (#185)
- docs: replace `SOAT_API_KEY` with `SOAT_TOKEN` in traces example (#183)

Merge this PR to trigger the automated release pipeline (npm publish + Docker image + website deploy).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KS5Ns9Wqk4K6ZB2RPEQNdM)_