### PR TITLE
chore(release): publish packages v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.2](https://github.com/ttoss/soat/compare/v0.8.1...v0.8.2) (2026-06-11)
+
+### Bug Fixes
+
+* **sessions:** enforce singleSessionPerActor at DB level to prevent race condition ([#191](https://github.com/ttoss/soat/issues/191)) ([0db866e](https://github.com/ttoss/soat/commit/0db866ef7334279bce7aadbd5538596dd7c7b9b3)), closes [#190](https://github.com/ttoss/soat/issues/190)
+* **sessions:** persist and honor inactivity_ttl_seconds ([#192](https://github.com/ttoss/soat/issues/192)) ([dabb6a7](https://github.com/ttoss/soat/commit/dabb6a7219720e344b9f1542e614b6c6a31fb723)), closes [#189](https://github.com/ttoss/soat/issues/189)
+
 ## [0.8.1](https://github.com/ttoss/soat/compare/v0.8.0...v0.8.1) (2026-06-10)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "npmClient": "pnpm",
   "stream": true,
   "command": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.2](https://github.com/ttoss/soat/compare/v0.8.1...v0.8.2) (2026-06-11)
+
+**Note:** Version bump only for package @soat/cli
+
 ## [0.8.1](https://github.com/ttoss/soat/compare/v0.8.0...v0.8.1) (2026-06-10)
 
 **Note:** Version bump only for package @soat/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "generate": "tsx scripts/generate.ts",

--- a/packages/postgresdb/CHANGELOG.md
+++ b/packages/postgresdb/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.2](https://127.0.0.1/41431/git/ttoss/compare/v0.8.1...v0.8.2) (2026-06-11)
+
+**Note:** Version bump only for package @soat/postgresdb
+
 ## [0.8.1](https://127.0.0.1/37303/git/ttoss/compare/v0.8.0...v0.8.1) (2026-06-10)
 
 ### Bug Fixes

--- a/packages/postgresdb/package.json
+++ b/packages/postgresdb/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@soat/postgresdb",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Database models and operations for SOAT packages",
   "type": "module",
   "exports": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.2](https://github.com/ttoss/soat/compare/v0.8.1...v0.8.2) (2026-06-11)
+
+**Note:** Version bump only for package @soat/sdk
+
 ## [0.8.1](https://github.com/ttoss/soat/compare/v0.8.0...v0.8.1) (2026-06-10)
 
 **Note:** Version bump only for package @soat/sdk

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/sdk",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "TypeScript SDK for the SOAT API",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.2](https://127.0.0.1/41431/git/ttoss/compare/v0.8.1...v0.8.2) (2026-06-11)
+
+### Bug Fixes
+
+* **sessions:** enforce singleSessionPerActor at DB level to prevent race condition ([#191](https://127.0.0.1/41431/git/ttoss/issues/191)) ([0db866e](https://127.0.0.1/41431/git/ttoss/commits/0db866ef7334279bce7aadbd5538596dd7c7b9b3)), closes [#190](https://127.0.0.1/41431/git/ttoss/issues/190)
+* **sessions:** persist and honor inactivity_ttl_seconds ([#192](https://127.0.0.1/41431/git/ttoss/issues/192)) ([dabb6a7](https://127.0.0.1/41431/git/ttoss/commits/dabb6a7219720e344b9f1542e614b6c6a31fb723)), closes [#189](https://127.0.0.1/41431/git/ttoss/issues/189)
+
 ## [0.8.1](https://127.0.0.1/37303/git/ttoss/compare/v0.8.0...v0.8.1) (2026-06-10)
 
 ### Bug Fixes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "dist/server.mjs",
   "scripts": {
     "build": "tsdown",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.2](https://127.0.0.1/41431/git/ttoss/compare/v0.8.1...v0.8.2) (2026-06-11)
+
+### Bug Fixes
+
+* **sessions:** persist and honor inactivity_ttl_seconds ([#192](https://127.0.0.1/41431/git/ttoss/issues/192)) ([dabb6a7](https://127.0.0.1/41431/git/ttoss/commits/dabb6a7219720e344b9f1542e614b6c6a31fb723)), closes [#189](https://127.0.0.1/41431/git/ttoss/issues/189)
+
 ## [0.8.1](https://127.0.0.1/37303/git/ttoss/compare/v0.8.0...v0.8.1) (2026-06-10)
 
 **Note:** Version bump only for package @soat/website

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/website",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Summary

- fix(sessions): persist and honor `inactivity_ttl_seconds` (#192)
- fix(sessions): enforce `singleSessionPerActor` at DB level to prevent race condition (#191)

## Packages bumped

| Package | Version |
|---|---|
| `@soat/cli` | 0.8.1 → 0.8.2 |
| `@soat/sdk` | 0.8.1 → 0.8.2 |
| `@soat/server` | 0.8.1 → 0.8.2 |
| `@soat/postgresdb` | 0.8.1 → 0.8.2 (private) |
| `@soat/website` | 0.8.1 → 0.8.2 (private) |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mg7YZagbvR2bzKk1zXQYDM)_