### PR TITLE
fix(sessions): reject messages/generation on closed sessions and cancel stale timers

### DIFF
--- a/packages/server/src/errors/codes.ts
+++ b/packages/server/src/errors/codes.ts
@@ -48,6 +48,11 @@ export const ERROR_CODES = {
     description:
       'The session has expired due to inactivity. Open a new session to continue.',
   },
+  SESSION_CLOSED: {
+    httpStatus: 409,
+    description:
+      'The session is closed and does not accept new messages or generation requests. Open a new session to continue.',
+  },
   AGENT_AND_CHAT_EXCLUSIVE: {
     httpStatus: 400,
     description:

--- a/packages/server/src/lib/sessionOperations.ts
+++ b/packages/server/src/lib/sessionOperations.ts
@@ -27,7 +27,7 @@ const sessionAbortControllers = new Map<string, AbortController>();
  * Abort and remove the controller for the given session key, if one exists.
  * Safe to call when no controller is registered.
  */
-const abortSessionGeneration = (sessionKey: string) => {
+export const abortSessionGeneration = (sessionKey: string) => {
   const existing = sessionAbortControllers.get(sessionKey);
   if (existing) {
     existing.abort();
@@ -175,6 +175,13 @@ export const generateSessionResponse = async (args: {
     throw new DomainError('RESOURCE_NOT_FOUND', 'Session not found');
   }
 
+  if (session.status === 'closed') {
+    throw new DomainError(
+      'SESSION_CLOSED',
+      'The session is closed. Open a new session to continue.'
+    );
+  }
+
   await checkSessionExpiry(session);
 
   const sessionKey = `${args.agentId}#${args.sessionId}`;
@@ -289,6 +296,20 @@ export const addSessionMessage = async (args: {
 
   if (!session) {
     throw new DomainError('RESOURCE_NOT_FOUND', 'Session not found');
+  }
+
+  if (session.status === 'closed') {
+    throw new DomainError(
+      'SESSION_CLOSED',
+      'The session is closed. Open a new session to continue.'
+    );
+  }
+
+  if (session.status === 'expired') {
+    throw new DomainError(
+      'SESSION_EXPIRED',
+      'The session has expired due to inactivity. Open a new session to continue.'
+    );
   }
 
   const conversation = session.conversation as InstanceType<

--- a/packages/server/src/lib/sessions.ts
+++ b/packages/server/src/lib/sessions.ts
@@ -1,6 +1,8 @@
 import { db } from '../db';
 import { DomainError } from '../errors';
 import { emitEvent, resolveProjectPublicId } from './eventBus';
+import { cancelDelayTimer } from './sessionDelayHelpers';
+import { abortSessionGeneration } from './sessionOperations';
 import { createSessionTransaction } from './sessionTransaction';
 
 const isSessionExpired = (session: InstanceType<(typeof db)['Session']>) => {
@@ -309,6 +311,15 @@ export const updateSession = async (args: {
   }
 
   await session.save();
+
+  // When a session is closed, cancel any pending delay timers and abort any
+  // in-flight LLM call for this session. This prevents a closed session from
+  // replaying its message history and re-executing tool calls via a stale timer.
+  if (args.status === 'closed' || args.status === 'expired') {
+    const sessionKey = `${args.agentId}#${args.sessionId}`;
+    cancelDelayTimer(sessionKey);
+    abortSessionGeneration(sessionKey);
+  }
 
   const sessionWithIncludes = await db.Session.findOne({
     where: { id: session.id },

--- a/packages/server/tests/unit/tests/rest/sessions.test.ts
+++ b/packages/server/tests/unit/tests/rest/sessions.test.ts
@@ -707,6 +707,87 @@ describe('Sessions', () => {
     });
   });
 
+  // ── Closed session guards (regression: session replay duplicates) ─────
+
+  describe('closed session guards', () => {
+    let closedSessionId: string;
+
+    beforeAll(async () => {
+      const res = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions`)
+        .send({ name: 'Close Guard Test' });
+      closedSessionId = res.body.id;
+
+      // Add a message so the session has history
+      await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions/${closedSessionId}/messages`)
+        .send({ message: 'Message before close' });
+
+      // Close the session
+      const closeRes = await authenticatedTestClient(userToken)
+        .patch(`/api/v1/agents/${agentId}/sessions/${closedSessionId}`)
+        .send({ status: 'closed' });
+      expect(closeRes.status).toBe(200);
+      expect(closeRes.body.status).toBe('closed');
+    });
+
+    test('adding a message to a closed session returns 409 SESSION_CLOSED', async () => {
+      const response = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions/${closedSessionId}/messages`)
+        .send({ message: 'Should not be added' });
+
+      expect(response.status).toBe(409);
+      expect(response.body.error.code).toBe('SESSION_CLOSED');
+    });
+
+    test('generating for a closed session returns 409 SESSION_CLOSED', async () => {
+      const response = await authenticatedTestClient(userToken).post(
+        `/api/v1/agents/${agentId}/sessions/${closedSessionId}/generate`
+      );
+
+      expect(response.status).toBe(409);
+      expect(response.body.error.code).toBe('SESSION_CLOSED');
+    });
+
+    test('a new session created after close starts with zero messages', async () => {
+      const newSessionRes = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions`)
+        .send({ name: 'Fresh Session After Close' });
+
+      expect(newSessionRes.status).toBe(201);
+      const newSessionId = newSessionRes.body.id;
+
+      const messagesRes = await authenticatedTestClient(userToken).get(
+        `/api/v1/agents/${agentId}/sessions/${newSessionId}/messages`
+      );
+
+      expect(messagesRes.status).toBe(200);
+      expect(messagesRes.body.data).toHaveLength(0);
+    });
+
+    test('a new session accepts messages independently of the closed session', async () => {
+      const newSessionRes = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions`)
+        .send({ name: 'Independent Session' });
+      const newSessionId = newSessionRes.body.id;
+
+      const addRes = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions/${newSessionId}/messages`)
+        .send({ message: 'Fresh start' });
+
+      expect(addRes.status).toBe(201);
+      expect(addRes.body.content).toBe('Fresh start');
+
+      // Confirm old closed session still rejects
+      const rejectRes = await authenticatedTestClient(userToken)
+        .post(`/api/v1/agents/${agentId}/sessions/${closedSessionId}/messages`)
+        .send({ message: 'Still rejected' });
+
+      expect(rejectRes.status).toBe(409);
+      expect(rejectRes.body.error.code).toBe('SESSION_CLOSED');
+    });
+  });
+
   // ── Permission checks ─────────────────────────────────────────────────
 
   describe('Permission enforcement', () => {


### PR DESCRIPTION
## Summary

- **Root cause**: Closing a session (`PATCH status=closed`) did not cancel in-memory delay timers or abort in-flight LLM calls. A stale timer firing after close would call `generateSessionResponse` on the closed session, re-run its full message history (including unresolved tool calls from the stuck generation), and re-execute those tool calls — causing duplicate DB writes visible in the next session opened for the same actor.
- **Fix 1**: `addSessionMessage` now throws `SESSION_CLOSED` (409) for closed sessions and `SESSION_EXPIRED` (410) for expired sessions, preventing any new messages from being added.
- **Fix 2**: `generateSessionResponse` now throws `SESSION_CLOSED` (409) for closed sessions, so even if a stale delay timer fires it is immediately rejected.
- **Fix 3**: `updateSession` cancels the in-memory delay timer and aborts any in-flight LLM call when status is set to `closed` or `expired`, cutting off the timer before it can fire.
- `abortSessionGeneration` exported so `updateSession` can call it without a circular import.
- New `SESSION_CLOSED` error code (409) added to the error registry.

## Test plan

- [ ] `test('adding a message to a closed session returns 409 SESSION_CLOSED')` — verify `addSessionMessage` rejects closed sessions
- [ ] `test('generating for a closed session returns 409 SESSION_CLOSED')` — verify `generateSessionResponse` rejects closed sessions
- [ ] `test('a new session created after close starts with zero messages')` — verify new sessions are isolated / start clean
- [ ] `test('a new session accepts messages independently of the closed session')` — verify the new session works normally while old closed session remains locked
- [ ] `pnpm typecheck` passes — no type errors
- [ ] `pnpm eslint --fix` passes — no lint warnings

https://claude.ai/code/session_01XmLftoETTf7dTaP5wgcR5p

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmLftoETTf7dTaP5wgcR5p)_