### PR TITLE
chore(release): publish packages v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/ttoss/soat/compare/v0.8.2...v0.9.0) (2026-06-11)
+
+### Features
+
+* **tools:** support ${body.xxx} path parameter interpolation in HTTP tool URLs ([#195](https://github.com/ttoss/soat/issues/195)) ([85f8eb4](https://github.com/ttoss/soat/commit/85f8eb43bf65a47330c3a2b7a25ed94693ccd894)), closes [#194](https://github.com/ttoss/soat/issues/194)
+
 ## [0.8.2](https://github.com/ttoss/soat/compare/v0.8.1...v0.8.2) (2026-06-11)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "npmClient": "pnpm",
   "stream": true,
   "command": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/ttoss/soat/compare/v0.8.2...v0.9.0) (2026-06-11)
+
+**Note:** Version bump only for package @soat/cli
+
 ## [0.8.2](https://github.com/ttoss/soat/compare/v0.8.1...v0.8.2) (2026-06-11)
 
 **Note:** Version bump only for package @soat/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/cli",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "generate": "tsx scripts/generate.ts",

--- a/packages/postgresdb/CHANGELOG.md
+++ b/packages/postgresdb/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://127.0.0.1/40289/git/ttoss/compare/v0.8.2...v0.9.0) (2026-06-11)
+
+**Note:** Version bump only for package @soat/postgresdb
+
 ## [0.8.2](https://127.0.0.1/41431/git/ttoss/compare/v0.8.1...v0.8.2) (2026-06-11)
 
 **Note:** Version bump only for package @soat/postgresdb

--- a/packages/postgresdb/package.json
+++ b/packages/postgresdb/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@soat/postgresdb",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Database models and operations for SOAT packages",
   "type": "module",
   "exports": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/ttoss/soat/compare/v0.8.2...v0.9.0) (2026-06-11)
+
+**Note:** Version bump only for package @soat/sdk
+
 ## [0.8.2](https://github.com/ttoss/soat/compare/v0.8.1...v0.8.2) (2026-06-11)
 
 **Note:** Version bump only for package @soat/sdk

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/sdk",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "TypeScript SDK for the SOAT API",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://127.0.0.1/40289/git/ttoss/compare/v0.8.2...v0.9.0) (2026-06-11)
+
+### Features
+
+* **tools:** support ${body.xxx} path parameter interpolation in HTTP tool URLs ([#195](https://127.0.0.1/40289/git/ttoss/issues/195)) ([85f8eb4](https://127.0.0.1/40289/git/ttoss/commits/85f8eb43bf65a47330c3a2b7a25ed94693ccd894)), closes [#194](https://127.0.0.1/40289/git/ttoss/issues/194)
+
 ## [0.8.2](https://127.0.0.1/41431/git/ttoss/compare/v0.8.1...v0.8.2) (2026-06-11)
 
 ### Bug Fixes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/server",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "main": "dist/server.mjs",
   "scripts": {
     "build": "tsdown",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://127.0.0.1/40289/git/ttoss/compare/v0.8.2...v0.9.0) (2026-06-11)
+
+### Features
+
+* **tools:** support ${body.xxx} path parameter interpolation in HTTP tool URLs ([#195](https://127.0.0.1/40289/git/ttoss/issues/195)) ([85f8eb4](https://127.0.0.1/40289/git/ttoss/commits/85f8eb43bf65a47330c3a2b7a25ed94693ccd894)), closes [#194](https://127.0.0.1/40289/git/ttoss/issues/194)
+
 ## [0.8.2](https://127.0.0.1/41431/git/ttoss/compare/v0.8.1...v0.8.2) (2026-06-11)
 
 ### Bug Fixes

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/website",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Summary

- Bumps all packages from `0.8.2` → `0.9.0`
- Includes `${body.fieldName}` path interpolation in HTTP tool URLs for formation templates
- Includes improved HTTP tool error tracing (captures status, URL, method, and response body)

## Release checklist

- [ ] CI passes (`build-and-test`, `smoke-test`, `tutorials-test`)
- [ ] Merge triggers automated npm publish + Docker image push

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4pgkzZifHwHiJ2hwvBchg)_