### PR TITLE
feat(server): deep-thinking reasoning — PRD reframe + provider-native effort + reflect mode

### DIFF
--- a/docs/prd-discussions.md
+++ b/docs/prd-discussions.md
@@ -1,403 +1,164 @@
-# PRD: Discussions Module
+# PRD: Deep Thinking — Reasoning Engine & Discussions
+
+> Supersedes the original "Discussions Module" PRD. The multi-agent deliberation idea is re-layered: the **deliberation engine** ships first as invisible machinery behind the existing generate flow (a `reasoning` config — "deep thinking"), and the user-facing **Discussions resource** becomes a later surface on the same engine. The original Discussions design is preserved as Phase 4.
 
 ## Implementation Status
 
-| Component                               | Status         | Notes                                                                                       |
-| --------------------------------------- | -------------- | ------------------------------------------------------------------------------------------- |
-| Discussion model (CRUD)                 | ❌ Not started | Model, lib, REST, OpenAPI, permissions, tests, docs                                          |
-| DiscussionParticipant model             | ❌ Not started | Join table linking discussions to agents with per-participant persona                       |
-| Discussion run loop (`round_robin`)     | ❌ Not started | Async server-side loop over `generateConversationMessage()` with fixed speaker order        |
-| Organizer synthesis                     | ❌ Not started | Final organizer call producing the `outcome` document                                       |
-| Organizer decision protocol             | ❌ Not started | Prompt-based JSON contract for `continue`/`end` and `next_speaker`                          |
-| `organizer_selects` turn policy         | ❌ Not started | Organizer picks the next speaker each turn                                                  |
-| Lifecycle events + webhooks             | ❌ Not started | `discussion.completed` / `discussion.failed` via eventBus + webhook dispatcher              |
-| Streaming (SSE turn feed)               | ❌ Not started | Live feed of turns as they are generated                                                    |
-| Human participants                      | ❌ Not started | Pause/`required_action` flow modelled after orchestration human nodes                       |
-| Formation support                       | ❌ Not started | `discussionsFormationModule` + `DiscussionResourceProperties` in `formations.yaml`          |
-| Orchestration `discussion` node type    | ❌ Not started | Embed a discussion as a single node inside an orchestration DAG                             |
+| Component                                   | Status         | Notes                                                                                          |
+| ------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------- |
+| Provider-native reasoning passthrough       | ❌ Not started | `reasoning_effort` / thinking-budget params forwarded to providers that support them            |
+| Shared completion resolver                  | ❌ Not started | Extract provider/model resolution (incl. project-scope check) from `memoryExtractionCompletion` |
+| `reasoning` config (agent + per-generate)   | ❌ Not started | `mode: "none" \| "reflect" \| "debate"` on `Agent.reasoningConfig` and generate body override   |
+| Reflect mode (draft → critique → revise)    | ❌ Not started | Single agent, ~3 calls; optional `critique` override block                                      |
+| Debate mode (homogeneous)                   | ❌ Not started | N auto-personas on the agent's own provider/model → bounded rounds → synthesis                  |
+| Heterogeneous perspectives                  | ❌ Not started | Per-perspective `{ name, prompt, ai_provider_id, model }` overrides                             |
+| Synthesis overrides                         | ❌ Not started | `synthesis: { ai_provider_id?, model?, prompt? }`                                               |
+| Trace integration                           | ❌ Not started | Each internal call recorded as trace steps tagged with perspective name + model                 |
+| Discussions resource module                 | ❌ Not started | Visible transcript, organizer-selected turns, human participants (original PRD, now Phase 4)    |
 
 ## Implementation Phases
 
-### Phase 1 — Core Model & Round-Robin Loop ❌ Not started
+### Phase 0 — Provider-Native Reasoning Passthrough ❌ Not started
 
-**Goal:** Create a discussion with N participant agents and an organizer, start it, and poll until the organizer's synthesis is ready. Turn order is deterministic (`round_robin`); the organizer only synthesizes at the end.
-
-**Deliverables:**
-
-- `Discussion` and `DiscussionParticipant` DB models
-- `POST/GET/PATCH/DELETE /api/v1/discussions` — CRUD
-- `POST /api/v1/discussions/:discussionId/start` — kicks off the async run loop; returns `202 Accepted`
-- `POST /api/v1/discussions/:discussionId/cancel` — cancels a running discussion
-- Run loop in `src/lib/discussionEngine.ts`: seeds the underlying conversation with the topic, iterates participants in declared order for `max_rounds` rounds, each turn via the existing conversation generate plumbing
-- Organizer synthesis call after the last round; result stored as a document and exposed as `outcome`
-- Auto-created [Actors](../packages/website/docs/modules/actors.md) per participant carrying persona `instructions`
-- OpenAPI spec, SDK/CLI regeneration, permissions JSON, unit tests, smoke test steps, module docs
-
-**Unlocks:** "Have three agents debate this idea and give me the organizer's summary" in two API calls.
-
----
-
-### Phase 2 — Organizer Control ❌ Not started
-
-**Goal:** Make the discussion adaptive. The organizer decides whether the discussion should continue after each round and, with `turn_policy: organizer_selects`, which participant speaks next.
+**Goal:** The cheapest deep thinking is one LLM call with the provider's own reasoning mode turned on. Expose it before building any orchestration.
 
 **Deliverables:**
 
-- Organizer decision protocol (see [Organizer Decision Protocol](#organizer-decision-protocol)) — prompt-based JSON with lenient parsing, one retry, and a safe fallback to `round_robin`/`continue`
-- `turn_policy` field: `round_robin` (default) | `organizer_selects`
-- Early termination: organizer returns `action: "end"` → loop stops before `max_rounds`
-- `rounds_completed` and `turns` counters on the Discussion resource
-- Decision turns recorded in the trace (but **not** appended to the conversation transcript)
-- Tests covering decision parsing, fallback behaviour, and early termination
+- `reasoning_effort` (or provider-appropriate thinking-budget) field on the Agent and on the generate request body, forwarded via the AI SDK provider options for providers that support it (Anthropic extended thinking, OpenAI reasoning models, etc.); ignored otherwise
+- OpenAPI + SDK/CLI regeneration, docs, tests
 
-**Unlocks:** Moderated debates that converge when consensus is reached instead of burning a fixed number of rounds.
+**Unlocks:** Better answers with zero added latency architecture — and a baseline to measure reflect/debate against.
 
 ---
 
-### Phase 3 — Observability & Events ❌ Not started
+### Phase 1 — Reflect Mode ❌ Not started
 
-**Goal:** Make long-running discussions observable without polling.
+**Goal:** Draft → self-critique → revise. One agent, no personas, roughly 3 LLM calls. The biggest quality-per-dollar step after Phase 0.
 
 **Deliverables:**
 
-- `discussion.started`, `discussion.turn.completed`, `discussion.completed`, `discussion.failed` events emitted on the eventBus and deliverable via [Webhooks](../packages/website/docs/modules/webhooks.md)
-- `GET /api/v1/discussions/:discussionId/turns` — paginated turn listing (participant, round, message ref)
-- Optional SSE stream (`?stream=true` on start) emitting one event per completed turn
-- Trace ancestry: every turn's generation links to a shared discussion trace ID
+- `reasoningConfig` JSONB on Agent (mirrors `knowledgeConfig` pattern); per-generate `reasoning` body field merged over it (scalar override semantics)
+- Flow inside the generation pipeline: produce a draft, run a critique completion, run a revision completion, return the revision as the normal `GenerationResult`
+- **`critique` override block** `{ ai_provider_id?, model?, prompt? }` — same triple, resolution, and project-scope validation as `knowledge_config.extraction` (see [Override Semantics](#override-semantics)). Cross-model critique decorrelates errors: a different model family reviewing the draft catches blind spots the drafting model shares with itself
+- Critique/revision calls are plain completions (no tools) recorded in the trace; the draft is preserved as a trace artifact
+- Tests: reflect produces a completed result; critique override routes to the right provider/model; failure of the critique call degrades to returning the draft (logged, noted in trace)
 
-**Unlocks:** UIs that render the debate live; automation that reacts to a finished discussion.
+**Unlocks:** "Think before you answer" on any existing agent with one config field.
 
 ---
 
-### Phase 4 — Human Participants ❌ Not started
+### Phase 2 — Debate Mode ❌ Not started
 
-**Goal:** Let a human join the panel. When it is the human participant's turn, the discussion pauses with a `required_action`, mirroring orchestration human nodes.
+**Goal:** Internal multi-perspective deliberation behind a single generate call. This is the deliberation engine — built as an internal library, not a REST resource.
 
 **Deliverables:**
 
-- Participant entries with `actor_id` but no `agent_id` are treated as human participants
-- Status `paused` + `required_action: { type: "human_turn", participant_id, prompt }`
-- `POST /api/v1/discussions/:discussionId/turn-inputs` — submit the human's message and resume the loop
-- Tests covering pause/resume and timeout behaviour
+- `mode: "debate"` with:
+  - **`perspectives`** — an integer (auto-generated personas: advocate / skeptic / pragmatist, on the agent's own provider/model) **or** an array of perspective objects:
+    `{ name?, prompt?, ai_provider_id?, model? }` — each perspective may run on a **different provider and model with its own prompt**. Defaults per field fall back to the agent. 2–5 perspectives.
+  - **`max_rounds`** — hard cap (default 1, max 3). One round is often enough: independent takes + synthesis ≈ self-consistency; additional rounds let perspectives rebut each other
+  - **`synthesis`** — `{ ai_provider_id?, model?, prompt? }` override for the final pass that weighs the debate and produces the single answer (defaults to the agent itself)
+- Engine (`src/lib/deliberation.ts` or similar): round-robin turns over an in-memory transcript; every perspective sees the question and all prior turns attributed by perspective name; perspective calls are plain completions (no tools — only the final synthesis-bearing agent context owns side effects)
+- The response remains a normal `GenerationResult`; callers don't change. The full deliberation is visible in the trace, each step tagged with perspective name and model
+- **No new resources**: no Conversation, no Actors — the transcript is engine state persisted only into the trace
+- Failure semantics: a failing perspective is dropped and noted in the trace (quorum continues); if all perspectives fail or synthesis fails, fall back to a plain single-pass generation rather than failing the request — deep thinking must never make an agent *less* reliable
+- Tests: homogeneous debate, heterogeneous routing (per-perspective provider/model asserted via completion-boundary spy), perspective-failure degradation, full-failure fallback, max_rounds enforcement
 
-**Unlocks:** Expert-in-the-loop reviews — agents debate, a human weighs in, the organizer synthesizes everything.
+**Why heterogeneous matters:** perspectives from one model correlate — same weights, same blind spots, polite self-agreement. Different model families disagree more substantively, and that disagreement is the signal synthesis harvests. It also shapes cost: cheap fast models debate, a flagship model synthesizes (or the inverse).
+
+**Unlocks:** "Deep thinking" as a per-agent or per-request knob; the engine that Phase 4 later exposes as a product.
 
 ---
 
-### Phase 5 — Composition ❌ Not started
+### Phase 3 — Observability & Async ❌ Not started
 
-**Goal:** Make discussions a building block.
+**Goal:** Deliberation is slow (N×M calls); make it watchable and non-blocking.
 
 **Deliverables:**
 
-- `discussionsFormationModule.ts` + `DiscussionResourceProperties` schema in `formations.yaml` so panels are templatable
-- New orchestration node type `discussion`: runs a discussion to completion and maps `outcome` into orchestration state
-- Reusable panel definitions (create a discussion from an existing one's participants with a new topic)
-
-**Unlocks:** "Run a panel debate" as one deterministic step inside a larger orchestration pipeline.
+- Async generate (`?async=true` parity with sessions) returning `in_progress` + poll, for debate-mode generations
+- Trace UI affordances: deliberation steps grouped per round, perspective name + model on each step; `metadata.reasoning` summary on the generation record (`{ mode, perspectives, rounds, dropped, fallback }`) — same pattern as `metadata.extraction`
+- Optional `reasoning.budget` guard (max total completions per generation)
+- Webhook/event on deliberation fallback so silent degradation is detectable
 
 ---
 
-## Overview
+### Phase 4 — Discussions Resource (the visible surface) ❌ Not started
 
-The Discussions module coordinates a **multi-agent debate**: a set of participant [Agents](../packages/website/docs/modules/agents.md), each with its own persona, take turns discussing a **topic** in a shared transcript, while an **organizer agent** moderates the flow and produces a final synthesis (the **outcome**).
+**Goal:** When the debate itself is the deliverable — brainstorming an idea, red-teaming a decision, expert-in-the-loop review — expose the same engine as a first-class resource. This is the original Discussions PRD, now explicitly layered on the Phase 2 engine.
 
-A Discussion is a thin coordination layer over existing primitives:
+**Summary of the original design (full details in the git history of this file):**
 
-- The transcript **is** a [Conversation](../packages/website/docs/modules/conversations.md) — every turn is a regular conversation message with `actor_id` authorship and `agent_id` attribution, generated through the existing `generateConversationMessage` plumbing (advisory locks, traces, tools all included).
-- Each participant **is** an [Actor](../packages/website/docs/modules/actors.md) linked to an agent — the actor's `instructions` carry the persona ("argue the contrarian position").
-- The organizer **is** a regular agent — no special agent type is introduced.
+- `Discussion` (`disc_`) + `DiscussionParticipant` (`dpt_`): topic, participants (agents with personas), organizer agent, `turn_policy: round_robin | organizer_selects`, `max_rounds`, status lifecycle `pending → running → paused → completed/failed/cancelled`
+- Transcript persisted as a real [Conversation](../packages/website/docs/modules/conversations.md) with [Actor](../packages/website/docs/modules/actors.md) authorship (escape hatch retained); outcome stored as a document
+- Organizer decision protocol (continue/end, next speaker) — prompt-based JSON with lenient parsing and safe fallback until agents support structured output
+- Human participants via `paused` + `required_action` (mirroring orchestration human nodes); webhooks; formation support; optional orchestration `discussion` node type
+- Differences from the Phase 2 engine: persistent transcript (Conversation vs trace), participant identity (Actors vs prompt personas), turn policies with an organizer, human-in-the-loop, async-first lifecycle
 
-What the module adds is the **server-side loop**: turn scheduling, round counting, organizer decision handling, stop conditions, and an async run lifecycle — so a client gets a full debate plus synthesis from a single `start` call instead of orchestrating dozens of generate calls itself.
+**Key decision deferred to this phase:** whether participants reference full Agents (tools enabled per turn) or the engine's tool-less perspective calls. The resource surface likely wants real Agents; the deep-thinking engine deliberately avoids tools.
 
-This resolves the roadmap's "Agent Handoff / multi-agent" direction for the deliberation use case and fills the gap between:
+---
 
-| Module             | Shape                                                          |
-| ------------------ | -------------------------------------------------------------- |
-| **Chats**          | Raw LLM completions — caller manages everything                |
-| **Sessions**       | 1 user ↔ 1 agent — automated single-agent dialogue            |
-| **Conversations**  | Multi-party engine — primitives only, caller drives the loop  |
-| **Discussions**    | N agents + 1 organizer — automated multi-agent deliberation    |
-| **Orchestrations** | Deterministic DAG — known steps, no LLM-driven control flow    |
+## Override Semantics
 
-### Why Not Orchestrations
+All provider/model/prompt overrides in this PRD — `critique`, each `perspectives[]` entry, and `synthesis` — use the **same contract established by `knowledge_config.extraction`**:
 
-Orchestrations are explicitly a **DAG**: the engine rejects cycles (`ORCHESTRATION_CYCLE_DETECTED`) and its contract is "use when you know the exact steps in advance". A discussion violates both constraints:
+| Field            | Default                | Rule                                                                                       |
+| ---------------- | ---------------------- | -------------------------------------------------------------------------------------------- |
+| `ai_provider_id` | agent's provider       | Must belong to the agent's project (validated at call time; prevents borrowing another project's secret) |
+| `model`          | chain below            | `model` → override provider's `default_model` (when `ai_provider_id` set) → agent's `model` → agent provider's `default_model` |
+| `prompt`         | built-in instructions  | Replaces task instructions only; engine-owned scaffolding (debate transcript framing, synthesis contract) is always appended |
 
-1. **It is iterative** — rounds repeat until convergence; the round count is not known in advance. Expressing this in a DAG requires statically unrolling rounds.
-2. **Control flow is LLM-driven** — the organizer decides who speaks next and when to stop. Orchestration routing (`condition` nodes) is JSON Logic over state, not LLM judgment.
-3. **State is a shared transcript** — orchestration agent nodes exchange data through `input_mapping`/`output_mapping` on a state object; participants in a debate need to see the full ordered history with authorship, which is exactly what a Conversation already provides.
+**Shared implementation:** extract the resolution + project-scope check currently in `memoryExtractionCompletion.ts` into a shared helper (e.g. `resolveCompletionModel({ agentId, projectIds, aiProviderId?, model? })`) used by extraction, reflect, debate, and synthesis — one source of truth for the security check.
 
-A *fixed-shape* variant (fan-out N opinions → fan-in organizer synthesis) is already expressible as an orchestration today and remains the right tool when no iteration is needed. Discussions and Orchestrations compose rather than compete — Phase 5 embeds a discussion as a single orchestration node.
+## Reasoning Config Schema
 
-## Key Concepts
+Stored as `reasoningConfig` JSONB on the `agents` table; per-generate `reasoning` body field overrides it (object replace, not deep merge). All snake_case on the wire per case convention.
 
-### Discussion
+```jsonc
+// Agent-level default — cheap reflect everywhere
+{ "reasoning": { "mode": "reflect" } }
 
-A Discussion is an **instance**, not a template (like a Session, unlike an Orchestration). It is created with a topic, a panel, and an organizer; started once; and ends `completed` with an outcome or `failed` with an error.
-
-| Field                | Type             | Required | Description                                                                                     |
-| -------------------- | ---------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `id`                 | string           | auto     | Public ID with `disc_` prefix                                                                    |
-| `project_id`         | string           | yes      | Owning project                                                                                   |
-| `name`               | string           | no       | Human-readable name                                                                              |
-| `topic`              | string           | yes      | The idea under discussion; seeds the transcript as the first `user` message                      |
-| `organizer_agent_id` | string           | yes      | Agent that moderates and synthesizes (`agt_` prefix)                                             |
-| `participants`       | array            | yes      | 2–10 participant definitions (see [Participants](#participants))                                 |
-| `turn_policy`        | string           | no       | `round_robin` (default) \| `organizer_selects`                                                   |
-| `max_rounds`         | integer          | no       | Hard upper bound on rounds (default `3`, max `20`). Always enforced regardless of turn policy.   |
-| `status`             | string           | auto     | `pending` \| `running` \| `paused` \| `completed` \| `failed` \| `cancelled`                     |
-| `conversation_id`    | string           | auto     | Underlying conversation (escape hatch to the full Conversations API)                             |
-| `rounds_completed`   | integer          | auto     | Number of completed rounds                                                                       |
-| `outcome`            | string \| null   | auto     | Organizer's final synthesis text (`null` until completed)                                        |
-| `outcome_document_id`| string \| null   | auto     | Document holding the synthesis                                                                   |
-| `required_action`    | object \| null   | auto     | Present when `paused` (Phase 4 human turns)                                                      |
-| `error`              | object \| null   | auto     | Error details when `failed`                                                                      |
-| `tags`               | object           | no       | Free-form key-value metadata                                                                     |
-| `created_at`         | string           | auto     | ISO 8601                                                                                         |
-| `updated_at`         | string           | auto     | ISO 8601                                                                                         |
-
-### Participants
-
-Each participant binds an agent to the discussion with an optional persona. On creation the engine auto-creates an [Actor](../packages/website/docs/modules/actors.md) linked to the agent, with the persona stored in the actor's `instructions` — reusing the existing instruction-composition path for generate calls.
-
-| Field          | Type           | Required | Description                                                                                  |
-| -------------- | -------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `id`           | string         | auto     | Public ID with `dpt_` prefix                                                                  |
-| `agent_id`     | string         | yes\*    | The agent that generates this participant's turns                                             |
-| `actor_id`     | string         | auto/no  | Auto-created actor; may be supplied to reuse an existing actor. \*Phase 4: an `actor_id` without `agent_id` denotes a human participant |
-| `name`         | string         | yes      | Display name used in the transcript and organizer prompts (e.g. `"Optimist"`). Unique per discussion. |
-| `instructions` | string \| null | no       | Persona prompt composed into the agent's system prompt for this discussion's turns           |
-| `position`     | integer        | auto     | Speaking order for `round_robin`                                                              |
-
-The same `agent_id` may appear in multiple participants with different personas (one model arguing both sides is a valid panel).
-
-### Organizer
-
-The organizer is a normal agent referenced by `organizer_agent_id`. The engine calls it in two distinct modes, each with an engine-supplied system prompt wrapping the agent's own instructions:
-
-1. **Decision mode** (Phase 2, after each round — or each turn under `organizer_selects`): the organizer sees the transcript and returns a JSON decision (see below). Decision generations are traced but **not** written to the transcript.
-2. **Synthesis mode** (final step): the organizer sees the full transcript and produces the outcome. The synthesis **is** appended to the conversation as the final `assistant` message (authored by the organizer's actor) and stored as `outcome` / `outcome_document_id`.
-
-### Organizer Decision Protocol
-
-Agents do not currently support structured output (`response_format`), so the decision contract is prompt-based:
-
-```
-Engine prompt (appended to organizer instructions, decision mode):
-  "Respond with a single JSON object and nothing else:
-   { \"action\": \"continue\" | \"end\",
-     \"next_speaker\": \"<participant name>\",   // only when asked to pick
-     \"reason\": \"<one sentence>\" }"
-```
-
-Parsing is lenient (first JSON object found in the reply). On parse failure the engine retries **once** with an error-correction prompt; on a second failure it falls back to the safe default — `continue` with `round_robin` order — so a malformed organizer reply degrades the discussion rather than failing it. `max_rounds` remains the hard stop in all cases.
-
-If agents gain native structured output later, the protocol swaps to it without changing the API surface.
-
-### The Discussion Loop
-
-```
-Input: discussion (status: pending)
-
-START
-  status ← running
-  Append topic as first message (role: user) to the conversation.
-
-LOOP (round = 1 .. max_rounds)
-  Determine speaker order:
-    round_robin       → participants by position
-    organizer_selects → ask organizer for next_speaker before each turn
-  For each speaker:
-    If human participant → status ← paused, set required_action, WAIT   (Phase 4)
-    Else → generateConversationMessage(conversation_id, speaker.agent_id)
-           with the speaker's actor instructions composed in.
-           The reply is appended as an assistant message
-           (actor_id = speaker.actor_id, agent_id = speaker.agent_id).
-  rounds_completed ← round
-  Ask organizer: continue or end?                                        (Phase 2)
-    action == "end" → break
-
-SYNTHESIZE
-  Call organizer in synthesis mode over the full transcript.
-  Append synthesis as final assistant message; store outcome + outcome_document_id.
-  status ← completed
-
-ON ERROR (any turn or synthesis fails)
-  status ← failed, error ← { code, message, participant_id?, round }
-ON CANCEL
-  status ← cancelled (current in-flight generation completes; no further turns)
-```
-
-The loop runs **asynchronously** server-side: `start` returns `202` immediately and clients poll `GET /discussions/:id` (or subscribe to webhooks, Phase 3). The existing per-conversation advisory lock serializes turns; the engine never issues concurrent generate calls for the same discussion. `start` on a discussion that is not `pending` returns `409 Conflict`.
-
-### Prompt Visibility
-
-Every participant turn receives:
-
-- The participant agent's own `instructions` (unchanged — agents stay reusable outside discussions)
-- The participant's persona `instructions` (via the actor, existing composition path)
-- An engine preamble identifying the discussion: topic, participant roster with names, and the rule "you are <name>; reply with your next contribution only"
-- The full transcript so far, with each prior turn attributed to its participant name
-
-This means participants always argue with full context, which is the property orchestration state-mapping cannot provide.
-
-### Stop Conditions
-
-| Condition                  | Behaviour                                                       |
-| -------------------------- | ---------------------------------------------------------------- |
-| `max_rounds` reached       | Loop exits; synthesis runs. Always enforced (hard cap `20`).    |
-| Organizer `action: "end"`  | Loop exits early; synthesis runs. (Phase 2)                     |
-| `POST .../cancel`          | No further turns; **no synthesis**; status `cancelled`.         |
-| Turn/synthesis error       | Status `failed` with `error`; transcript preserved for debugging.|
-
-### Relationship to Other Modules
-
-| Concern              | Owned by Discussions | Delegated to                                  |
-| -------------------- | -------------------- | ---------------------------------------------- |
-| Turn scheduling      | ✅                   | —                                              |
-| Transcript storage   | —                    | Conversations (`conversation_id` escape hatch) |
-| Persona instructions | —                    | Actors (`instructions`)                        |
-| Text generation      | —                    | Agents (full tool support per turn)            |
-| Observability        | —                    | Generations / Traces (one trace per discussion)|
-| Delivery of events   | —                    | Webhooks (Phase 3)                             |
-
-Deleting a discussion cascades to its underlying conversation and auto-created actors (mirroring session deletion semantics). Supplied (pre-existing) actors are **not** deleted.
-
-## Data Model
-
-### Discussion Table
-
-| Column            | Type        | Constraints                                                            |
-| ----------------- | ----------- | ----------------------------------------------------------------------- |
-| id                | INTEGER     | PK, auto-increment                                                      |
-| publicId          | VARCHAR(32) | UNIQUE, NOT NULL, `disc_` prefix                                        |
-| projectId         | INTEGER     | FK → Project, NOT NULL                                                  |
-| conversationId    | INTEGER     | FK → Conversation, NOT NULL                                             |
-| organizerAgentId  | INTEGER     | FK → Agent, NOT NULL                                                    |
-| name              | VARCHAR     | NULL                                                                    |
-| topic             | TEXT        | NOT NULL                                                                |
-| turnPolicy        | VARCHAR(20) | NOT NULL, enum: `round_robin`, `organizer_selects`, default `round_robin` |
-| maxRounds         | INTEGER     | NOT NULL, default 3, CHECK 1–20                                         |
-| status            | VARCHAR(20) | NOT NULL, enum, default `pending`                                       |
-| roundsCompleted   | INTEGER     | NOT NULL, default 0                                                     |
-| outcomeDocumentId | INTEGER     | FK → Document, NULL                                                     |
-| requiredAction    | JSONB       | NULL                                                                    |
-| error             | JSONB       | NULL                                                                    |
-| tags              | JSONB       | NULL, default `{}`                                                      |
-| createdAt         | TIMESTAMP   | NOT NULL                                                                |
-| updatedAt         | TIMESTAMP   | NOT NULL                                                                |
-
-### DiscussionParticipant Table
-
-| Column       | Type        | Constraints                          |
-| ------------ | ----------- | ------------------------------------- |
-| id           | INTEGER     | PK, auto-increment                    |
-| publicId     | VARCHAR(32) | UNIQUE, NOT NULL, `dpt_` prefix       |
-| discussionId | INTEGER     | FK → Discussion, NOT NULL             |
-| agentId      | INTEGER     | FK → Agent, NULL (Phase 4: human)     |
-| actorId      | INTEGER     | FK → Actor, NOT NULL                  |
-| name         | VARCHAR     | NOT NULL                              |
-| position     | INTEGER     | NOT NULL                              |
-| createdAt    | TIMESTAMP   | NOT NULL                              |
-| updatedAt    | TIMESTAMP   | NOT NULL                              |
-
-**Indexes:**
-
-- `UNIQUE (publicId)` on both tables
-- `(projectId)` on Discussion — project-scoped listing
-- `(discussionId)` on DiscussionParticipant
-- `UNIQUE (discussionId, name)` — participant names are the organizer's addressing scheme
-- `UNIQUE (discussionId, position)` — stable round-robin order
-
-Deleting an Agent referenced by a participant of a **non-terminal** discussion is blocked (`409`); for terminal discussions the participant's `agentId` is set NULL, preserving the transcript (same philosophy as actor deletion rules in Conversations).
-
-## Permissions
-
-| Permission                      | Endpoint                                            |
-| ------------------------------- | ---------------------------------------------------- |
-| `discussions:CreateDiscussion`  | `POST /api/v1/discussions`                           |
-| `discussions:ListDiscussions`   | `GET /api/v1/discussions`                            |
-| `discussions:GetDiscussion`     | `GET /api/v1/discussions/:discussionId`              |
-| `discussions:UpdateDiscussion`  | `PATCH /api/v1/discussions/:discussionId`            |
-| `discussions:DeleteDiscussion`  | `DELETE /api/v1/discussions/:discussionId`           |
-| `discussions:StartDiscussion`   | `POST /api/v1/discussions/:discussionId/start`       |
-| `discussions:CancelDiscussion`  | `POST /api/v1/discussions/:discussionId/cancel`      |
-| `discussions:ListDiscussionTurns` | `GET /api/v1/discussions/:discussionId/turns` (Phase 3) |
-
-Creating a discussion additionally requires read access to the referenced agents. The run loop executes generations under the discussion's project scope — participants' agents must belong to the same project.
-
-## REST API
-
-All body fields use `snake_case` per project convention.
-
-| Method | Path                                          | Description                                                              |
-| ------ | --------------------------------------------- | ------------------------------------------------------------------------- |
-| POST   | `/api/v1/discussions`                         | Create a discussion (status `pending`). `auto_start: true` starts it immediately. |
-| GET    | `/api/v1/discussions`                         | List discussions (filter by `project_id`, `status`)                       |
-| GET    | `/api/v1/discussions/:discussionId`           | Get a discussion incl. status, `rounds_completed`, `outcome`              |
-| PATCH  | `/api/v1/discussions/:discussionId`           | Update name/tags; topic/participants/policy only while `pending`          |
-| DELETE | `/api/v1/discussions/:discussionId`           | Delete (cascades to conversation + auto-created actors); `409` while `running` |
-| POST   | `/api/v1/discussions/:discussionId/start`     | Start the async loop; `202 Accepted`; `409` if not `pending`              |
-| POST   | `/api/v1/discussions/:discussionId/cancel`    | Cancel a `running`/`paused` discussion                                    |
-| GET    | `/api/v1/discussions/:discussionId/turns`     | Paginated turn list (Phase 3)                                             |
-| POST   | `/api/v1/discussions/:discussionId/turn-inputs` | Submit a human participant's turn while `paused` (Phase 4)              |
-
-### Example — create and run a discussion
-
-```json
-POST /api/v1/discussions
+// Per-request escalation — heterogeneous debate for a hard question
 {
-  "project_id": "proj_ABC",
-  "name": "Pricing model debate",
-  "topic": "Should we move from seat-based to usage-based pricing?",
-  "organizer_agent_id": "agt_moderator",
-  "turn_policy": "round_robin",
-  "max_rounds": 3,
-  "auto_start": true,
-  "participants": [
-    { "agent_id": "agt_a", "name": "Growth advocate",
-      "instructions": "Argue for usage-based pricing. Focus on expansion revenue." },
-    { "agent_id": "agt_a", "name": "CFO perspective",
-      "instructions": "Argue for predictable revenue. Challenge optimistic projections." },
-    { "agent_id": "agt_b", "name": "Customer voice",
-      "instructions": "Represent existing customers. Surface migration risks." }
-  ]
-}
-
-→ 201 { "id": "disc_01", "status": "running", "conversation_id": "conv_42", ... }
-```
-
-```json
-GET /api/v1/discussions/disc_01
-
-→ 200 {
-  "id": "disc_01",
-  "status": "completed",
-  "rounds_completed": 2,
-  "outcome": "The panel converged on a hybrid model: ...",
-  "outcome_document_id": "doc_99",
-  "conversation_id": "conv_42"
+  "reasoning": {
+    "mode": "debate",
+    "max_rounds": 2,
+    "perspectives": [
+      { "name": "Skeptic",  "prompt": "Attack the strongest claim and surface hidden assumptions.", "ai_provider_id": "aip_anthropic", "model": "claude-sonnet-4-6" },
+      { "name": "Advocate", "prompt": "Steelman the proposal with concrete evidence.", "model": "gpt-4o-mini" },
+      { "name": "Pragmatist" }
+    ],
+    "synthesis": {
+      "ai_provider_id": "aip_flagship",
+      "prompt": "Weigh the arguments; commit to a single recommendation with rationale."
+    }
+  }
 }
 ```
 
-The full transcript is available via `GET /api/v1/conversations/conv_42/messages` — no new transcript API is introduced.
+| Field          | Type                | Default  | Notes                                                          |
+| -------------- | ------------------- | -------- | --------------------------------------------------------------- |
+| `mode`         | string              | `"none"` | `none` \| `reflect` \| `debate`                                 |
+| `critique`     | object              | —        | Reflect only — override triple for the critique pass            |
+| `perspectives` | integer \| object[] | `3`      | Debate only — count (auto personas) or explicit perspective list |
+| `max_rounds`   | integer             | `1`      | Debate only — hard cap 3                                        |
+| `synthesis`    | object              | —        | Debate only — override triple + prompt for the final pass       |
+| `budget`       | integer             | —        | Phase 3 — max total internal completions                        |
 
-## Module Checklist Impact
+## Relationship to Other Modules
 
-Per `modules.md`, shipping Phase 1 requires:
-
-- `packages/server/src/lib/discussions.ts` + `discussionEngine.ts`
-- `packages/server/src/rest/v1/discussions.ts` (+ mount in `index.ts`) with `@openapi` blocks
-- `packages/server/src/rest/openapi/v1/discussions.yaml` → regenerate SDK (`pnpm --filter @soat/sdk generate`) and CLI (`pnpm --filter @soat/cli generate`); MCP tools derive automatically
-- `packages/server/src/permissions/discussions.json` → regenerate permissions page
-- `packages/website/docs/modules/discussions.md`
-- `packages/server/tests/unit/tests/rest/discussions.test.ts` (happy path, `401`, `403`, `404`, `409` on double-start, loop behaviour with `mockCreateGeneration`)
-- Smoke test steps in `tests/smoke-tests.sh` via `$SOAT_CLI` (create → start → poll → assert `status == "completed"` and `outcome` present; do **not** assert LLM content)
+| Concern                       | Owner                                                                  |
+| ----------------------------- | ----------------------------------------------------------------------- |
+| Provider/model resolution     | Shared completion resolver (also used by memory extraction)             |
+| Deliberation transcript (P2)  | Engine state → trace steps only                                         |
+| Deliberation transcript (P4)  | Conversations (+ Actors for authorship)                                 |
+| Observability                 | Traces + `metadata.reasoning` on the generation record                  |
+| Cost controls                 | `max_rounds`, perspective count limits, `budget`                        |
 
 ## Open Questions
 
-1. **Decision-mode cost** — under `organizer_selects`, the organizer is called before every turn (N×M extra generations). Should decision calls use a cheaper model override on the organizer agent? Proposal: defer; users can point `organizer_agent_id` at a cheap-model agent.
-2. **Turn token budget** — long debates can blow the context window. Proposal: defer to the agents' existing context handling in Phase 1; consider transcript summarization (reusing memories) later.
-3. **Reusable panels** — should a "panel" (participants + organizer, no topic) be a separate template resource? Proposal: no for v1; formations (Phase 5) cover templating.
-4. **Per-turn timeout** — generations can hang on provider issues. Proposal: reuse the generation lifecycle's existing timeout/recovery handling (`agentGenerationRecovery.ts`) and mark the discussion `failed` on unrecoverable turns.
+1. **Auto-escalation** — should a cheap triage step decide *when* to debate ("is this question contested/hard?") instead of a static config? Proposal: defer; per-request override covers it manually.
+2. **Knowledge injection in perspectives** — do perspective calls get the agent's `knowledge_config` context? Proposal: yes for the question context (it's the same question), but no self-retrieval tools.
+3. **Streaming** — debate mode can't stream the final answer until synthesis; stream synthesis tokens only, or emit per-round trace events? Proposal: Phase 3 decision.
+4. **Reflect + debate composition** — allow synthesis output to be reflected on? Proposal: no; keep modes exclusive until there's a proven need.

--- a/docs/prd-discussions.md
+++ b/docs/prd-discussions.md
@@ -6,10 +6,10 @@
 
 | Component                                   | Status         | Notes                                                                                          |
 | ------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------- |
-| Provider-native reasoning passthrough       | ❌ Not started | `reasoning_effort` / thinking-budget params forwarded to providers that support them            |
-| Shared completion resolver                  | ❌ Not started | Extract provider/model resolution (incl. project-scope check) from `memoryExtractionCompletion` |
-| `reasoning` config (agent + per-generate)   | ❌ Not started | `mode: "none" \| "reflect" \| "debate"` on `Agent.reasoningConfig` and generate body override   |
-| Reflect mode (draft → critique → revise)    | ❌ Not started | Single agent, ~3 calls; optional `critique` override block                                      |
+| Provider-native reasoning passthrough       | ✅ Implemented | `reasoning.effort` (low/medium/high) mapped to OpenAI reasoningEffort, Anthropic thinking budget, Google thinking budget in `reasoning.ts` |
+| Shared completion resolver                  | ✅ Implemented | `resolveCompletionModel()` in `completionModel.ts`; used by extraction and reasoning completions |
+| `reasoning` config (agent + per-generate)   | ✅ Implemented | `Agent.reasoningConfig` JSONB (`reasoning` on the wire) + per-generate override (object replace) |
+| Reflect mode (draft → critique → revise)    | ✅ Implemented | `applyReflection()` in `reasoning.ts`; APPROVED short-circuit; failures degrade to the draft     |
 | Debate mode (homogeneous)                   | ❌ Not started | N auto-personas on the agent's own provider/model → bounded rounds → synthesis                  |
 | Heterogeneous perspectives                  | ❌ Not started | Per-perspective `{ name, prompt, ai_provider_id, model }` overrides                             |
 | Synthesis overrides                         | ❌ Not started | `synthesis: { ai_provider_id?, model?, prompt? }`                                               |
@@ -18,30 +18,31 @@
 
 ## Implementation Phases
 
-### Phase 0 — Provider-Native Reasoning Passthrough ❌ Not started
+### Phase 0 — Provider-Native Reasoning Passthrough ✅ Complete
 
 **Goal:** The cheapest deep thinking is one LLM call with the provider's own reasoning mode turned on. Expose it before building any orchestration.
 
-**Deliverables:**
+**Deliverables (as implemented):**
 
-- `reasoning_effort` (or provider-appropriate thinking-budget) field on the Agent and on the generate request body, forwarded via the AI SDK provider options for providers that support it (Anthropic extended thinking, OpenAI reasoning models, etc.); ignored otherwise
-- OpenAPI + SDK/CLI regeneration, docs, tests
+- ✅ `reasoning.effort` (`low` / `medium` / `high`) on the Agent and the generate request body, forwarded via AI SDK `providerOptions` — OpenAI `reasoningEffort`, Anthropic `thinking` budget (4096/16384/32768 tokens, with `maxOutputTokens` raised above the budget), Google `thinkingBudget`; a no-op on providers without a mapping. *(Design deviation: effort lives inside the unified `reasoning` object rather than a separate `reasoning_effort` field — one config, one column, and effort/mode compose.)*
+- ✅ OpenAPI + SDK/CLI regeneration, docs, tests
 
 **Unlocks:** Better answers with zero added latency architecture — and a baseline to measure reflect/debate against.
 
 ---
 
-### Phase 1 — Reflect Mode ❌ Not started
+### Phase 1 — Reflect Mode ✅ Complete
 
 **Goal:** Draft → self-critique → revise. One agent, no personas, roughly 3 LLM calls. The biggest quality-per-dollar step after Phase 0.
 
-**Deliverables:**
+**Deliverables (as implemented):**
 
-- `reasoningConfig` JSONB on Agent (mirrors `knowledgeConfig` pattern); per-generate `reasoning` body field merged over it (scalar override semantics)
-- Flow inside the generation pipeline: produce a draft, run a critique completion, run a revision completion, return the revision as the normal `GenerationResult`
-- **`critique` override block** `{ ai_provider_id?, model?, prompt? }` — same triple, resolution, and project-scope validation as `knowledge_config.extraction` (see [Override Semantics](#override-semantics)). Cross-model critique decorrelates errors: a different model family reviewing the draft catches blind spots the drafting model shares with itself
-- Critique/revision calls are plain completions (no tools) recorded in the trace; the draft is preserved as a trace artifact
-- Tests: reflect produces a completed result; critique override routes to the right provider/model; failure of the critique call degrades to returning the draft (logged, noted in trace)
+- ✅ `reasoningConfig` JSONB on Agent (mirrors `knowledgeConfig`); per-generate `reasoning` body field replaces it (object replace, not merge)
+- ✅ Reflect flow inside the generation pipeline (`maybeApplyReflectionToResult` hooked before the completion result is built, so the trace, completion event, and API response all carry the final text): draft → critique → revise, with an APPROVED short-circuit that skips the revision call when the critique finds nothing to improve
+- ✅ **`critique` override block** `{ ai_provider_id?, model?, prompt? }` — same triple, resolution, and project-scope validation as `knowledge_config.extraction`, via the shared `resolveCompletionModel()`
+- ✅ Critique/revision calls are plain completions (no tools); the outcome is recorded on the generation record's `metadata.reasoning` (`{ mode, applied, reason }`)
+- ✅ Tests: pipeline wiring (providerOptions forwarding, text replacement, fallback), reflect orchestration (override routing, APPROVED, failure degradation), real-execution completion boundary, REST config round-trip
+- **Scope notes:** reflect applies to non-streaming completed generations; streaming and `requires_action` (client-tool) continuations are skipped. When reflection rewrites the text, the draft's `responseMessages` are dropped so conversation replay does not resurrect the draft.
 
 **Unlocks:** "Think before you answer" on any existing agent with one config field.
 

--- a/packages/postgresdb/src/models/Agent.ts
+++ b/packages/postgresdb/src/models/Agent.ts
@@ -90,6 +90,9 @@ export class Agent extends Model {
   @Column({ type: DataType.JSONB, allowNull: true })
   declare knowledgeConfig: object | null;
 
+  @Column({ type: DataType.JSONB, allowNull: true })
+  declare reasoningConfig: object | null;
+
   @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: false })
   declare singleSessionPerActor: boolean;
 

--- a/packages/server/src/lib/agentGeneration.ts
+++ b/packages/server/src/lib/agentGeneration.ts
@@ -32,6 +32,11 @@ import {
 } from './generationInputMessages';
 import { recordGenerationFailure } from './generationLifecycle';
 import { createGenerationRecord } from './generations';
+import {
+  type ProviderOptionsMap,
+  type ReasoningConfig,
+  resolveReasoningForContext,
+} from './reasoning';
 
 const log = createDebug('soat:generation');
 
@@ -47,6 +52,9 @@ type GenerationContext = {
   generationId: string;
   toolContext?: Record<string, string> | null;
   remainingDepth?: number | null;
+  reasoningConfig?: ReasoningConfig | null;
+  providerOptions?: ProviderOptionsMap;
+  maxOutputTokens?: number;
 };
 
 const buildKnowledgeTools = (args: {
@@ -79,13 +87,44 @@ const resolveGenerationModel = async (args: {
     );
   }
 
-  return buildModel({
+  const model = await buildModel({
     provider: resolved.provider,
     secretValue: resolved.secretValue,
     model: args.typedAgent.model ?? resolved.defaultModel,
     baseUrl: resolved.baseUrl,
     config: resolved.config as Record<string, unknown> | undefined,
   });
+
+  return { model, provider: resolved.provider };
+};
+
+const assembleContextMessages = async (args: {
+  agentId: string;
+  projectIds?: number[];
+  typedAgent: TypedAgent;
+  resolvedMessages: Array<{ role: string; content: unknown }>;
+}): Promise<Array<{ role: string; content: unknown }>> => {
+  const knowledgeMessages = await buildKnowledgeMessages({
+    knowledgeConfig: args.typedAgent.knowledgeConfig,
+    projectIds: args.projectIds,
+    messages: args.resolvedMessages,
+  });
+
+  log(
+    'assembleContextMessages: agentId=%s knowledgeMessages=%d userMessages=%d',
+    args.agentId,
+    knowledgeMessages.length,
+    args.resolvedMessages.length
+  );
+
+  const allMessages = buildAllMessages(args.typedAgent.instructions, [
+    ...knowledgeMessages,
+    ...args.resolvedMessages,
+  ]);
+
+  log('assembleContextMessages: allMessages=%o', allMessages);
+
+  return allMessages;
 };
 
 const buildGenerationContext = async (args: {
@@ -99,6 +138,7 @@ const buildGenerationContext = async (args: {
   parentTraceId?: string | null;
   rootTraceId?: string | null;
   remainingDepth?: number;
+  reasoning?: object;
 }): Promise<GenerationContext> => {
   const typedAgent = await resolveAgentForGeneration({
     agentId: args.agentId,
@@ -121,9 +161,15 @@ const buildGenerationContext = async (args: {
       : undefined,
     agentBoundaryPolicy: typedAgent.boundaryPolicy,
   });
-  const model = await resolveGenerationModel({
+  const { model, provider } = await resolveGenerationModel({
     agentId: args.agentId,
     typedAgent,
+  });
+
+  const { reasoningConfig, reasoningOptions } = resolveReasoningForContext({
+    typedAgent,
+    override: args.reasoning,
+    provider,
   });
 
   const resolvedTools = typedAgent.toolIds
@@ -142,25 +188,12 @@ const buildGenerationContext = async (args: {
 
   buildKnowledgeTools({ typedAgent, resolvedTools });
 
-  const knowledgeMessages = await buildKnowledgeMessages({
-    knowledgeConfig: typedAgent.knowledgeConfig,
+  const allMessages = await assembleContextMessages({
+    agentId: args.agentId,
     projectIds: args.projectIds,
-    messages: resolvedMessages,
+    typedAgent,
+    resolvedMessages,
   });
-
-  log(
-    'buildGenerationContext: agentId=%s knowledgeMessages=%d userMessages=%d',
-    args.agentId,
-    knowledgeMessages.length,
-    resolvedMessages.length
-  );
-
-  const allMessages = buildAllMessages(typedAgent.instructions, [
-    ...knowledgeMessages,
-    ...resolvedMessages,
-  ]);
-
-  log('buildGenerationContext: allMessages=%o', allMessages);
 
   return {
     typedAgent,
@@ -170,6 +203,9 @@ const buildGenerationContext = async (args: {
     generationId: generatePublicId(PUBLIC_ID_PREFIXES.generation),
     toolContext: args.toolContext ?? null,
     remainingDepth: args.remainingDepth ?? null,
+    reasoningConfig,
+    providerOptions: reasoningOptions?.providerOptions,
+    maxOutputTokens: reasoningOptions?.maxOutputTokens,
   };
 };
 
@@ -195,6 +231,8 @@ const dispatchGeneration = (args: {
       agentId: args.agentId,
       parentTraceId: args.parentTraceId ?? null,
       rootTraceId: args.rootTraceId ?? null,
+      providerOptions: args.ctx.providerOptions,
+      maxOutputTokens: args.ctx.maxOutputTokens,
     });
     return Promise.resolve(stream);
   }
@@ -211,6 +249,9 @@ const dispatchGeneration = (args: {
     abortSignal: args.abortSignal,
     toolContext: args.ctx.toolContext ?? null,
     remainingDepth: args.ctx.remainingDepth ?? null,
+    providerOptions: args.ctx.providerOptions,
+    maxOutputTokens: args.ctx.maxOutputTokens,
+    reasoningConfig: args.ctx.reasoningConfig,
   });
 };
 
@@ -226,6 +267,7 @@ const resolveContextAndRecord = async (args: {
   rootTraceId?: string | null;
   initiatorGenerationId?: string | null;
   remainingDepth?: number;
+  reasoning?: object;
 }): Promise<GenerationContext> => {
   const ctx = await buildGenerationContext({
     agentId: args.agentId,
@@ -238,6 +280,7 @@ const resolveContextAndRecord = async (args: {
     parentTraceId: args.parentTraceId,
     rootTraceId: args.rootTraceId,
     remainingDepth: args.remainingDepth,
+    reasoning: args.reasoning,
   });
 
   // Awaited so the record reliably exists before the generation runs and a
@@ -275,6 +318,7 @@ export const createGeneration = async (args: {
   authUser?: AuthUser;
   toolContext?: Record<string, string>;
   abortSignal?: AbortSignal;
+  reasoning?: object;
 }): Promise<GenerationResult | ReadableStream> => {
   const maxDepth = args.remainingDepth ?? 10;
   const traceId = args.traceId ?? generatePublicId(PUBLIC_ID_PREFIXES.trace);
@@ -314,6 +358,7 @@ export const createGeneration = async (args: {
     rootTraceId: args.rootTraceId,
     initiatorGenerationId: args.initiatorGenerationId,
     remainingDepth: maxDepth,
+    reasoning: args.reasoning,
   });
 
   log('createGeneration: agentId=%s stream=%s', args.agentId, args.stream);

--- a/packages/server/src/lib/agentGenerationHelpers.ts
+++ b/packages/server/src/lib/agentGenerationHelpers.ts
@@ -4,6 +4,7 @@ import createDebug from 'debug';
 
 import { emitEvent } from './eventBus';
 import { updateGenerationRecord } from './generations';
+import type { ProviderOptionsMap } from './reasoning';
 import { saveTrace, serializeSteps } from './traces';
 
 const log = createDebug('soat:generation');
@@ -73,6 +74,7 @@ export type TypedAgent = {
   boundaryPolicy: unknown;
   temperature: unknown;
   knowledgeConfig: unknown;
+  reasoningConfig: unknown;
   project: { id: unknown; publicId: string };
   aiProvider: { publicId: string };
 };
@@ -142,6 +144,8 @@ export const runStreamGeneration = (args: {
   agentId: string;
   parentTraceId?: string | null;
   rootTraceId?: string | null;
+  providerOptions?: ProviderOptionsMap;
+  maxOutputTokens?: number;
 }): ReadableStream => {
   const system = args.allMessages.find((m) => {
     return m.role === 'system';
@@ -176,6 +180,8 @@ export const runStreamGeneration = (args: {
     prepareStep,
     stopWhen: stepCountIs((args.typedAgent.maxSteps as number) ?? 20),
     temperature: (args.typedAgent.temperature as number) ?? undefined,
+    providerOptions: args.providerOptions,
+    maxOutputTokens: args.maxOutputTokens,
     onFinish: ({ steps, finishReason }) => {
       saveTrace({
         traceId: args.traceId,

--- a/packages/server/src/lib/agentNonStreamGeneration.ts
+++ b/packages/server/src/lib/agentNonStreamGeneration.ts
@@ -15,6 +15,11 @@ import {
   recordGenerationFailure,
 } from './generationLifecycle';
 import { toProviderDomainError } from './providerError';
+import {
+  maybeApplyReflectionToResult,
+  type ProviderOptionsMap,
+  type ReasoningConfig,
+} from './reasoning';
 
 const log = createDebug('soat:generation');
 
@@ -79,6 +84,8 @@ const callGenerateText = async (args: {
   typedAgent: TypedAgent;
   prepareStep: ReturnType<typeof buildPrepareStep>;
   abortSignal?: AbortSignal;
+  providerOptions?: ProviderOptionsMap;
+  maxOutputTokens?: number;
 }) => {
   const hasTools = Object.keys(args.resolvedTools).length > 0;
 
@@ -98,6 +105,8 @@ const callGenerateText = async (args: {
       stopWhen: stepCountIs((args.typedAgent.maxSteps as number) ?? 20),
       temperature: (args.typedAgent.temperature as number) ?? undefined,
       abortSignal: args.abortSignal,
+      providerOptions: args.providerOptions,
+      maxOutputTokens: args.maxOutputTokens,
     });
   } catch (error) {
     log(
@@ -131,6 +140,7 @@ const resolveGenerationResult = async (args: {
   result: GenerateTextResult;
   toolContext?: Record<string, string> | null;
   remainingDepth?: number | null;
+  reasoningConfig?: ReasoningConfig | null;
 }): Promise<GenerationResult> => {
   const pendingToolCalls = findPendingClientTools(
     args.result.steps as Array<{
@@ -166,6 +176,18 @@ const resolveGenerationResult = async (args: {
     });
   }
 
+  // Reflect mode (deep thinking): critique and revise the draft BEFORE the
+  // completion result is built, so the trace, the completion event, and the
+  // API response all carry the final text.
+  await maybeApplyReflectionToResult({
+    reasoningConfig: args.reasoningConfig,
+    agentId: args.agentId,
+    generationId: args.generationId,
+    messages: args.allMessages,
+    result: args.result,
+    temperature: args.typedAgent.temperature as number | null,
+  });
+
   return buildCompletedGenerationResult({
     generationId: args.generationId,
     traceId: args.traceId,
@@ -190,6 +212,9 @@ export const runNonStreamGeneration = async (args: {
   abortSignal?: AbortSignal;
   toolContext?: Record<string, string> | null;
   remainingDepth?: number | null;
+  providerOptions?: ProviderOptionsMap;
+  maxOutputTokens?: number;
+  reasoningConfig?: ReasoningConfig | null;
 }): Promise<GenerationResult> => {
   const system = args.allMessages.find((message) => {
     return message.role === 'system';
@@ -218,6 +243,8 @@ export const runNonStreamGeneration = async (args: {
     typedAgent: args.typedAgent,
     prepareStep,
     abortSignal: args.abortSignal,
+    providerOptions: args.providerOptions,
+    maxOutputTokens: args.maxOutputTokens,
   };
 
   let result;
@@ -295,6 +322,7 @@ const buildTypedAgentFromPending = (pending: PendingGeneration): TypedAgent => {
     boundaryPolicy: null,
     temperature: pending.agentConfig.temperature,
     knowledgeConfig: null,
+    reasoningConfig: null,
     project: { id: pending.projectId, publicId: pending.projectPublicId },
     aiProvider: { publicId: '' },
   };

--- a/packages/server/src/lib/agents.ts
+++ b/packages/server/src/lib/agents.ts
@@ -28,6 +28,7 @@ export type MappedAgent = {
   boundaryPolicy: object | null;
   temperature: number | null;
   knowledgeConfig: object | null;
+  reasoning: object | null;
   maxContextMessages: number | null;
   singleSessionPerActor: boolean;
   createdAt: Date;
@@ -65,6 +66,7 @@ const mapAgent = (
     boundaryPolicy: agent.boundaryPolicy,
     temperature: agent.temperature,
     knowledgeConfig: agent.knowledgeConfig,
+    reasoning: agent.reasoningConfig,
     maxContextMessages: agent.maxContextMessages,
     singleSessionPerActor: agent.singleSessionPerActor,
     createdAt: agent.createdAt,
@@ -88,6 +90,7 @@ type AgentUpdateFields = {
   boundaryPolicy?: object | null;
   temperature?: number | null;
   knowledgeConfig?: object | null;
+  reasoningConfig?: object | null;
   maxContextMessages?: number | null;
   singleSessionPerActor?: boolean;
 };
@@ -105,6 +108,7 @@ const AGENT_SCALAR_FIELDS = [
   'boundaryPolicy',
   'temperature',
   'knowledgeConfig',
+  'reasoningConfig',
   'maxContextMessages',
   'singleSessionPerActor',
 ] as const;
@@ -143,6 +147,7 @@ export const createAgent = async (args: {
   boundaryPolicy?: object;
   temperature?: number;
   knowledgeConfig?: object;
+  reasoningConfig?: object;
   maxContextMessages?: number;
   singleSessionPerActor?: boolean;
 }): Promise<MappedAgent> => {

--- a/packages/server/src/lib/completionModel.ts
+++ b/packages/server/src/lib/completionModel.ts
@@ -1,0 +1,90 @@
+import type { LanguageModel } from 'ai';
+import createDebug from 'debug';
+import { resolveAiProviderSecret } from 'src/lib/aiProviders';
+
+import { db } from '../db';
+import { DomainError } from '../errors';
+import { resolveAgentForGeneration } from './agentGenerationRecovery';
+import { buildModel } from './agentModel';
+
+const log = createDebug('soat:completion-model');
+
+/**
+ * Resolves a LanguageModel for an internal system completion (memory
+ * extraction, reasoning critique/revision, future deliberation perspectives)
+ * anchored to an agent.
+ *
+ * By default the agent's own AI provider and model are used. `aiProviderId`
+ * switches to another provider — which must belong to the agent's project,
+ * otherwise the config could borrow another project's provider secret — and
+ * its `default_model` becomes the model fallback. `model` overrides the
+ * model name directly.
+ */
+export const resolveCompletionModel = async (args: {
+  agentId: string;
+  projectIds?: number[];
+  aiProviderId?: string;
+  model?: string;
+}): Promise<{ model: LanguageModel; modelName: string; provider: string }> => {
+  const typedAgent = await resolveAgentForGeneration({
+    agentId: args.agentId,
+    projectIds: args.projectIds,
+  });
+
+  if (!typedAgent) {
+    throw new DomainError(
+      'RESOURCE_NOT_FOUND',
+      `Agent '${args.agentId}' not found.`
+    );
+  }
+
+  if (args.aiProviderId) {
+    const override = await db.AiProvider.findOne({
+      where: {
+        publicId: args.aiProviderId,
+        projectId: typedAgent.project.id as number,
+      },
+    });
+    if (!override) {
+      throw new DomainError(
+        'AI_PROVIDER_NOT_FOUND',
+        `AI provider '${args.aiProviderId}' not found in the agent's project.`
+      );
+    }
+  }
+
+  const providerId = args.aiProviderId ?? typedAgent.aiProvider.publicId;
+  const resolved = await resolveAiProviderSecret({ aiProviderId: providerId });
+
+  if (!resolved) {
+    throw new DomainError(
+      'AI_PROVIDER_NOT_FOUND',
+      `AI provider for agent '${args.agentId}' could not be resolved.`
+    );
+  }
+
+  // With a provider override, the agent's model name is likely meaningless on
+  // the other provider — fall back to that provider's default_model instead.
+  const modelName =
+    args.model ??
+    (args.aiProviderId
+      ? resolved.defaultModel
+      : (typedAgent.model ?? resolved.defaultModel));
+
+  log(
+    'resolveCompletionModel: agentId=%s providerId=%s model=%s',
+    args.agentId,
+    providerId,
+    modelName
+  );
+
+  const model = await buildModel({
+    provider: resolved.provider,
+    secretValue: resolved.secretValue,
+    model: modelName,
+    baseUrl: resolved.baseUrl,
+    config: resolved.config as Record<string, unknown> | undefined,
+  });
+
+  return { model, modelName, provider: resolved.provider };
+};

--- a/packages/server/src/lib/formation-modules/agentsFormationModule.ts
+++ b/packages/server/src/lib/formation-modules/agentsFormationModule.ts
@@ -89,6 +89,7 @@ const mapAgentProperties = (properties: Record<string, unknown>) => {
       properties.single_session_per_actor
     ),
     knowledgeConfig: toOptional(toNullableObject(properties.knowledge_config)),
+    reasoningConfig: toOptional(toNullableObject(properties.reasoning)),
   };
 };
 
@@ -157,6 +158,7 @@ export const agentsFormationModule: FormationModule = {
         properties.single_session_per_actor
       ),
       knowledgeConfig: toNullableObject(properties.knowledge_config),
+      reasoningConfig: toNullableObject(properties.reasoning),
     });
   },
 
@@ -183,6 +185,7 @@ export const agentsFormationModule: FormationModule = {
         max_context_messages: agent.maxContextMessages,
         single_session_per_actor: agent.singleSessionPerActor,
         knowledge_config: agent.knowledgeConfig,
+        reasoning: agent.reasoning,
       };
     } catch {
       return null;

--- a/packages/server/src/lib/reasoning.ts
+++ b/packages/server/src/lib/reasoning.ts
@@ -1,0 +1,357 @@
+import type { JSONValue } from 'ai';
+import createDebug from 'debug';
+
+import { db } from '../db';
+import { updateGenerationRecord } from './generations';
+import * as reasoningCompletion from './reasoningCompletion';
+
+const log = createDebug('soat:reasoning');
+
+export type ReasoningEffort = 'low' | 'medium' | 'high';
+
+export type ReasoningOverrideTriple = {
+  aiProviderId?: string;
+  model?: string;
+  prompt?: string;
+};
+
+export type ReasoningConfig = {
+  /** Provider-native reasoning effort, forwarded to providers that support it. */
+  effort?: ReasoningEffort;
+  /** Orchestrated reasoning strategy. Defaults to none. */
+  mode?: 'none' | 'reflect';
+  /** Reflect only — overrides for the critique pass. */
+  critique?: ReasoningOverrideTriple;
+};
+
+export type ReasoningMessage = { role: string; content: unknown };
+
+/**
+ * Resolves the effective reasoning config: the per-generate override replaces
+ * the agent config entirely (object replace, not deep merge). Returns null
+ * when reasoning is not configured or explicitly disabled.
+ */
+export const resolveReasoningConfig = (args: {
+  agentConfig?: unknown;
+  override?: unknown;
+}): ReasoningConfig | null => {
+  const candidate = args.override ?? args.agentConfig;
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    return null;
+  }
+  const config = candidate as ReasoningConfig;
+  if (config.mode === 'none' && !config.effort) return null;
+  if (!config.mode && !config.effort && !config.critique) return null;
+  return config;
+};
+
+const EFFORT_BUDGET_TOKENS: Record<ReasoningEffort, number> = {
+  low: 4096,
+  medium: 16384,
+  high: 32768,
+};
+
+export type ProviderOptionsMap = Record<string, Record<string, JSONValue>>;
+
+export type ReasoningProviderOptions = {
+  providerOptions: ProviderOptionsMap;
+  /** Anthropic requires max_tokens to exceed the thinking budget. */
+  maxOutputTokens?: number;
+};
+
+/**
+ * Maps the normalized `effort` level to provider-native reasoning options.
+ * Returns undefined for providers without a supported mapping — the effort
+ * field is then a no-op rather than an error.
+ */
+export const buildReasoningProviderOptions = (args: {
+  provider: string;
+  effort?: ReasoningEffort;
+}): ReasoningProviderOptions | undefined => {
+  const budget = args.effort ? EFFORT_BUDGET_TOKENS[args.effort] : undefined;
+  if (!args.effort || !budget) return undefined;
+
+  if (args.provider === 'openai') {
+    return { providerOptions: { openai: { reasoningEffort: args.effort } } };
+  }
+  if (args.provider === 'anthropic') {
+    return {
+      providerOptions: {
+        anthropic: { thinking: { type: 'enabled', budgetTokens: budget } },
+      },
+      maxOutputTokens: budget + 8192,
+    };
+  }
+  if (args.provider === 'google') {
+    return {
+      providerOptions: {
+        google: { thinkingConfig: { thinkingBudget: budget } },
+      },
+    };
+  }
+
+  log(
+    'buildReasoningProviderOptions: no mapping provider=%s effort=%s',
+    args.provider,
+    args.effort
+  );
+  return undefined;
+};
+
+/**
+ * Resolves the effective reasoning config and provider-native options for a
+ * generation context in one step.
+ */
+export const resolveReasoningForContext = (args: {
+  typedAgent: { reasoningConfig: unknown };
+  override?: object;
+  provider: string;
+}) => {
+  const reasoningConfig = resolveReasoningConfig({
+    agentConfig: args.typedAgent.reasoningConfig,
+    override: args.override,
+  });
+  const reasoningOptions = buildReasoningProviderOptions({
+    provider: args.provider,
+    effort: reasoningConfig?.effort,
+  });
+  return { reasoningConfig, reasoningOptions };
+};
+
+const DEFAULT_CRITIQUE_INSTRUCTIONS = [
+  'You are reviewing a draft answer. Identify factual errors, gaps, unsupported claims, and weaknesses in the reasoning.',
+  'Be specific and concise.',
+].join('\n');
+
+const formatQuestion = (messages: ReasoningMessage[]): string => {
+  return messages
+    .filter((message) => {
+      return (
+        (message.role === 'user' || message.role === 'assistant') &&
+        typeof message.content === 'string' &&
+        (message.content as string).trim().length > 0
+      );
+    })
+    .map((message) => {
+      return `${message.role}: ${message.content as string}`;
+    })
+    .join('\n');
+};
+
+const buildCritiquePrompt = (args: {
+  question: string;
+  draft: string;
+  instructions?: string;
+}): string => {
+  // A custom prompt replaces only the critique instructions; the
+  // engine-owned scaffolding (question, draft, APPROVED contract) is kept.
+  return [
+    args.instructions ?? DEFAULT_CRITIQUE_INSTRUCTIONS,
+    'Reply with exactly APPROVED and nothing else if no meaningful improvement is possible.',
+    '',
+    'Question:',
+    args.question,
+    '',
+    'Draft answer:',
+    args.draft,
+  ].join('\n');
+};
+
+const buildRevisionPrompt = (args: {
+  question: string;
+  draft: string;
+  critique: string;
+}): string => {
+  return [
+    'Improve the draft answer using the critique. Respond with the final answer only — no preamble, no commentary about the revision.',
+    '',
+    'Question:',
+    args.question,
+    '',
+    'Draft answer:',
+    args.draft,
+    '',
+    'Critique:',
+    args.critique,
+  ].join('\n');
+};
+
+const isApproved = (critique: string): boolean => {
+  const trimmed = critique.trim();
+  return trimmed === 'APPROVED' || trimmed === 'APPROVED.';
+};
+
+export type ReflectionResult = {
+  text: string;
+  /** True when the returned text differs from the draft. */
+  applied: boolean;
+  reason:
+    | 'revised'
+    | 'approved'
+    | 'skipped'
+    | 'critique_failed'
+    | 'revision_failed';
+};
+
+const runRevision = async (args: {
+  agentId: string;
+  projectIds?: number[];
+  question: string;
+  draft: string;
+  critique: string;
+  temperature?: number | null;
+}): Promise<ReflectionResult> => {
+  try {
+    const revised = await reasoningCompletion.runReasoningCompletion({
+      agentId: args.agentId,
+      projectIds: args.projectIds,
+      prompt: buildRevisionPrompt({
+        question: args.question,
+        draft: args.draft,
+        critique: args.critique,
+      }),
+      temperature: args.temperature ?? undefined,
+    });
+    if (revised.trim().length === 0) {
+      return { text: args.draft, applied: false, reason: 'revision_failed' };
+    }
+    log('runRevision: revised agentId=%s', args.agentId);
+    return { text: revised, applied: true, reason: 'revised' };
+  } catch (error) {
+    log(
+      'runRevision: failed agentId=%s error=%s',
+      args.agentId,
+      error instanceof Error ? error.message : String(error)
+    );
+    return { text: args.draft, applied: false, reason: 'revision_failed' };
+  }
+};
+
+/**
+ * Reflect mode: critique the draft, then revise it. Failures and approvals
+ * fall back to the draft — reflection must never make a generation worse or
+ * fail a request that already has an answer.
+ */
+export const applyReflection = async (args: {
+  agentId: string;
+  projectIds?: number[];
+  reasoning: ReasoningConfig;
+  messages: ReasoningMessage[];
+  draft: string;
+  temperature?: number | null;
+}): Promise<ReflectionResult> => {
+  if (args.reasoning.mode !== 'reflect' || args.draft.trim().length === 0) {
+    return { text: args.draft, applied: false, reason: 'skipped' };
+  }
+
+  const question = formatQuestion(args.messages);
+  const critiqueOverride = args.reasoning.critique ?? {};
+
+  let critique: string;
+  try {
+    critique = await reasoningCompletion.runReasoningCompletion({
+      agentId: args.agentId,
+      projectIds: args.projectIds,
+      aiProviderId: critiqueOverride.aiProviderId,
+      model: critiqueOverride.model,
+      prompt: buildCritiquePrompt({
+        question,
+        draft: args.draft,
+        instructions: critiqueOverride.prompt,
+      }),
+    });
+  } catch (error) {
+    log(
+      'applyReflection: critique failed agentId=%s error=%s',
+      args.agentId,
+      error instanceof Error ? error.message : String(error)
+    );
+    return { text: args.draft, applied: false, reason: 'critique_failed' };
+  }
+
+  if (isApproved(critique)) {
+    log('applyReflection: draft approved agentId=%s', args.agentId);
+    return { text: args.draft, applied: false, reason: 'approved' };
+  }
+
+  return runRevision({ ...args, question, critique });
+};
+
+export const recordReasoningSummary = async (args: {
+  generationId: string;
+  summary: { mode: string; applied: boolean; reason: string };
+}): Promise<void> => {
+  try {
+    const generation = await db.Generation.findOne({
+      where: { publicId: args.generationId },
+    });
+    if (!generation) return;
+    await updateGenerationRecord({
+      publicId: args.generationId,
+      metadata: {
+        ...(generation.metadata ?? {}),
+        reasoning: args.summary,
+      },
+    });
+  } catch (error) {
+    log(
+      'recordReasoningSummary: failed generationId=%s error=%s',
+      args.generationId,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+};
+
+type ReflectableResult = {
+  text: string;
+  response?: { messages?: Array<unknown>; modelId?: string };
+};
+
+/**
+ * Pipeline hook: applies reflect mode to a completed raw generation result
+ * in place — the trace, completion event, and API response are all built
+ * from the final text afterwards. Records the outcome on the generation
+ * record's `metadata.reasoning` (fire-and-forget).
+ */
+export const maybeApplyReflectionToResult = async (args: {
+  reasoningConfig?: ReasoningConfig | null;
+  agentId: string;
+  generationId: string;
+  messages: ReasoningMessage[];
+  result: ReflectableResult;
+  temperature?: number | null;
+}): Promise<void> => {
+  if (args.reasoningConfig?.mode !== 'reflect') return;
+
+  const reflection = await applyReflection({
+    agentId: args.agentId,
+    reasoning: args.reasoningConfig,
+    messages: args.messages,
+    draft: args.result.text,
+    temperature: args.temperature,
+  });
+
+  if (reflection.applied) {
+    args.result.text = reflection.text;
+    // The draft's responseMessages no longer match the final text — drop
+    // them so conversation replay does not resurrect the draft.
+    if (args.result.response) {
+      args.result.response = { ...args.result.response, messages: undefined };
+    }
+  }
+
+  void recordReasoningSummary({
+    generationId: args.generationId,
+    summary: {
+      mode: 'reflect',
+      applied: reflection.applied,
+      reason: reflection.reason,
+    },
+  });
+};
+
+/**
+ * Records the reflection outcome on the generation record's metadata
+ * (merged, fire-and-forget) — same observability pattern as
+ * `metadata.extraction`.
+ */

--- a/packages/server/src/lib/reasoningCompletion.ts
+++ b/packages/server/src/lib/reasoningCompletion.ts
@@ -3,26 +3,23 @@ import createDebug from 'debug';
 
 import { resolveCompletionModel } from './completionModel';
 
-const log = createDebug('soat:memory-extraction');
+const log = createDebug('soat:reasoning');
 
 /**
- * Runs the fact-extraction completion as a plain text completion — no tools,
- * no knowledge injection — so the extraction prompt cannot trigger agent side
+ * Runs a reasoning step (critique or revision) as a plain text completion —
+ * no tools, no knowledge injection — so reflection cannot trigger agent side
  * effects.
  *
- * Provider/model resolution (including the project-scope check for
- * `aiProviderId` overrides) is shared with the reasoning completions via
- * `resolveCompletionModel`.
- *
  * Kept in its own module so tests can replace the LLM boundary with
- * `jest.spyOn` while the orchestration in `memoryExtraction.ts` runs for real.
+ * `jest.spyOn` while the orchestration in `reasoning.ts` runs for real.
  */
-export const runExtractionCompletion = async (args: {
+export const runReasoningCompletion = async (args: {
   agentId: string;
   projectIds?: number[];
   prompt: string;
   aiProviderId?: string;
   model?: string;
+  temperature?: number;
 }): Promise<string> => {
   const { model, modelName } = await resolveCompletionModel({
     agentId: args.agentId,
@@ -31,12 +28,12 @@ export const runExtractionCompletion = async (args: {
     model: args.model,
   });
 
-  log('runExtractionCompletion: agentId=%s model=%s', args.agentId, modelName);
+  log('runReasoningCompletion: agentId=%s model=%s', args.agentId, modelName);
 
   const { text } = await generateText({
     model,
     prompt: args.prompt,
-    temperature: 0,
+    temperature: args.temperature ?? 0,
   });
 
   return text;

--- a/packages/server/src/rest/openapi/v1/agents.yaml
+++ b/packages/server/src/rest/openapi/v1/agents.yaml
@@ -577,6 +577,32 @@ components:
                     prompt:
                       type: string
                       description: Replaces the default task instructions. The JSON response contract and the conversation transcript are always appended by the server.
+        reasoning:
+          type: object
+          nullable: true
+          description: 'Deep-thinking configuration. `effort` forwards provider-native reasoning options; `mode: reflect` runs a draft-critique-revise loop before returning the answer.'
+          properties:
+            effort:
+              type: string
+              enum: [low, medium, high]
+              description: Provider-native reasoning effort, forwarded to providers that support it (OpenAI reasoning models, Anthropic extended thinking, Google thinking budgets). Ignored elsewhere.
+            mode:
+              type: string
+              enum: [none, reflect]
+              description: Orchestrated reasoning strategy. `reflect` drafts an answer, critiques it, and revises it before responding. Applies to non-streaming completed generations only.
+            critique:
+              type: object
+              description: Overrides for the reflect critique pass.
+              properties:
+                ai_provider_id:
+                  type: string
+                  description: AI provider override for the critique call. Must belong to the agent's project. Its default_model becomes the model fallback.
+                model:
+                  type: string
+                  description: Model override for the critique call.
+                prompt:
+                  type: string
+                  description: Replaces the default critique instructions. The question, draft, and approval contract are always appended by the server.
         max_context_messages:
           type: integer
           nullable: true
@@ -677,6 +703,32 @@ components:
                     prompt:
                       type: string
                       description: Replaces the default task instructions. The JSON response contract and the conversation transcript are always appended by the server.
+        reasoning:
+          type: object
+          nullable: true
+          description: 'Deep-thinking configuration. `effort` forwards provider-native reasoning options; `mode: reflect` runs a draft-critique-revise loop before returning the answer.'
+          properties:
+            effort:
+              type: string
+              enum: [low, medium, high]
+              description: Provider-native reasoning effort, forwarded to providers that support it (OpenAI reasoning models, Anthropic extended thinking, Google thinking budgets). Ignored elsewhere.
+            mode:
+              type: string
+              enum: [none, reflect]
+              description: Orchestrated reasoning strategy. `reflect` drafts an answer, critiques it, and revises it before responding. Applies to non-streaming completed generations only.
+            critique:
+              type: object
+              description: Overrides for the reflect critique pass.
+              properties:
+                ai_provider_id:
+                  type: string
+                  description: AI provider override for the critique call. Must belong to the agent's project. Its default_model becomes the model fallback.
+                model:
+                  type: string
+                  description: Model override for the critique call.
+                prompt:
+                  type: string
+                  description: Replaces the default critique instructions. The question, draft, and approval contract are always appended by the server.
         max_context_messages:
           type: integer
           description: Maximum number of recent messages included in the context window. Null means no limit.
@@ -776,6 +828,32 @@ components:
                     prompt:
                       type: string
                       description: Replaces the default task instructions. The JSON response contract and the conversation transcript are always appended by the server.
+        reasoning:
+          type: object
+          nullable: true
+          description: 'Deep-thinking configuration. `effort` forwards provider-native reasoning options; `mode: reflect` runs a draft-critique-revise loop before returning the answer.'
+          properties:
+            effort:
+              type: string
+              enum: [low, medium, high]
+              description: Provider-native reasoning effort, forwarded to providers that support it (OpenAI reasoning models, Anthropic extended thinking, Google thinking budgets). Ignored elsewhere.
+            mode:
+              type: string
+              enum: [none, reflect]
+              description: Orchestrated reasoning strategy. `reflect` drafts an answer, critiques it, and revises it before responding. Applies to non-streaming completed generations only.
+            critique:
+              type: object
+              description: Overrides for the reflect critique pass.
+              properties:
+                ai_provider_id:
+                  type: string
+                  description: AI provider override for the critique call. Must belong to the agent's project. Its default_model becomes the model fallback.
+                model:
+                  type: string
+                  description: Model override for the critique call.
+                prompt:
+                  type: string
+                  description: Replaces the default critique instructions. The question, draft, and approval contract are always appended by the server.
         max_context_messages:
           type: integer
           nullable: true
@@ -841,6 +919,32 @@ components:
             type: string
           nullable: true
           description: Key-value pairs injected as context headers into all tool call requests made during this generation.
+        reasoning:
+          type: object
+          nullable: true
+          description: Per-generation deep-thinking override. Replaces the agent's stored reasoning config for this request (object replace, not merge). Same shape as the agent `reasoning` field.
+          properties:
+            effort:
+              type: string
+              enum: [low, medium, high]
+              description: Provider-native reasoning effort for this generation.
+            mode:
+              type: string
+              enum: [none, reflect]
+              description: Orchestrated reasoning strategy for this generation.
+            critique:
+              type: object
+              description: Overrides for the reflect critique pass.
+              properties:
+                ai_provider_id:
+                  type: string
+                  description: AI provider override for the critique call. Must belong to the agent's project.
+                model:
+                  type: string
+                  description: Model override for the critique call.
+                prompt:
+                  type: string
+                  description: Replaces the default critique instructions.
 
     ToolOutputMessageContent:
       type: object

--- a/packages/server/src/rest/openapi/v1/formations.yaml
+++ b/packages/server/src/rest/openapi/v1/formations.yaml
@@ -581,6 +581,32 @@ components:
                     prompt:
                       type: string
                       description: Replaces the default task instructions. The JSON response contract and the conversation transcript are always appended by the server.
+        reasoning:
+          type: object
+          nullable: true
+          description: 'Deep-thinking configuration. `effort` forwards provider-native reasoning options; `mode: reflect` runs a draft-critique-revise loop before returning the answer.'
+          properties:
+            effort:
+              type: string
+              enum: [low, medium, high]
+              description: Provider-native reasoning effort, forwarded to providers that support it.
+            mode:
+              type: string
+              enum: [none, reflect]
+              description: Orchestrated reasoning strategy.
+            critique:
+              type: object
+              description: Overrides for the reflect critique pass.
+              properties:
+                ai_provider_id:
+                  type: string
+                  description: AI provider override for the critique call. Must belong to the agent's project.
+                model:
+                  type: string
+                  description: Model override for the critique call.
+                prompt:
+                  type: string
+                  description: Replaces the default critique instructions.
 
     ActorResourceProperties:
       description: >-

--- a/packages/server/src/rest/v1/agentGeneration.ts
+++ b/packages/server/src/rest/v1/agentGeneration.ts
@@ -111,6 +111,7 @@ agentGenerationRouter.post(
       rootTraceId,
       maxCallDepth,
       toolContext,
+      reasoning,
     } = ctx.request.body as {
       messages?: unknown;
       stream?: boolean;
@@ -119,6 +120,7 @@ agentGenerationRouter.post(
       rootTraceId?: string;
       maxCallDepth?: unknown;
       toolContext?: Record<string, string>;
+      reasoning?: object;
     };
 
     if (!Array.isArray(messages) || messages.length === 0) {
@@ -142,6 +144,8 @@ agentGenerationRouter.post(
       authHeader: (ctx.headers.authorization as string) ?? '',
       authUser: ctx.authUser,
       toolContext,
+      reasoning:
+        reasoning && typeof reasoning === 'object' ? reasoning : undefined,
     });
 
     fireExtractionForCompletedResult({

--- a/packages/server/src/rest/v1/agents.ts
+++ b/packages/server/src/rest/v1/agents.ts
@@ -39,6 +39,7 @@ type CreateAgentBody = {
   boundaryPolicy?: unknown;
   temperature?: unknown;
   knowledgeConfig?: unknown;
+  reasoning?: unknown;
   maxContextMessages?: unknown;
   singleSessionPerActor?: unknown;
   projectId?: string;
@@ -74,6 +75,7 @@ const parseUpdateAgentBody = (body: Record<string, unknown>) => {
     boundaryPolicy: parseOptional<object | null>(body.boundaryPolicy),
     temperature: parseOptional<number | null>(body.temperature),
     knowledgeConfig: parseOptional<object | null>(body.knowledgeConfig),
+    reasoningConfig: parseOptional<object | null>(body.reasoning),
     maxContextMessages: parseOptional<number | null>(body.maxContextMessages),
     singleSessionPerActor:
       typeof body.singleSessionPerActor === 'boolean'
@@ -128,6 +130,7 @@ const buildCreateAgentArgs = (
     boundaryPolicy: body.boundaryPolicy as object | undefined,
     temperature: parseNumber(body.temperature),
     knowledgeConfig: body.knowledgeConfig as object | undefined,
+    reasoningConfig: body.reasoning as object | undefined,
     maxContextMessages: parseNumber(body.maxContextMessages),
     singleSessionPerActor:
       typeof body.singleSessionPerActor === 'boolean'

--- a/packages/server/tests/unit/tests/lib/agentGenerationHelpers.test.ts
+++ b/packages/server/tests/unit/tests/lib/agentGenerationHelpers.test.ts
@@ -160,6 +160,7 @@ const mockAgent: TypedAgent = {
   boundaryPolicy: null,
   temperature: null,
   knowledgeConfig: null,
+  reasoningConfig: null,
   project: { id: 1, publicId: 'prj_test123' },
   aiProvider: { publicId: 'aip_test123' },
 };

--- a/packages/server/tests/unit/tests/lib/reasoning.test.ts
+++ b/packages/server/tests/unit/tests/lib/reasoning.test.ts
@@ -1,0 +1,215 @@
+import {
+  applyReflection,
+  buildReasoningProviderOptions,
+  resolveReasoningConfig,
+} from 'src/lib/reasoning';
+import * as reasoningCompletionModule from 'src/lib/reasoningCompletion';
+
+const mockRunReasoningCompletion = jest.spyOn(
+  reasoningCompletionModule,
+  'runReasoningCompletion'
+);
+
+describe('reasoning lib', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('resolveReasoningConfig', () => {
+    test('returns the agent config when no override is given', () => {
+      expect(
+        resolveReasoningConfig({ agentConfig: { mode: 'reflect' } })
+      ).toEqual({ mode: 'reflect' });
+    });
+
+    test('the per-generate override replaces the agent config entirely', () => {
+      expect(
+        resolveReasoningConfig({
+          agentConfig: { mode: 'reflect', effort: 'high' },
+          override: { effort: 'low' },
+        })
+      ).toEqual({ effort: 'low' });
+    });
+
+    test('returns null when nothing is configured or mode is none', () => {
+      expect(resolveReasoningConfig({})).toBeNull();
+      expect(resolveReasoningConfig({ agentConfig: null })).toBeNull();
+      expect(
+        resolveReasoningConfig({ agentConfig: { mode: 'none' } })
+      ).toBeNull();
+    });
+
+    test('ignores non-object configs', () => {
+      expect(
+        resolveReasoningConfig({ agentConfig: 'reflect' as never })
+      ).toBeNull();
+    });
+  });
+
+  describe('buildReasoningProviderOptions', () => {
+    test('maps effort to openai reasoningEffort', () => {
+      expect(
+        buildReasoningProviderOptions({ provider: 'openai', effort: 'high' })
+      ).toEqual({
+        providerOptions: { openai: { reasoningEffort: 'high' } },
+      });
+    });
+
+    test('maps effort to anthropic thinking budget with raised output cap', () => {
+      const result = buildReasoningProviderOptions({
+        provider: 'anthropic',
+        effort: 'medium',
+      });
+      expect(result?.providerOptions.anthropic).toEqual({
+        thinking: { type: 'enabled', budgetTokens: 16384 },
+      });
+      // Anthropic requires max_tokens to exceed the thinking budget.
+      expect(result?.maxOutputTokens).toBeGreaterThan(16384);
+    });
+
+    test('maps effort to google thinking budget', () => {
+      expect(
+        buildReasoningProviderOptions({ provider: 'google', effort: 'low' })
+      ).toEqual({
+        providerOptions: {
+          google: { thinkingConfig: { thinkingBudget: 4096 } },
+        },
+      });
+    });
+
+    test('returns undefined for unsupported providers and missing effort', () => {
+      expect(
+        buildReasoningProviderOptions({ provider: 'ollama', effort: 'high' })
+      ).toBeUndefined();
+      expect(
+        buildReasoningProviderOptions({ provider: 'openai' })
+      ).toBeUndefined();
+      expect(
+        buildReasoningProviderOptions({
+          provider: 'openai',
+          effort: 'extreme' as never,
+        })
+      ).toBeUndefined();
+    });
+  });
+
+  describe('applyReflection', () => {
+    const baseArgs = {
+      agentId: 'agent_test01',
+      projectIds: [1],
+      messages: [{ role: 'user', content: 'What is the capital of France?' }],
+      draft: 'The capital of France is Lyon.',
+      temperature: null,
+    };
+
+    test('runs critique then revision and returns the revised text', async () => {
+      mockRunReasoningCompletion
+        .mockResolvedValueOnce('The draft names the wrong city; it is Paris.')
+        .mockResolvedValueOnce('The capital of France is Paris.');
+
+      const result = await applyReflection({
+        ...baseArgs,
+        reasoning: { mode: 'reflect' },
+      });
+
+      expect(result.applied).toBe(true);
+      expect(result.text).toBe('The capital of France is Paris.');
+      expect(mockRunReasoningCompletion).toHaveBeenCalledTimes(2);
+
+      const critiqueCall = mockRunReasoningCompletion.mock.calls[0][0];
+      expect(critiqueCall.prompt).toContain('What is the capital of France?');
+      expect(critiqueCall.prompt).toContain('The capital of France is Lyon.');
+
+      const reviseCall = mockRunReasoningCompletion.mock.calls[1][0];
+      expect(reviseCall.prompt).toContain(
+        'The draft names the wrong city; it is Paris.'
+      );
+    });
+
+    test('short-circuits without a revision call when the critique approves', async () => {
+      mockRunReasoningCompletion.mockResolvedValueOnce('APPROVED');
+
+      const result = await applyReflection({
+        ...baseArgs,
+        draft: 'The capital of France is Paris.',
+        reasoning: { mode: 'reflect' },
+      });
+
+      expect(result.applied).toBe(false);
+      expect(result.text).toBe('The capital of France is Paris.');
+      expect(mockRunReasoningCompletion).toHaveBeenCalledTimes(1);
+    });
+
+    test('routes the critique call through the critique override triple', async () => {
+      mockRunReasoningCompletion
+        .mockResolvedValueOnce('Needs more precision.')
+        .mockResolvedValueOnce('Revised answer.');
+
+      await applyReflection({
+        ...baseArgs,
+        reasoning: {
+          mode: 'reflect',
+          critique: {
+            aiProviderId: 'aip_cheap01',
+            model: 'tiny-critic',
+            prompt: 'Critique only factual accuracy.',
+          },
+        },
+      });
+
+      const critiqueCall = mockRunReasoningCompletion.mock.calls[0][0];
+      expect(critiqueCall.aiProviderId).toBe('aip_cheap01');
+      expect(critiqueCall.model).toBe('tiny-critic');
+      // The custom prompt replaces the default critique instructions...
+      expect(critiqueCall.prompt).toContain('Critique only factual accuracy.');
+      expect(critiqueCall.prompt).not.toContain('weaknesses');
+      // ...but the engine-owned scaffolding (question + draft) is kept.
+      expect(critiqueCall.prompt).toContain('What is the capital of France?');
+      expect(critiqueCall.prompt).toContain('The capital of France is Lyon.');
+
+      // The revision stays on the agent's own model.
+      const reviseCall = mockRunReasoningCompletion.mock.calls[1][0];
+      expect(reviseCall.aiProviderId).toBeUndefined();
+      expect(reviseCall.model).toBeUndefined();
+    });
+
+    test('returns the draft when the critique call fails', async () => {
+      mockRunReasoningCompletion.mockRejectedValueOnce(
+        new Error('provider down')
+      );
+
+      const result = await applyReflection({
+        ...baseArgs,
+        reasoning: { mode: 'reflect' },
+      });
+
+      expect(result.applied).toBe(false);
+      expect(result.text).toBe(baseArgs.draft);
+    });
+
+    test('returns the draft when the revision call fails', async () => {
+      mockRunReasoningCompletion
+        .mockResolvedValueOnce('The city is wrong.')
+        .mockRejectedValueOnce(new Error('provider down'));
+
+      const result = await applyReflection({
+        ...baseArgs,
+        reasoning: { mode: 'reflect' },
+      });
+
+      expect(result.applied).toBe(false);
+      expect(result.text).toBe(baseArgs.draft);
+    });
+
+    test('does nothing when mode is not reflect', async () => {
+      const result = await applyReflection({
+        ...baseArgs,
+        reasoning: { effort: 'high' },
+      });
+
+      expect(result.applied).toBe(false);
+      expect(result.text).toBe(baseArgs.draft);
+      expect(mockRunReasoningCompletion).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/server/tests/unit/tests/lib/reasoningCompletion.test.ts
+++ b/packages/server/tests/unit/tests/lib/reasoningCompletion.test.ts
@@ -108,6 +108,24 @@ describe('reasoningCompletion lib', () => {
     );
   });
 
+  test('defaults the temperature to 0 when not provided', async () => {
+    const agentRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/agents')
+      .send({
+        project_id: projectId,
+        ai_provider_id: aiProviderId,
+        name: 'ReasoningComplDefaultTempAgent',
+      });
+
+    const text = await runReasoningCompletion({
+      agentId: agentRes.body.id,
+      prompt: 'Critique deterministically.',
+    });
+
+    expect(text).toBe('critique text');
+    expect(lastRequestBody?.temperature).toBe(0);
+  });
+
   test('rejects a provider override from another project', async () => {
     const otherProjectRes = await authenticatedTestClient(adminToken)
       .post('/api/v1/projects')

--- a/packages/server/tests/unit/tests/lib/reasoningCompletion.test.ts
+++ b/packages/server/tests/unit/tests/lib/reasoningCompletion.test.ts
@@ -1,0 +1,140 @@
+import type { Server } from 'node:http';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { runReasoningCompletion } from 'src/lib/reasoningCompletion';
+
+import { authenticatedTestClient, loginAs, testClient } from '../../testClient';
+
+describe('reasoningCompletion lib', () => {
+  let adminToken: string;
+  let projectId: string;
+  let aiProviderId: string;
+  let stubServer: Server;
+  let lastRequestBody: Record<string, unknown> | undefined;
+
+  // Local OpenAI-compatible chat completions stub — the real generateText
+  // call runs end-to-end with no mocks (same pattern as
+  // memoryExtractionCompletion.test.ts).
+  const startStubServer = async (): Promise<string> => {
+    stubServer = createServer((req, res) => {
+      let raw = '';
+      req.on('data', (chunk) => {
+        raw += chunk;
+      });
+      req.on('end', () => {
+        lastRequestBody = JSON.parse(raw);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            id: 'chatcmpl-reason',
+            object: 'chat.completion',
+            created: 0,
+            model: 'stub-model',
+            choices: [
+              {
+                index: 0,
+                message: { role: 'assistant', content: 'critique text' },
+                finish_reason: 'stop',
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          })
+        );
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      stubServer.listen(0, '127.0.0.1', resolve);
+    });
+    const { port } = stubServer.address() as AddressInfo;
+    return `http://127.0.0.1:${port}`;
+  };
+
+  beforeAll(async () => {
+    const stubBaseUrl = await startStubServer();
+
+    await testClient
+      .post('/api/v1/users/bootstrap')
+      .send({ username: 'reasoningcompladmin', password: 'supersecret' });
+
+    adminToken = await loginAs('reasoningcompladmin', 'supersecret');
+
+    const projectRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/projects')
+      .send({ name: 'Reasoning Completion Project' });
+    projectId = projectRes.body.id;
+
+    const aiProvRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/ai-providers')
+      .send({
+        project_id: projectId,
+        name: 'ReasoningComplProvider',
+        provider: 'ollama',
+        default_model: 'reasoning-default-model',
+        base_url: stubBaseUrl,
+      });
+    aiProviderId = aiProvRes.body.id;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      stubServer.close((err) => {
+        return err ? reject(err) : resolve();
+      });
+    });
+  });
+
+  test('runs the prompt against the agent provider and returns the text', async () => {
+    const agentRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/agents')
+      .send({
+        project_id: projectId,
+        ai_provider_id: aiProviderId,
+        name: 'ReasoningComplAgent',
+      });
+
+    const text = await runReasoningCompletion({
+      agentId: agentRes.body.id,
+      prompt: 'Critique this draft.',
+      temperature: 0.3,
+    });
+
+    expect(text).toBe('critique text');
+    expect(lastRequestBody?.model).toBe('reasoning-default-model');
+    expect(lastRequestBody?.temperature).toBe(0.3);
+    expect(JSON.stringify(lastRequestBody?.messages)).toContain(
+      'Critique this draft.'
+    );
+  });
+
+  test('rejects a provider override from another project', async () => {
+    const otherProjectRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/projects')
+      .send({ name: 'Reasoning Foreign Project' });
+    const foreignProvRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/ai-providers')
+      .send({
+        project_id: otherProjectRes.body.id,
+        name: 'ReasoningForeignProvider',
+        provider: 'ollama',
+        default_model: 'foreign-model',
+      });
+
+    const agentRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/agents')
+      .send({
+        project_id: projectId,
+        ai_provider_id: aiProviderId,
+        name: 'ReasoningForeignAgent',
+      });
+
+    await expect(
+      runReasoningCompletion({
+        agentId: agentRes.body.id,
+        aiProviderId: foreignProvRes.body.id,
+        prompt: 'Critique.',
+      })
+    ).rejects.toMatchObject({ code: 'AI_PROVIDER_NOT_FOUND' });
+  });
+});

--- a/packages/server/tests/unit/tests/lib/reasoningPipeline.test.ts
+++ b/packages/server/tests/unit/tests/lib/reasoningPipeline.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Pipeline wiring tests for reasoning: providerOptions forwarding (P0) and
+ * reflect-mode text replacement (P1) inside runNonStreamGeneration.
+ *
+ * Uses the jest.doMock('ai') + resetModules pattern (see
+ * agentNonStreamGeneration.test.ts) because the 'ai' package itself is the
+ * boundary under test here.
+ */
+
+const loadNonStreamModule = async () => {
+  return import('src/lib/agentNonStreamGeneration');
+};
+
+const loadHelpersModule = async () => {
+  return import('src/lib/agentGenerationHelpers');
+};
+
+const loadReasoningCompletionModule = async () => {
+  return import('src/lib/reasoningCompletion');
+};
+
+const buildTypedAgent = (reasoningConfig: object | null) => {
+  return {
+    instructions: 'sys',
+    model: 'mock-model',
+    toolIds: null,
+    maxSteps: 3,
+    toolChoice: 'auto',
+    stopConditions: null,
+    activeToolIds: null,
+    stepRules: null,
+    boundaryPolicy: null,
+    temperature: null,
+    knowledgeConfig: null,
+    reasoningConfig,
+    project: { id: 1, publicId: 'prj_test' },
+    aiProvider: { publicId: 'aip_test' },
+  } as never;
+};
+
+// The pipeline mutates its result object during reflection, so every mock
+// call must return a fresh copy.
+const draftResult = () => {
+  return {
+    steps: [],
+    response: { messages: [], modelId: 'model-a' },
+    text: 'draft answer',
+    finishReason: 'stop',
+  };
+};
+
+describe('reasoning pipeline wiring', () => {
+  beforeEach(() => {
+    // The module under test is already in the registry (loaded by app.ts in
+    // setup); reset so jest.doMock('ai') applies to the dynamic import.
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.unmock('ai');
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+
+  test('forwards providerOptions and maxOutputTokens into generateText', async () => {
+    const generateTextMock = jest.fn().mockImplementation(draftResult);
+    jest.doMock('ai', () => {
+      const actual = jest.requireActual('ai');
+      return { ...actual, generateText: generateTextMock };
+    });
+
+    const { runNonStreamGeneration } = await loadNonStreamModule();
+    const helpersModule = await loadHelpersModule();
+    jest.spyOn(helpersModule, 'findPendingClientTools').mockReturnValue([]);
+    jest
+      .spyOn(helpersModule, 'buildCompletedGenerationResult')
+      .mockResolvedValue({
+        id: 'gen_1',
+        traceId: 'trc_1',
+        status: 'completed',
+        output: {
+          model: 'model-a',
+          content: 'draft answer',
+          finishReason: 'stop',
+        },
+      });
+
+    await runNonStreamGeneration({
+      model: {} as never,
+      allMessages: [{ role: 'user', content: 'hi' }],
+      resolvedTools: {},
+      typedAgent: buildTypedAgent(null),
+      generationId: 'gen_1',
+      traceId: 'trc_1',
+      agentId: 'agent_1',
+      providerOptions: { openai: { reasoningEffort: 'high' } },
+      maxOutputTokens: 24576,
+    });
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    const callArgs = generateTextMock.mock.calls[0][0];
+    expect(callArgs.providerOptions).toEqual({
+      openai: { reasoningEffort: 'high' },
+    });
+    expect(callArgs.maxOutputTokens).toBe(24576);
+  });
+
+  test('reflect mode replaces the final text before completion', async () => {
+    jest.doMock('ai', () => {
+      const actual = jest.requireActual('ai');
+      return {
+        ...actual,
+        generateText: jest.fn().mockImplementation(draftResult),
+      };
+    });
+
+    const { runNonStreamGeneration } = await loadNonStreamModule();
+    const helpersModule = await loadHelpersModule();
+    const reasoningCompletionModule = await loadReasoningCompletionModule();
+
+    jest
+      .spyOn(reasoningCompletionModule, 'runReasoningCompletion')
+      .mockResolvedValueOnce('The draft is too vague.')
+      .mockResolvedValueOnce('revised answer');
+
+    jest.spyOn(helpersModule, 'findPendingClientTools').mockReturnValue([]);
+    const buildCompletedSpy = jest
+      .spyOn(helpersModule, 'buildCompletedGenerationResult')
+      .mockImplementation(async (args) => {
+        return {
+          id: args.generationId,
+          traceId: args.traceId,
+          status: 'completed',
+          output: {
+            model: 'model-a',
+            content: args.result.text,
+            finishReason: args.result.finishReason,
+            responseMessages: args.result.response?.messages,
+          },
+        };
+      });
+
+    const result = await runNonStreamGeneration({
+      model: {} as never,
+      allMessages: [{ role: 'user', content: 'hard question' }],
+      resolvedTools: {},
+      typedAgent: buildTypedAgent({ mode: 'reflect' }),
+      generationId: 'gen_2',
+      traceId: 'trc_2',
+      agentId: 'agent_2',
+      reasoningConfig: { mode: 'reflect' },
+    });
+
+    // The completion result is built from the revised text, so the trace,
+    // event, and API response all agree.
+    expect(buildCompletedSpy).toHaveBeenCalledTimes(1);
+    expect(buildCompletedSpy.mock.calls[0][0].result.text).toBe(
+      'revised answer'
+    );
+    expect(result.status).toBe('completed');
+    expect(result.output?.content).toBe('revised answer');
+    // The draft's responseMessages no longer match the final text — they
+    // must not leak into conversation replay.
+    expect(result.output?.responseMessages).toBeUndefined();
+  });
+
+  test('reflect failure falls back to the draft', async () => {
+    jest.doMock('ai', () => {
+      const actual = jest.requireActual('ai');
+      return {
+        ...actual,
+        generateText: jest.fn().mockImplementation(draftResult),
+      };
+    });
+
+    const { runNonStreamGeneration } = await loadNonStreamModule();
+    const helpersModule = await loadHelpersModule();
+    const reasoningCompletionModule = await loadReasoningCompletionModule();
+
+    jest
+      .spyOn(reasoningCompletionModule, 'runReasoningCompletion')
+      .mockRejectedValue(new Error('provider down'));
+
+    jest.spyOn(helpersModule, 'findPendingClientTools').mockReturnValue([]);
+    jest
+      .spyOn(helpersModule, 'buildCompletedGenerationResult')
+      .mockImplementation(async (args) => {
+        return {
+          id: args.generationId,
+          traceId: args.traceId,
+          status: 'completed',
+          output: {
+            model: 'model-a',
+            content: args.result.text,
+            finishReason: args.result.finishReason,
+          },
+        };
+      });
+
+    const result = await runNonStreamGeneration({
+      model: {} as never,
+      allMessages: [{ role: 'user', content: 'hard question' }],
+      resolvedTools: {},
+      typedAgent: buildTypedAgent({ mode: 'reflect' }),
+      generationId: 'gen_3',
+      traceId: 'trc_3',
+      agentId: 'agent_3',
+      reasoningConfig: { mode: 'reflect' },
+    });
+
+    expect(result.status).toBe('completed');
+    expect(result.output?.content).toBe('draft answer');
+  });
+});

--- a/packages/server/tests/unit/tests/rest/formations.test.ts
+++ b/packages/server/tests/unit/tests/rest/formations.test.ts
@@ -1639,6 +1639,43 @@ resources:
       );
     });
 
+    test('creates an agent with a reasoning config from a formation', async () => {
+      const res = await authenticatedTestClient(userToken)
+        .post('/api/v1/formations')
+        .send({
+          project_id: projectId,
+          name: `reasoning-formation-${Date.now()}`,
+          template: {
+            resources: {
+              ReasoningAgent: {
+                type: 'agent',
+                properties: {
+                  ai_provider_id: aiProviderId,
+                  name: 'reasoning-agent',
+                  reasoning: {
+                    effort: 'high',
+                    mode: 'reflect',
+                    critique: { model: 'tiny-critic' },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.status).toBe('active');
+      const reasoningAgentId = res.body.resources[0].physical_resource_id;
+
+      const agentRes = await authenticatedTestClient(adminToken).get(
+        `/api/v1/agents/${reasoningAgentId}`
+      );
+      expect(agentRes.status).toBe(200);
+      expect(agentRes.body.reasoning.effort).toBe('high');
+      expect(agentRes.body.reasoning.mode).toBe('reflect');
+      expect(agentRes.body.reasoning.critique.model).toBe('tiny-critic');
+    });
+
     test('formation update can switch extraction to the boolean form', async () => {
       const res = await authenticatedTestClient(userToken)
         .put(`/api/v1/formations/${extractionFormationId}`)

--- a/packages/server/tests/unit/tests/rest/reasoning.test.ts
+++ b/packages/server/tests/unit/tests/rest/reasoning.test.ts
@@ -1,0 +1,126 @@
+import { mockCreateGeneration } from '../../setupTestsAfterEnv';
+import { authenticatedTestClient, loginAs, testClient } from '../../testClient';
+
+describe('Reasoning config', () => {
+  let adminToken: string;
+  let projectId: string;
+  let aiProviderId: string;
+
+  beforeAll(async () => {
+    await testClient
+      .post('/api/v1/users/bootstrap')
+      .send({ username: 'reasoningadmin', password: 'supersecret' });
+
+    adminToken = await loginAs('reasoningadmin', 'supersecret');
+
+    const projectRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/projects')
+      .send({ name: 'Reasoning Test Project' });
+    projectId = projectRes.body.id;
+
+    const aiProvRes = await authenticatedTestClient(adminToken)
+      .post('/api/v1/ai-providers')
+      .send({
+        project_id: projectId,
+        name: 'ReasoningProvider',
+        provider: 'ollama',
+        default_model: 'llama3.2',
+      });
+    aiProviderId = aiProvRes.body.id;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('agent reasoning contract', () => {
+    test('agent create round-trips the reasoning config', async () => {
+      const res = await authenticatedTestClient(adminToken)
+        .post('/api/v1/agents')
+        .send({
+          project_id: projectId,
+          ai_provider_id: aiProviderId,
+          name: 'ReasoningContractAgent',
+          reasoning: {
+            effort: 'high',
+            mode: 'reflect',
+            critique: {
+              ai_provider_id: aiProviderId,
+              model: 'critique-model',
+              prompt: 'Focus on factual accuracy.',
+            },
+          },
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.reasoning.effort).toBe('high');
+      expect(res.body.reasoning.mode).toBe('reflect');
+      expect(res.body.reasoning.critique.ai_provider_id).toBe(aiProviderId);
+      expect(res.body.reasoning.critique.model).toBe('critique-model');
+      expect(res.body.reasoning.critique.prompt).toBe(
+        'Focus on factual accuracy.'
+      );
+    });
+
+    test('agent update sets and clears the reasoning config', async () => {
+      const createRes = await authenticatedTestClient(adminToken)
+        .post('/api/v1/agents')
+        .send({
+          project_id: projectId,
+          ai_provider_id: aiProviderId,
+          name: 'ReasoningUpdateAgent',
+        });
+      expect(createRes.status).toBe(201);
+      expect(createRes.body.reasoning ?? null).toBeNull();
+      const agentId = createRes.body.id;
+
+      const updateRes = await authenticatedTestClient(adminToken)
+        .put(`/api/v1/agents/${agentId}`)
+        .send({ reasoning: { mode: 'reflect' } });
+      expect(updateRes.status).toBe(200);
+      expect(updateRes.body.reasoning.mode).toBe('reflect');
+
+      const clearRes = await authenticatedTestClient(adminToken)
+        .put(`/api/v1/agents/${agentId}`)
+        .send({ reasoning: null });
+      expect(clearRes.status).toBe(200);
+      expect(clearRes.body.reasoning ?? null).toBeNull();
+    });
+  });
+
+  describe('per-generate reasoning override', () => {
+    test('generate route forwards the reasoning override to the pipeline', async () => {
+      const agentRes = await authenticatedTestClient(adminToken)
+        .post('/api/v1/agents')
+        .send({
+          project_id: projectId,
+          ai_provider_id: aiProviderId,
+          name: 'ReasoningOverrideAgent',
+        });
+      const agentId = agentRes.body.id;
+
+      mockCreateGeneration.mockResolvedValueOnce({
+        id: 'gen_reason_1',
+        traceId: 'trc_reason_1',
+        status: 'completed',
+        output: {
+          model: 'test-model',
+          content: 'Deeply considered answer.',
+          finishReason: 'stop',
+        },
+      });
+
+      const res = await authenticatedTestClient(adminToken)
+        .post(`/api/v1/agents/${agentId}/generate`)
+        .send({
+          messages: [{ role: 'user', content: 'Hard question.' }],
+          reasoning: { mode: 'reflect', effort: 'high' },
+        });
+
+      expect(res.status).toBe(200);
+      expect(mockCreateGeneration).toHaveBeenCalledTimes(1);
+      const callArgs = mockCreateGeneration.mock.calls[0][0];
+      expect(callArgs.reasoning).toEqual({ mode: 'reflect', effort: 'high' });
+    });
+  });
+});

--- a/packages/website/docs/modules/agents.md
+++ b/packages/website/docs/modules/agents.md
@@ -38,6 +38,7 @@ Agents differ from [Chats](./chats.md) in that they can call tools, observe resu
 | `boundary_policy`          | object        | Boundary policy that limits which `soat` actions the agent can perform — see [SOAT Action Permissions](#soat-action-permissions) |
 | `temperature`              | number        | Sampling temperature                                                                                                             |
 | `knowledge_config`         | object        | Knowledge retrieval config injected before every generation — see [Knowledge Config](#knowledge-config)                          |
+| `reasoning`                | object        | Deep-thinking configuration (provider-native effort and reflect mode) — see [Reasoning (Deep Thinking)](#reasoning-deep-thinking) |
 | `max_context_messages`     | number        | Maximum number of recent messages sent to the model per generation — see [Context Window Limiting](#context-window-limiting)     |
 | `single_session_per_actor` | boolean       | When `true`, only one open session per `actor_id` is allowed — see [Single Session Per Actor](#single-session-per-actor)         |
 | `created_at`               | string        | ISO 8601 creation timestamp                                                                                                      |
@@ -307,6 +308,30 @@ Results are injected as system messages prepended to the conversation:
 [Document: /reports/q1.txt] Q1 revenue was $4.2M across all regions.
 [Memory: Customer Preferences] Customer prefers email over phone calls.
 ```
+
+### Reasoning (Deep Thinking)
+
+The `reasoning` config makes an agent think harder before answering. It applies to non-streaming generations across all flows (direct generate, conversations, sessions) and can be set on the agent or overridden per request in the generate body (object replace, not merge).
+
+| Field      | Type     | Description                                                                                                          |
+| ---------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| `effort`   | string   | `low` \| `medium` \| `high` — forwarded as provider-native reasoning options (OpenAI reasoning effort, Anthropic extended-thinking budget, Google thinking budget). Ignored on providers without a mapping. |
+| `mode`     | string   | `none` (default) \| `reflect` — orchestrated reasoning strategy                                                       |
+| `critique` | object   | Reflect only — `{ ai_provider_id?, model?, prompt? }` overrides for the critique pass (same contract as [extraction overrides](./memories.md#automatic-extraction)) |
+
+**Reflect mode** runs three steps behind a single generate call: the agent drafts an answer, a critique pass reviews it (on the agent's own model, or the `critique` override — a different model family catches blind spots the drafting model shares with itself), and a revision pass produces the final answer. If the critique approves the draft, the revision is skipped. The response is a normal generation result; the outcome is recorded on the generation's `metadata.reasoning` (`{ mode, applied, reason }`).
+
+```json
+{
+  "reasoning": {
+    "effort": "high",
+    "mode": "reflect",
+    "critique": { "ai_provider_id": "aip_cheap", "model": "gpt-4o-mini" }
+  }
+}
+```
+
+Failure semantics: reflection never makes a generation worse — if the critique or revision call fails, the draft is returned. Reflect mode does not run for streaming generations or `requires_action` (client-tool) turns; `effort` applies to streaming as well.
 
 ### SOAT Action Permissions
 

--- a/tests/smoke-tests.sh
+++ b/tests/smoke-tests.sh
@@ -882,6 +882,26 @@ fi
 $SOAT_CLI update-agent --agent-id "$AGENT_ID" --knowledge_config '{}' >/dev/null
 echo "knowledge_config extraction round-trip: OK"
 
+# 22b3. Reasoning config (deep thinking) round-trip
+echo "--- Setting reasoning config ---"
+RC_UPDATE_RESP=$($SOAT_CLI update-agent --agent-id "$AGENT_ID" \
+  --reasoning '{"mode":"reflect","effort":"low","critique":{"prompt":"Critique factual accuracy only."}}')
+if ! printf '%s\n' "$RC_UPDATE_RESP" | jq -e '.reasoning.mode == "reflect" and .reasoning.effort == "low"' >/dev/null 2>&1; then
+  echo "ERROR: update-agent did not round-trip the reasoning config" >&2
+  echo "$RC_UPDATE_RESP" >&2
+  exit 1
+fi
+RC_GET_RESP=$($SOAT_CLI get-agent --agent-id "$AGENT_ID")
+if ! printf '%s\n' "$RC_GET_RESP" | jq -e '.reasoning.critique.prompt == "Critique factual accuracy only."' >/dev/null 2>&1; then
+  echo "ERROR: get-agent did not return the reasoning critique config" >&2
+  echo "$RC_GET_RESP" >&2
+  exit 1
+fi
+# Disable again so later generations in this script stay single-pass
+# (reflect behavior is LLM-dependent and covered by unit tests, not smoke).
+$SOAT_CLI update-agent --agent-id "$AGENT_ID" --reasoning '{"mode":"none"}' >/dev/null
+echo "reasoning config round-trip: OK"
+
 # 22c. Create a deterministic HTTP tool for tool_output message content
 echo "--- Creating project-detail tool ---"
 PROJECT_DETAIL_TOOL_RESP=$($SOAT_CLI create-tool \


### PR DESCRIPTION
## Summary

Two things in this PR:

1. **Reframes `docs/prd-discussions.md`** into a layered deep-thinking design: the deliberation engine ships behind the existing generate flow as a `reasoning` config, and the Discussions resource becomes Phase 4 on the same engine.
2. **Implements Phases 0 and 1** of that PRD.

## Phase 0 — provider-native reasoning passthrough

`reasoning.effort` (`low` / `medium` / `high`) on the Agent and per-generate body, forwarded as AI SDK `providerOptions`: OpenAI `reasoningEffort`, Anthropic extended-thinking budget (4096/16384/32768 tokens, with `maxOutputTokens` raised above the budget as Anthropic requires), Google `thinkingBudget`. A no-op on providers without a mapping; applies to streaming and non-streaming.

## Phase 1 — reflect mode

`reasoning.mode: "reflect"` runs draft → critique → revise behind a single generate call (direct generate, conversations, and sessions all inherit it from the agent config). The hook runs **before** the completion result is built, so the trace, the completion event, and the API response all carry the final text. Design properties:

- APPROVED short-circuit: when the critique finds nothing to improve, the revision call is skipped
- Failures degrade to the draft — reflection can never make a generation worse or fail a request that already has an answer
- The `critique` pass takes the same `{ ai_provider_id, model, prompt }` override triple as `knowledge_config.extraction` (cross-model critique decorrelates errors); provider overrides are validated against the agent's project via the new shared `resolveCompletionModel()`, which extraction now also uses
- Outcome recorded on the generation's `metadata.reasoning` (`{ mode, applied, reason }`)
- Scope: non-streaming completed generations; streaming and `requires_action` continuations skip reflect (`effort` still applies to streaming)

## Surface

- `reasoningConfig` JSONB on Agent (`reasoning` on the wire), per-generate override with object-replace semantics
- OpenAPI (3 agent schemas + generate request body), SDK/CLI regenerated
- Formation schema (`AgentResourceProperties.reasoning`) + agents formation module pass-through, with round-trip test
- agents.md Key Concepts section, PRD Phases 0–1 marked complete, smoke round-trip step

## Tests

REST contract (config round-trip, per-generate override forwarding), reflect orchestration (override routing, APPROVED, failure degradation), real-execution completion boundary against a local OpenAI-compatible stub, and pipeline wiring via the `doMock('ai')` pattern (providerOptions forwarding, text replacement, fallback). 575 tests across all touched suites green locally; typecheck/eslint/spectral clean.

https://claude.ai/code/session_0187UoknfxfdLvSiJfdKzeqh