### PR TITLE
chore(release): publish packages v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.10.0](https://github.com/ttoss/soat/compare/v0.9.1...v0.10.0) (2026-06-13)
+
+### Bug Fixes
+
+* **server:** add coverage for SPA static middleware to meet 65% threshold ([24d14dc](https://github.com/ttoss/soat/commit/24d14dcb0837e9174718446c77f19ecbd63365df))
+
+### Features
+
+* **app:** add @soat/app — auth flow with login page and welcome screen ([ef45db5](https://github.com/ttoss/soat/commit/ef45db5f4d8980efa635052ab2a7f84d55a7721a))
+* debate mode — Phase 2 multi-perspective deliberation ([#202](https://github.com/ttoss/soat/issues/202)) ([d3e66c3](https://github.com/ttoss/soat/commit/d3e66c3e19aeafb941d285e4008b2eddede8ada8))
+* **server:** deep-thinking reasoning — PRD reframe + provider-native effort + reflect mode ([#200](https://github.com/ttoss/soat/issues/200)) ([dec6192](https://github.com/ttoss/soat/commit/dec61927979ac72bbce33f3b5c6428fa228a9a56))
+
 ## [0.9.1](https://github.com/ttoss/soat/compare/v0.9.0...v0.9.1) (2026-06-12)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "npmClient": "pnpm",
   "stream": true,
   "command": {

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.10.0](https://127.0.0.1/37241/git/ttoss/compare/v0.9.1...v0.10.0) (2026-06-13)
+
+### Features
+
+* **app:** add @soat/app — auth flow with login page and welcome screen ([ef45db5](https://127.0.0.1/37241/git/ttoss/commits/ef45db5f4d8980efa635052ab2a7f84d55a7721a))

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/app",
-  "version": "0.1.0",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.10.0](https://github.com/ttoss/soat/compare/v0.9.1...v0.10.0) (2026-06-13)
+
+**Note:** Version bump only for package @soat/cli
+
 ## [0.9.1](https://github.com/ttoss/soat/compare/v0.9.0...v0.9.1) (2026-06-12)
 
 **Note:** Version bump only for package @soat/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/cli",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "generate": "tsx scripts/generate.ts",

--- a/packages/postgresdb/CHANGELOG.md
+++ b/packages/postgresdb/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.10.0](https://127.0.0.1/37241/git/ttoss/compare/v0.9.1...v0.10.0) (2026-06-13)
+
+### Features
+
+* **server:** deep-thinking reasoning — PRD reframe + provider-native effort + reflect mode ([#200](https://127.0.0.1/37241/git/ttoss/issues/200)) ([dec6192](https://127.0.0.1/37241/git/ttoss/commits/dec61927979ac72bbce33f3b5c6428fa228a9a56))
+
 ## [0.9.1](https://127.0.0.1/46713/git/ttoss/compare/v0.9.0...v0.9.1) (2026-06-12)
 
 **Note:** Version bump only for package @soat/postgresdb

--- a/packages/postgresdb/package.json
+++ b/packages/postgresdb/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@soat/postgresdb",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Database models and operations for SOAT packages",
   "type": "module",
   "exports": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.10.0](https://github.com/ttoss/soat/compare/v0.9.1...v0.10.0) (2026-06-13)
+
+**Note:** Version bump only for package @soat/sdk
+
 ## [0.9.1](https://github.com/ttoss/soat/compare/v0.9.0...v0.9.1) (2026-06-12)
 
 **Note:** Version bump only for package @soat/sdk

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/sdk",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "TypeScript SDK for the SOAT API",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.10.0](https://127.0.0.1/37241/git/ttoss/compare/v0.9.1...v0.10.0) (2026-06-13)
+
+### Bug Fixes
+
+* **server:** add coverage for SPA static middleware to meet 65% threshold ([24d14dc](https://127.0.0.1/37241/git/ttoss/commits/24d14dcb0837e9174718446c77f19ecbd63365df))
+
+### Features
+
+* **app:** add @soat/app — auth flow with login page and welcome screen ([ef45db5](https://127.0.0.1/37241/git/ttoss/commits/ef45db5f4d8980efa635052ab2a7f84d55a7721a))
+* debate mode — Phase 2 multi-perspective deliberation ([#202](https://127.0.0.1/37241/git/ttoss/issues/202)) ([d3e66c3](https://127.0.0.1/37241/git/ttoss/commits/d3e66c3e19aeafb941d285e4008b2eddede8ada8))
+* **server:** deep-thinking reasoning — PRD reframe + provider-native effort + reflect mode ([#200](https://127.0.0.1/37241/git/ttoss/issues/200)) ([dec6192](https://127.0.0.1/37241/git/ttoss/commits/dec61927979ac72bbce33f3b5c6428fa228a9a56))
+
 ## [0.9.1](https://127.0.0.1/46713/git/ttoss/compare/v0.9.0...v0.9.1) (2026-06-12)
 
 ### Bug Fixes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/server",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "main": "dist/server.mjs",
   "scripts": {
     "build": "tsdown",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.10.0](https://127.0.0.1/37241/git/ttoss/compare/v0.9.1...v0.10.0) (2026-06-13)
+
+### Features
+
+* debate mode — Phase 2 multi-perspective deliberation ([#202](https://127.0.0.1/37241/git/ttoss/issues/202)) ([d3e66c3](https://127.0.0.1/37241/git/ttoss/commits/d3e66c3e19aeafb941d285e4008b2eddede8ada8))
+* **server:** deep-thinking reasoning — PRD reframe + provider-native effort + reflect mode ([#200](https://127.0.0.1/37241/git/ttoss/issues/200)) ([dec6192](https://127.0.0.1/37241/git/ttoss/commits/dec61927979ac72bbce33f3b5c6428fa228a9a56))
+
 ## [0.9.1](https://127.0.0.1/46713/git/ttoss/compare/v0.9.0...v0.9.1) (2026-06-12)
 
 **Note:** Version bump only for package @soat/website

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/website",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Summary

- Bump all packages from `0.9.1` → `0.10.0`
- Adds `@soat/app` — React + Vite SPA served at `/app` with login/auth flow and welcome page
- Adds `GET /api/v1/users/me` endpoint for token validation
- Server now statically serves the app from `packages/app/dist` (path-traversal-safe)
- `@soat/server` build now depends on `@soat/app` build in turbo pipeline

## Test plan

- [ ] CI `build-and-test` passes
- [ ] CI `smoke-test` passes
- [ ] CI `tutorials-test` passes
- [ ] All packages publish to npm after merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZhSnUiGYZGvUUiDmJcZ1g)_