### PR TITLE
fix(sessions): persist and honor inactivity_ttl_seconds

### DIFF
--- a/packages/server/src/lib/formation-modules/sessionsFormationModule.ts
+++ b/packages/server/src/lib/formation-modules/sessionsFormationModule.ts
@@ -127,6 +127,10 @@ export const sessionsFormationModule: FormationModule = {
         typeof properties.auto_generate === 'boolean'
           ? properties.auto_generate
           : undefined,
+      inactivityTtlSeconds:
+        typeof properties.inactivity_ttl_seconds === 'number'
+          ? properties.inactivity_ttl_seconds
+          : undefined,
       toolContext:
         (toNullableObject(properties.tool_context) as Record<
           string,
@@ -195,6 +199,7 @@ export const sessionsFormationModule: FormationModule = {
         name: session.name,
         actor_id: session.actorId,
         auto_generate: session.autoGenerate,
+        inactivity_ttl_seconds: session.inactivityTtlSeconds,
         tool_context: session.toolContext,
       };
     } catch {

--- a/packages/server/src/lib/sessions.ts
+++ b/packages/server/src/lib/sessions.ts
@@ -270,6 +270,7 @@ export const updateSession = async (args: {
   status?: string;
   autoGenerate?: boolean;
   toolContext?: Record<string, string> | null;
+  inactivityTtlSeconds?: number;
   messageDelaySeconds?: number | null;
 }) => {
   const session = await db.Session.findOne({
@@ -297,6 +298,10 @@ export const updateSession = async (args: {
 
   if (args.toolContext !== undefined) {
     session.toolContext = args.toolContext;
+  }
+
+  if (args.inactivityTtlSeconds !== undefined) {
+    session.inactivityTtlSeconds = args.inactivityTtlSeconds;
   }
 
   if (args.messageDelaySeconds !== undefined) {

--- a/packages/server/src/rest/openapi/v1/formations.yaml
+++ b/packages/server/src/rest/openapi/v1/formations.yaml
@@ -956,6 +956,9 @@ components:
         auto_generate:
           type: boolean
           description: Whether to automatically generate a response when messages are sent
+        inactivity_ttl_seconds:
+          type: integer
+          description: Number of seconds of inactivity after which the session expires. 0 means never expires.
         tool_context:
           type: object
           additionalProperties: true

--- a/packages/server/src/rest/openapi/v1/sessions.yaml
+++ b/packages/server/src/rest/openapi/v1/sessions.yaml
@@ -676,6 +676,13 @@ components:
             type: string
           nullable: true
           description: Key-value pairs injected as context headers into all tool call requests made during this session.
+        inactivity_ttl_seconds:
+          type: integer
+          description: >
+            Number of seconds of inactivity after which the session expires.
+            0 means the session never expires. Updates the stored TTL; the inactivity clock
+            continues from the last activity timestamp.
+          example: 300
         message_delay_seconds:
           type: integer
           nullable: true

--- a/packages/server/src/rest/v1/sessions.ts
+++ b/packages/server/src/rest/v1/sessions.ts
@@ -181,6 +181,7 @@ sessionsRouter.patch('/:session_id', async (ctx: Context) => {
     status?: string;
     autoGenerate?: boolean;
     toolContext?: Record<string, string> | null;
+    inactivityTtlSeconds?: number;
     messageDelaySeconds?: number | null;
   };
 
@@ -191,6 +192,7 @@ sessionsRouter.patch('/:session_id', async (ctx: Context) => {
     status: body.status,
     autoGenerate: body.autoGenerate,
     toolContext: body.toolContext,
+    inactivityTtlSeconds: body.inactivityTtlSeconds,
     messageDelaySeconds: body.messageDelaySeconds,
   });
 

--- a/packages/server/tests/unit/tests/rest/sessions.test.ts
+++ b/packages/server/tests/unit/tests/rest/sessions.test.ts
@@ -1860,6 +1860,61 @@ describe('Sessions', () => {
 
       expect(genRes.status).toBe(200);
     });
+
+    test('GET session returns persisted inactivity_ttl_seconds', async () => {
+      const createRes = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions`)
+        .send({ inactivity_ttl_seconds: 450 });
+      expect(createRes.status).toBe(201);
+      const sessionId = createRes.body.id;
+
+      const getRes = await authenticatedTestClient(userToken).get(
+        `/api/v1/agents/${agentId}/sessions/${sessionId}`
+      );
+      expect(getRes.status).toBe(200);
+      expect(getRes.body.inactivity_ttl_seconds).toBe(450);
+    });
+
+    test('PATCH session can update inactivity_ttl_seconds', async () => {
+      const createRes = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions`)
+        .send({ inactivity_ttl_seconds: 300 });
+      expect(createRes.status).toBe(201);
+      const sessionId = createRes.body.id;
+
+      const patchRes = await authenticatedTestClient(userToken)
+        .patch(`/api/v1/agents/${agentId}/sessions/${sessionId}`)
+        .send({ inactivity_ttl_seconds: 900 });
+      expect(patchRes.status).toBe(200);
+      expect(patchRes.body.inactivity_ttl_seconds).toBe(900);
+
+      const getRes = await authenticatedTestClient(userToken).get(
+        `/api/v1/agents/${agentId}/sessions/${sessionId}`
+      );
+      expect(getRes.body.inactivity_ttl_seconds).toBe(900);
+    });
+
+    test('updating inactivity_ttl_seconds to 0 disables expiry', async () => {
+      const createRes = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions`)
+        .send({ inactivity_ttl_seconds: 1 });
+      expect(createRes.status).toBe(201);
+      const sessionId = createRes.body.id;
+
+      await authenticatedTestClient(userToken)
+        .patch(`/api/v1/agents/${agentId}/sessions/${sessionId}`)
+        .send({ inactivity_ttl_seconds: 0 });
+
+      await new Promise((resolve) => {
+        return setTimeout(resolve, 1200);
+      });
+
+      const getRes = await authenticatedTestClient(userToken).get(
+        `/api/v1/agents/${agentId}/sessions/${sessionId}`
+      );
+      expect(getRes.status).toBe(200);
+      expect(getRes.body.status).toBe('open');
+    });
   });
 
   // ── single_session_per_actor ───────────────────────────────────────────

--- a/packages/website/docs/modules/sessions.md
+++ b/packages/website/docs/modules/sessions.md
@@ -136,6 +136,8 @@ Sessions can expire automatically after a period of inactivity using `inactivity
 
 When a session exceeds its TTL, its `status` is lazily updated to `expired` the next time it is fetched or listed. Once expired, `POST .../generate` returns `410 Gone` with error code `SESSION_EXPIRED`. Open a fresh session to continue.
 
+The TTL is stored server-side at session creation and persists without requiring the client to re-send it. It can also be updated at any time via `PATCH .../sessions/:session_id` — the inactivity clock continues from the last `last_activity_at` timestamp, so changing the TTL takes effect on the next fetch.
+
 ```json
 HTTP 410 Gone
 {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add `inactivity_ttl_seconds` to `updateSession` lib function, REST `PATCH` handler, and `UpdateSessionRequest` OpenAPI schema — clients can now update the TTL after session creation
- Add `inactivity_ttl_seconds` to `SessionResourceProperties` in `formations.yaml` and wire it through the sessions formation module `create` and `read` paths
- Add 3 new tests: GET returns persisted TTL, PATCH updates TTL, setting TTL to 0 disables expiry
- Update `sessions.md`: clarify TTL is stored server-side and updatable via PATCH

## Root cause (issue #189)

`inactivity_ttl_seconds` was missing from `UpdateSessionRequest` and the formation module, so:
1. Clients receiving `SINGLE_SESSION_CONFLICT` and falling back to `updateSession` had no way to carry the TTL forward on the conflict path
2. Sessions created via formations silently dropped the `inactivity_ttl_seconds` property

## Test plan

- [ ] `pnpm --filter @soat/server typecheck` — passes
- [ ] `pnpm --filter @soat/server eslint --fix` — clean
- [ ] New tests cover: GET session persists TTL, PATCH updates TTL, TTL=0 disables expiry
- [ ] CI runs full integration test suite

Closes #189

https://claude.ai/code/session_01DkZDzrzyAtQ298P5hrqDLo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkZDzrzyAtQ298P5hrqDLo)_