### PR TITLE
chore(release): v0.8.1

### DIFF
--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -23,7 +23,7 @@ When the release PR is merged, the `chore(release): publish packages` commit lan
 push-release-tag   →   release (npm publish + website deploy)   →   publish-docker
 ```
 
-- `build-and-test`, `smoke-test`, and `tutorials-test` are **skipped** on release commits (guarded by `chore(release):` in the commit message).
+- `build-and-test`, `smoke-test`, and `tutorials-test` are **skipped** on non-release commits; they only run when the commit message starts with `chore(release):`.
 - `push-release-tag` pushes the `vX.Y.Z` git tag.
 - `release` publishes `@soat/sdk` and `@soat/cli` to npm and deploys the website.
 - `publish-docker` builds and pushes the Docker image to Docker Hub.
@@ -93,6 +93,8 @@ git checkout -b release/vX.Y.Z
 git push -u origin release/vX.Y.Z
 # open PR targeting main
 ```
+
+The PR title must start with `chore(release):` — the release pipeline in `main.yml` is gated on `startsWith(github.event.head_commit.message, 'chore(release):')`. A title like `chore(release): publish packages` or `chore(release): v0.8.1` both work.
 
 Merge the PR once CI passes. The release pipeline runs automatically.
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
-    if: "startsWith(github.event.head_commit.message, 'chore(release): publish packages')"
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
 
     steps:
       - uses: actions/checkout@v6
@@ -42,7 +42,7 @@ jobs:
   smoke-test:
     name: Smoke Tests
     runs-on: ubuntu-latest
-    if: "startsWith(github.event.head_commit.message, 'chore(release): publish packages')"
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
 
     steps:
       - uses: actions/checkout@v6
@@ -79,7 +79,7 @@ jobs:
     name: Push Release Tag
     runs-on: ubuntu-latest
     needs: [build-and-test, smoke-test, tutorials-test]
-    if: "startsWith(github.event.head_commit.message, 'chore(release): publish packages')"
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
     permissions:
       contents: write
     steps:
@@ -204,7 +204,7 @@ jobs:
   tutorials-test:
     name: Tutorials Tests
     runs-on: ubuntu-latest
-    if: "startsWith(github.event.head_commit.message, 'chore(release): publish packages')"
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Re-triggers the v0.8.1 release pipeline (previous PR #187 used a title that didn't match the `startsWith 'chore(release): publish packages'` gate).

Also fixes the trigger condition in `main.yml` to `startsWith 'chore(release):'` so any `chore(release):` PR title works going forward, and updates the release docs accordingly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KS5Ns9Wqk4K6ZB2RPEQNdM)_