### PR TITLE
chore(release): publish packages v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.1](https://github.com/ttoss/soat/compare/v0.9.0...v0.9.1) (2026-06-12)
+
+### Bug Fixes
+
+* return requires_action when continuation produces new client tool calls ([#197](https://github.com/ttoss/soat/issues/197)) ([5e4221a](https://github.com/ttoss/soat/commit/5e4221af1c3081d02cb940915189d75ace05a745))
+* **sessions:** reject messages/generation on closed sessions and cancel stale timers ([#198](https://github.com/ttoss/soat/issues/198)) ([4597368](https://github.com/ttoss/soat/commit/4597368821a80e2e09e774dec400f1306625ba90))
+
 # [0.9.0](https://github.com/ttoss/soat/compare/v0.8.2...v0.9.0) (2026-06-11)
 
 ### Features

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "npmClient": "pnpm",
   "stream": true,
   "command": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.1](https://github.com/ttoss/soat/compare/v0.9.0...v0.9.1) (2026-06-12)
+
+**Note:** Version bump only for package @soat/cli
+
 # [0.9.0](https://github.com/ttoss/soat/compare/v0.8.2...v0.9.0) (2026-06-11)
 
 **Note:** Version bump only for package @soat/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "generate": "tsx scripts/generate.ts",

--- a/packages/postgresdb/CHANGELOG.md
+++ b/packages/postgresdb/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.1](https://127.0.0.1/46713/git/ttoss/compare/v0.9.0...v0.9.1) (2026-06-12)
+
+**Note:** Version bump only for package @soat/postgresdb
+
 # [0.9.0](https://127.0.0.1/40289/git/ttoss/compare/v0.8.2...v0.9.0) (2026-06-11)
 
 **Note:** Version bump only for package @soat/postgresdb

--- a/packages/postgresdb/package.json
+++ b/packages/postgresdb/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@soat/postgresdb",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Database models and operations for SOAT packages",
   "type": "module",
   "exports": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.1](https://github.com/ttoss/soat/compare/v0.9.0...v0.9.1) (2026-06-12)
+
+**Note:** Version bump only for package @soat/sdk
+
 # [0.9.0](https://github.com/ttoss/soat/compare/v0.8.2...v0.9.0) (2026-06-11)
 
 **Note:** Version bump only for package @soat/sdk

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "TypeScript SDK for the SOAT API",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.1](https://127.0.0.1/46713/git/ttoss/compare/v0.9.0...v0.9.1) (2026-06-12)
+
+### Bug Fixes
+
+* return requires_action when continuation produces new client tool calls ([#197](https://127.0.0.1/46713/git/ttoss/issues/197)) ([5e4221a](https://127.0.0.1/46713/git/ttoss/commits/5e4221af1c3081d02cb940915189d75ace05a745))
+* **sessions:** reject messages/generation on closed sessions and cancel stale timers ([#198](https://127.0.0.1/46713/git/ttoss/issues/198)) ([4597368](https://127.0.0.1/46713/git/ttoss/commits/4597368821a80e2e09e774dec400f1306625ba90))
+
 # [0.9.0](https://127.0.0.1/40289/git/ttoss/compare/v0.8.2...v0.9.0) (2026-06-11)
 
 ### Features

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "dist/server.mjs",
   "scripts": {
     "build": "tsdown",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.1](https://127.0.0.1/46713/git/ttoss/compare/v0.9.0...v0.9.1) (2026-06-12)
+
+**Note:** Version bump only for package @soat/website
+
 # [0.9.0](https://127.0.0.1/40289/git/ttoss/compare/v0.8.2...v0.9.0) (2026-06-11)
 
 ### Features

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/website",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Summary

- Bumps all packages from `0.9.0` → `0.9.1`
- Includes fixes for sessions (reject messages/generation on closed sessions, cancel stale timers, return `requires_action` on client tool call continuations)
- Includes Discussions module PRD and Memories Phase 4 automatic extraction

## Commits since v0.9.0

- `feat`: Discussions module PRD + Memories Phase 4: automatic extraction (#199)
- `fix(sessions)`: reject messages/generation on closed sessions and cancel stale timers (#198)
- `fix`: return requires_action when continuation produces new client tool calls (#197)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuMmksUTMaTfU4NQeaJpZe)_