### PR TITLE
chore(release): v0.8.1

### DIFF
--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -32,7 +32,15 @@ push-release-tag   →   release (npm publish + website deploy)   →   publish-
 
 Branch protection prevents direct pushes to `main`, so releases go through a PR.
 
-### Step 1 — Patch engines (environment workaround)
+### Step 1 — Fetch tags
+
+Lerna determines the changelog range and version bump from the last git tag. Always fetch tags before running lerna, otherwise it will fall back to including all commits and produce duplicate changelog entries:
+
+```bash
+git fetch --tags origin
+```
+
+### Step 2 — Patch engines (environment workaround)
 
 This environment runs Node 22 / pnpm 10 but the project declares `^24` / `^11`. Temporarily relax the constraint before running lerna:
 
@@ -46,7 +54,7 @@ fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 "
 ```
 
-### Step 2 — Run lerna version
+### Step 3 — Run lerna version
 
 Always pass `--no-push` — branch protection blocks direct pushes to `main`, and the PR flow handles the push. Never run lerna without `--no-push` or it will attempt (and fail) to push to `main` directly.
 
@@ -66,7 +74,7 @@ pnpm lerna version major --yes --no-push   # 0.6.9 → 1.0.0
 
 Lerna will create a `chore(release): publish packages` commit and tag locally.
 
-### Step 3 — Restore engines
+### Step 4 — Restore engines
 
 ```bash
 node -e "
@@ -78,7 +86,7 @@ fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 " && git add package.json && git commit --amend --no-edit
 ```
 
-### Step 4 — Push to a release branch and open a PR
+### Step 5 — Push to a release branch and open a PR
 
 ```bash
 git checkout -b release/vX.Y.Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.1](https://github.com/ttoss/soat/compare/v0.8.0...v0.8.1) (2026-06-10)
+
+### Bug Fixes
+
+* expire stale sessions during singleSessionPerActor conflict check ([#185](https://github.com/ttoss/soat/issues/185)) ([1b4dece](https://github.com/ttoss/soat/commit/1b4dece66cf4eb26fe39b1aebe48b8f1e0924fe6))
+
 # 0.8.0 (2026-06-10)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "npmClient": "pnpm",
   "stream": true,
   "command": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.1](https://github.com/ttoss/soat/compare/v0.8.0...v0.8.1) (2026-06-10)
+
+**Note:** Version bump only for package @soat/cli
+
 # 0.8.0 (2026-06-10)
 
 ### Bug Fixes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "generate": "tsx scripts/generate.ts",

--- a/packages/postgresdb/CHANGELOG.md
+++ b/packages/postgresdb/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.1](https://127.0.0.1/37303/git/ttoss/compare/v0.8.0...v0.8.1) (2026-06-10)
+
+### Bug Fixes
+
+* expire stale sessions during singleSessionPerActor conflict check ([#185](https://127.0.0.1/37303/git/ttoss/issues/185)) ([1b4dece](https://127.0.0.1/37303/git/ttoss/commits/1b4dece66cf4eb26fe39b1aebe48b8f1e0924fe6))
+
 # 0.8.0 (2026-06-10)
 
 ### Bug Fixes

--- a/packages/postgresdb/package.json
+++ b/packages/postgresdb/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@soat/postgresdb",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Database models and operations for SOAT packages",
   "type": "module",
   "exports": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.1](https://github.com/ttoss/soat/compare/v0.8.0...v0.8.1) (2026-06-10)
+
+**Note:** Version bump only for package @soat/sdk
+
 # 0.8.0 (2026-06-10)
 
 ### Bug Fixes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "TypeScript SDK for the SOAT API",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.1](https://127.0.0.1/37303/git/ttoss/compare/v0.8.0...v0.8.1) (2026-06-10)
+
+### Bug Fixes
+
+* expire stale sessions during singleSessionPerActor conflict check ([#185](https://127.0.0.1/37303/git/ttoss/issues/185)) ([1b4dece](https://127.0.0.1/37303/git/ttoss/commits/1b4dece66cf4eb26fe39b1aebe48b8f1e0924fe6))
+
 # 0.8.0 (2026-06-10)
 
 ### Bug Fixes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/server",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "dist/server.mjs",
   "scripts": {
     "build": "tsdown",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.1](https://127.0.0.1/37303/git/ttoss/compare/v0.8.0...v0.8.1) (2026-06-10)
+
+**Note:** Version bump only for package @soat/website
+
 # 0.8.0 (2026-06-10)
 
 ### Bug Fixes

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/website",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Release v0.8.1

Bumps all packages from `0.8.0` → `0.8.1`.

### Bug Fixes

- fix: expire stale sessions during `singleSessionPerActor` conflict check (#185)

Merge to trigger the automated release pipeline (npm publish + Docker image + website deploy).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KS5Ns9Wqk4K6ZB2RPEQNdM)_