### PR TITLE
fix: return requires_action when continuation produces new client tool calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,5 @@ github-app/
 **/i18n/unused/
 tsup.config.bundled*.mjs
 .playwright-mcp/
+.claude/worktrees/
+

--- a/packages/server/src/lib/agentGeneration.ts
+++ b/packages/server/src/lib/agentGeneration.ts
@@ -21,6 +21,7 @@ import { buildKnowledgeMessages, buildWriteMemoryTool } from './agentKnowledge';
 import { buildModel } from './agentModel';
 import {
   buildToolResultMessages as buildToolResultMessagesFromOutputs,
+  resolveToolOutputsResult,
   runNonStreamGeneration,
   runToolOutputsGeneration,
 } from './agentNonStreamGeneration';
@@ -29,10 +30,7 @@ import {
   type GenerationInputMessage,
   resolveGenerationInputMessages,
 } from './generationInputMessages';
-import {
-  fireCompletionSideEffects,
-  recordGenerationFailure,
-} from './generationLifecycle';
+import { recordGenerationFailure } from './generationLifecycle';
 import { createGenerationRecord } from './generations';
 
 const log = createDebug('soat:generation');
@@ -389,24 +387,11 @@ export const submitToolOutputs = async (args: {
     nonSystemMessages,
   });
 
-  const completedResult: GenerationResult = {
-    id: args.generationId,
-    traceId: pending.traceId,
-    status: 'completed',
-    output: {
-      model: result.response?.modelId ?? '',
-      content: result.text,
-      finishReason: result.finishReason,
-      responseMessages: result.response?.messages as Array<unknown> | undefined,
-    },
-  };
-
-  fireCompletionSideEffects({
+  return resolveToolOutputsResult({
     generationId: args.generationId,
+    agentId: args.agentId,
     pending,
+    allMessages,
     result,
-    completedResult,
   });
-
-  return completedResult;
 };

--- a/packages/server/src/lib/agentNonStreamGeneration.ts
+++ b/packages/server/src/lib/agentNonStreamGeneration.ts
@@ -10,7 +10,10 @@ import {
   savePendingGeneration,
   type TypedAgent,
 } from './agentGenerationHelpers';
-import { recordGenerationFailure } from './generationLifecycle';
+import {
+  fireCompletionSideEffects,
+  recordGenerationFailure,
+} from './generationLifecycle';
 import { toProviderDomainError } from './providerError';
 
 const log = createDebug('soat:generation');
@@ -270,6 +273,104 @@ export const runToolOutputsGeneration = async (args: {
       error: toProviderDomainError(error) ?? error,
     });
   }
+};
+
+type ToolOutputsGenerationResult = {
+  steps: unknown[];
+  response?: { messages?: unknown[]; modelId?: string };
+  text: string;
+  finishReason: string;
+};
+
+const buildTypedAgentFromPending = (pending: PendingGeneration): TypedAgent => {
+  return {
+    instructions: pending.agentConfig.instructions,
+    model: null,
+    toolIds: null,
+    maxSteps: pending.agentConfig.maxSteps,
+    toolChoice: pending.agentConfig.toolChoice,
+    stopConditions: pending.agentConfig.stopConditions,
+    activeToolIds: pending.agentConfig.activeToolIds,
+    stepRules: pending.agentConfig.stepRules,
+    boundaryPolicy: null,
+    temperature: pending.agentConfig.temperature,
+    knowledgeConfig: null,
+    project: { id: pending.projectId, publicId: pending.projectPublicId },
+    aiProvider: { publicId: '' },
+  };
+};
+
+export const resolveToolOutputsResult = (args: {
+  generationId: string;
+  agentId: string;
+  pending: PendingGeneration;
+  allMessages: unknown[];
+  result: ToolOutputsGenerationResult;
+}): GenerationResult => {
+  const newPendingToolCalls = findPendingClientTools(
+    args.result.steps as Array<{
+      toolCalls?: Array<{
+        toolCallId: string;
+        toolName: string;
+        input: unknown;
+      }>;
+    }>,
+    args.pending.resolvedTools
+  );
+
+  if (newPendingToolCalls.length > 0) {
+    log(
+      'resolveToolOutputsResult: continuation produced %d new client tool calls generationId=%s',
+      newPendingToolCalls.length,
+      args.generationId
+    );
+    return savePendingGeneration({
+      generationId: args.generationId,
+      traceId: args.pending.traceId,
+      parentTraceId: args.pending.parentTraceId,
+      rootTraceId: args.pending.rootTraceId,
+      pendingToolCalls: newPendingToolCalls,
+      allMessages: args.allMessages as Array<{
+        role: string;
+        content: unknown;
+      }>,
+      result: args.result as {
+        steps: unknown[];
+        response: { messages: unknown[]; modelId?: string };
+        text: string;
+        finishReason: string;
+      },
+      model: args.pending.resolvedModel,
+      typedAgent: buildTypedAgentFromPending(args.pending),
+      agentId: args.agentId,
+      resolvedTools: args.pending.resolvedTools,
+      toolContext: args.pending.toolContext ?? null,
+      remainingDepth: null,
+    });
+  }
+
+  const completedResult: GenerationResult = {
+    id: args.generationId,
+    traceId: args.pending.traceId,
+    status: 'completed',
+    output: {
+      model: args.result.response?.modelId ?? '',
+      content: args.result.text,
+      finishReason: args.result.finishReason,
+      responseMessages: args.result.response?.messages as
+        | Array<unknown>
+        | undefined,
+    },
+  };
+
+  fireCompletionSideEffects({
+    generationId: args.generationId,
+    pending: args.pending,
+    result: args.result as { steps: unknown[]; finishReason: string },
+    completedResult,
+  });
+
+  return completedResult;
 };
 
 export const buildToolResultMessages = (args: {

--- a/packages/server/tests/unit/tests/lib/agentGeneration.test.ts
+++ b/packages/server/tests/unit/tests/lib/agentGeneration.test.ts
@@ -85,6 +85,121 @@ describe('submitToolOutputs', () => {
     ).rejects.toThrow('not found');
   });
 
+  test('returns requires_action when continuation produces a new client tool call', async () => {
+    jest.doMock('ai', () => {
+      const actual = jest.requireActual('ai');
+      return {
+        ...actual,
+        generateText: jest.fn().mockResolvedValue({
+          text: 'I will send the reply.',
+          finishReason: 'tool-calls',
+          steps: [
+            {
+              toolCalls: [
+                {
+                  toolCallId: 'tc_new_1',
+                  toolName: 'send-reply',
+                  input: { message: 'Hello from bot' },
+                },
+              ],
+            },
+          ],
+          response: {
+            modelId: 'mock-model',
+            messages: [
+              {
+                role: 'assistant',
+                content: [
+                  { type: 'text', text: 'I will send the reply.' },
+                  {
+                    type: 'tool-call',
+                    toolCallId: 'tc_new_1',
+                    toolName: 'send-reply',
+                    args: { message: 'Hello from bot' },
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      };
+    });
+    jest.doMock('src/lib/eventBus', () => {
+      const actual = jest.requireActual('src/lib/eventBus');
+      return {
+        ...actual,
+        resolveProjectPublicId: jest.fn().mockResolvedValue('prj_test'),
+        emitEvent: jest.fn(),
+      };
+    });
+    jest.doMock('src/lib/generations', () => {
+      return {
+        createGenerationRecord: jest.fn().mockResolvedValue(undefined),
+        getGeneration: jest.fn().mockResolvedValue(null),
+        updateGenerationRecord: jest.fn().mockResolvedValue(undefined),
+      };
+    });
+
+    const { submitToolOutputs } = await loadAgentGenerationModule();
+    const { pendingGenerations } = await loadGenerationHelpersModule();
+
+    const sendReplyClientTool = {
+      description: 'Send reply to channel',
+      inputSchema: {},
+    };
+
+    const pending: PendingGeneration = {
+      agentId: 'agt_test',
+      projectId: 1,
+      projectPublicId: 'prj_test',
+      traceId: 'trc_test',
+      parentTraceId: null,
+      rootTraceId: null,
+      generationId: 'gen_pending_2',
+      initiatorGenerationId: null,
+      pendingToolCalls: [
+        { toolCallId: 'tc_1', toolName: 'send-reply', args: { message: 'Hi' } },
+      ],
+      messages: [{ role: 'user', content: 'hello' }],
+      steps: [],
+      resolvedModel: {} as never,
+      agentConfig: {
+        instructions: null,
+        maxSteps: 5,
+        toolChoice: 'auto',
+        stopConditions: null,
+        activeToolIds: null,
+        stepRules: null,
+        temperature: null,
+      },
+      resolvedTools: { 'send-reply': sendReplyClientTool as never },
+    };
+
+    pendingGenerations.set('gen_pending_2', pending);
+
+    const result = await submitToolOutputs({
+      agentId: 'agt_test',
+      generationId: 'gen_pending_2',
+      toolOutputs: [{ toolCallId: 'tc_1', output: 'sent' }],
+    });
+
+    expect(result).toMatchObject({
+      id: 'gen_pending_2',
+      traceId: 'trc_test',
+      status: 'requires_action',
+      requiredAction: {
+        type: 'submit_tool_outputs',
+        toolCalls: [
+          expect.objectContaining({
+            toolName: 'send-reply',
+            id: 'tc_new_1',
+          }),
+        ],
+      },
+    });
+    expect(pendingGenerations.has('gen_pending_2')).toBe(true);
+  });
+
   test('processes pending tool outputs and returns completed result', async () => {
     jest.doMock('ai', () => {
       const actual = jest.requireActual('ai');


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `submitToolOutputs` previously always returned `status: 'completed'` after running a continuation, ignoring the case where the model called another client tool in the same turn
- This caused sessions to hang: the unanswered tool call was stored in conversation history as a `responseMessages` entry, and subsequent generations failed with `AI_MissingToolResultsError`
- Fix mirrors the existing pattern in `resolveGenerationResult` (initial generation path): check for new client tool calls via `findPendingClientTools` and return `requires_action` if any are found

## Changes

- `agentNonStreamGeneration.ts`: added `resolveToolOutputsResult` (exported) and `buildTypedAgentFromPending` helpers
- `agentGeneration.ts`: `submitToolOutputs` now delegates to `resolveToolOutputsResult` instead of hardcoding `completed`
- `agentGeneration.test.ts`: added failing-first test covering the continuation-produces-client-tool-call case

## Test plan

- [ ] New test `returns requires_action when continuation produces a new client tool call` covers the fixed path
- [ ] Existing `processes pending tool outputs and returns completed result` test still passes (no regression)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm eslint` passes

https://claude.ai/code/session_011MgYC7ksCqrr4dZLVEF8rd
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011MgYC7ksCqrr4dZLVEF8rd)_