### PR TITLE
feat(app): OpenAPI-driven generic UI engine with workspace shell

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SOAT</title>
+    <!-- Brand typography: Space Grotesk (headings), Inter (body), JetBrains Mono (code) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Space+Grotesk:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -1,0 +1,47 @@
+export type ApiError = { message: string; code?: string };
+
+export type ApiResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; status: number; error: ApiError };
+
+const extractError = async (res: Response): Promise<ApiError> => {
+  try {
+    const body = (await res.json()) as {
+      error?: { message?: string; code?: string } | string;
+    };
+    if (typeof body.error === 'string') return { message: body.error };
+    if (typeof body.error === 'object' && body.error !== null) {
+      return {
+        message: body.error.message ?? `HTTP ${res.status}`,
+        code: body.error.code,
+      };
+    }
+  } catch {
+    // ignore parse error
+  }
+  return { message: `HTTP ${res.status}` };
+};
+
+export const apiFetch = async <T>(args: {
+  url: string;
+  method?: string;
+  body?: unknown;
+  token: string;
+}): Promise<ApiResult<T>> => {
+  const res = await fetch(args.url, {
+    method: args.method ?? 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${args.token}`,
+    },
+    body: args.body !== undefined ? JSON.stringify(args.body) : undefined,
+  });
+
+  if (!res.ok) {
+    const error = await extractError(res);
+    return { ok: false, status: res.status, error };
+  }
+
+  const data = (await res.json()) as T;
+  return { ok: true, data };
+};

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -1,6 +1,20 @@
 import { AuthProvider, useAuth } from './auth/authContext';
 import { LoginForm } from './auth/loginForm';
-import { WelcomePage } from './views/welcomePage';
+import { NavigationProvider } from './engine/navigationContext';
+import { SpecProvider } from './engine/specContext';
+import { Workspace } from './views/workspace';
+
+const AuthenticatedApp = () => {
+  const { state } = useAuth();
+  if (state.status !== 'authenticated') return null;
+  return (
+    <SpecProvider token={state.token}>
+      <NavigationProvider>
+        <Workspace />
+      </NavigationProvider>
+    </SpecProvider>
+  );
+};
 
 const AppContent = () => {
   const { state } = useAuth();
@@ -8,7 +22,7 @@ const AppContent = () => {
   if (state.status === 'loading') {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="text-muted-foreground">Loading…</div>
+        <div className="text-muted-foreground">{'Loading…'}</div>
       </div>
     );
   }
@@ -17,7 +31,7 @@ const AppContent = () => {
     return <LoginForm />;
   }
 
-  return <WelcomePage />;
+  return <AuthenticatedApp />;
 };
 
 export const App = () => {

--- a/packages/app/src/components/ui/card.tsx
+++ b/packages/app/src/components/ui/card.tsx
@@ -40,7 +40,10 @@ export const CardTitle = React.forwardRef<
   return (
     <div
       ref={ref}
-      className={cn('font-semibold leading-none tracking-tight', className)}
+      className={cn(
+        'font-heading font-semibold leading-none tracking-tight',
+        className
+      )}
       {...props}
     />
   );

--- a/packages/app/src/engine/detailView.tsx
+++ b/packages/app/src/engine/detailView.tsx
@@ -1,0 +1,193 @@
+import * as React from 'react';
+
+import { apiFetch } from '@/api/client';
+import { useAuth } from '@/auth/authContext';
+import { Button } from '@/components/ui/button';
+
+import { useNavigation } from './navigationContext';
+import {
+  buildUrl,
+  formatValue,
+  humanizeKey,
+  isSensitiveKey,
+} from './specUtils';
+import type { JsonObject, JsonValue, ModuleInfo, OpenApiSpec } from './types';
+
+type DetailState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'ok'; item: JsonObject };
+
+const FieldRow = ({ label, value }: { label: string; value: JsonValue }) => {
+  const displayValue = isSensitiveKey(label)
+    ? '[hidden]'
+    : formatValue(label, value);
+  const isLong = typeof displayValue === 'string' && displayValue.length > 80;
+
+  return (
+    <div className="grid grid-cols-[200px_1fr] gap-4 border-b py-3 last:border-0">
+      <span className="text-sm font-medium text-muted-foreground">
+        {humanizeKey(label)}
+      </span>
+      {isLong ? (
+        <pre className="whitespace-pre-wrap break-all text-sm font-mono">
+          {displayValue}
+        </pre>
+      ) : (
+        <span className="text-sm">{displayValue}</span>
+      )}
+    </div>
+  );
+};
+
+type DetailViewProps = {
+  module: ModuleInfo;
+  spec: OpenApiSpec;
+  pathParams: Record<string, string>;
+};
+
+export const DetailView = ({
+  module,
+  spec: _spec,
+  pathParams,
+}: DetailViewProps) => {
+  const { state } = useAuth();
+  const { navigate } = useNavigation();
+  const [viewState, setViewState] = React.useState<DetailState>({
+    status: 'loading',
+  });
+  const [deleting, setDeleting] = React.useState(false);
+  const [confirmDelete, setConfirmDelete] = React.useState(false);
+
+  const token = state.status === 'authenticated' ? state.token : '';
+
+  const fetchData = React.useCallback(() => {
+    if (!module.getOp || !token) return;
+    const url = buildUrl(module.getOp.pathTemplate, pathParams);
+    apiFetch<JsonObject>({ url, token })
+      .then((result) => {
+        if (!result.ok) {
+          setViewState({ status: 'error', message: result.error.message });
+          return;
+        }
+        setViewState({ status: 'ok', item: result.data });
+      })
+      .catch((error: unknown) => {
+        setViewState({ status: 'error', message: String(error) });
+      });
+  }, [module.getOp, pathParams, token]);
+
+  React.useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const handleEdit = () => {
+    if (!module.updateOp) return;
+    navigate({
+      tag: module.tag,
+      operationId: module.updateOp.operation.operationId,
+      pathParams,
+      mode: 'edit',
+    });
+  };
+
+  const handleDelete = async () => {
+    if (!module.deleteOp || !token) return;
+    setDeleting(true);
+    const url = buildUrl(module.deleteOp.pathTemplate, pathParams);
+    const result = await apiFetch<unknown>({ url, method: 'DELETE', token });
+    setDeleting(false);
+    setConfirmDelete(false);
+    if (result.ok) {
+      navigate(null);
+    } else {
+      setViewState({ status: 'error', message: result.error.message });
+    }
+  };
+
+  if (viewState.status === 'loading') {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        {'Loading…'}
+      </div>
+    );
+  }
+
+  if (viewState.status === 'error') {
+    return (
+      <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+        {viewState.message}
+      </div>
+    );
+  }
+
+  const { item } = viewState;
+  const fields = Object.keys(item).filter((k) => {
+    return k !== 'id' || !item.id;
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">{module.label}</h2>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              return navigate(null);
+            }}
+          >
+            {'← Back'}
+          </Button>
+          {module.updateOp && (
+            <Button variant="outline" size="sm" onClick={handleEdit}>
+              {'Edit'}
+            </Button>
+          )}
+          {module.deleteOp && !confirmDelete && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => {
+                return setConfirmDelete(true);
+              }}
+            >
+              {'Delete'}
+            </Button>
+          )}
+          {confirmDelete && (
+            <>
+              <span className="text-sm text-muted-foreground self-center">
+                {'Are you sure?'}
+              </span>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={deleting}
+                onClick={handleDelete}
+              >
+                {deleting ? 'Deleting…' : 'Confirm delete'}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  return setConfirmDelete(false);
+                }}
+              >
+                {'Cancel'}
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-md border">
+        {fields.map((key) => {
+          return <FieldRow key={key} label={key} value={item[key]} />;
+        })}
+      </div>
+    </div>
+  );
+};

--- a/packages/app/src/engine/engineView.tsx
+++ b/packages/app/src/engine/engineView.tsx
@@ -1,0 +1,81 @@
+import type * as React from 'react';
+
+import { DetailView } from './detailView';
+import { FormView } from './formView';
+import { ListView } from './listView';
+import type { ModuleInfo, OpenApiSpec, ViewDescriptor } from './types';
+
+type EngineViewProps = {
+  descriptor: ViewDescriptor;
+  modules: ModuleInfo[];
+  spec: OpenApiSpec;
+};
+
+const findModule = (
+  modules: ModuleInfo[],
+  tag: string
+): ModuleInfo | undefined => {
+  return modules.find((m) => {
+    return m.tag === tag;
+  });
+};
+
+export const EngineView = ({
+  descriptor,
+  modules,
+  spec,
+}: EngineViewProps): React.ReactElement | null => {
+  const module = findModule(modules, descriptor.tag);
+
+  if (!module) {
+    return (
+      <div className="text-muted-foreground text-sm p-4">
+        {`Module "${descriptor.tag}" not found in spec.`}
+      </div>
+    );
+  }
+
+  if (descriptor.mode === 'list') {
+    return (
+      <ListView
+        module={module}
+        spec={spec}
+        pathParams={descriptor.pathParams}
+      />
+    );
+  }
+
+  if (descriptor.mode === 'detail') {
+    return (
+      <DetailView
+        module={module}
+        spec={spec}
+        pathParams={descriptor.pathParams}
+      />
+    );
+  }
+
+  if (descriptor.mode === 'create') {
+    return (
+      <FormView
+        module={module}
+        spec={spec}
+        pathParams={descriptor.pathParams}
+        mode="create"
+      />
+    );
+  }
+
+  if (descriptor.mode === 'edit') {
+    return (
+      <FormView
+        module={module}
+        spec={spec}
+        pathParams={descriptor.pathParams}
+        mode="edit"
+      />
+    );
+  }
+
+  return null;
+};

--- a/packages/app/src/engine/fieldEditor.tsx
+++ b/packages/app/src/engine/fieldEditor.tsx
@@ -1,0 +1,168 @@
+import type * as React from 'react';
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { humanizeKey } from './specUtils';
+import type { OpenApiSchema } from './types';
+
+type FieldEditorProps = {
+  name: string;
+  schema: OpenApiSchema;
+  value: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+};
+
+const TextareaField = ({
+  id,
+  value,
+  onChange,
+  placeholder,
+}: {
+  id: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) => {
+  return (
+    <textarea
+      id={id}
+      value={value}
+      onChange={(e) => {
+        return onChange(e.target.value);
+      }}
+      placeholder={placeholder}
+      rows={4}
+      className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 font-mono"
+    />
+  );
+};
+
+const SelectField = ({
+  id,
+  value,
+  onChange,
+  options,
+}: {
+  id: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: string[];
+}) => {
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => {
+        return onChange(e.target.value);
+      }}
+      className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+    >
+      <option value={''}>{'— select —'}</option>
+      {options.map((opt) => {
+        return (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        );
+      })}
+    </select>
+  );
+};
+
+const isLongTextSchema = (schema: OpenApiSchema): boolean => {
+  return (
+    schema.type === 'object' ||
+    schema.type === 'array' ||
+    (schema.type === 'string' && (schema.description?.length ?? 0) > 60)
+  );
+};
+
+const getInputType = (schema: OpenApiSchema): 'number' | 'text' => {
+  return schema.type === 'integer' || schema.type === 'number'
+    ? 'number'
+    : 'text';
+};
+
+type FieldInputProps = {
+  id: string;
+  schema: OpenApiSchema;
+  value: string;
+  onChange: (v: string) => void;
+};
+
+const FieldInput = ({
+  id,
+  schema,
+  value,
+  onChange,
+}: FieldInputProps): React.ReactElement => {
+  if (schema.enum) {
+    return (
+      <SelectField
+        id={id}
+        value={value}
+        onChange={onChange}
+        options={schema.enum}
+      />
+    );
+  }
+  if (schema.type === 'boolean') {
+    return (
+      <div className="flex items-center gap-2">
+        <input
+          id={id}
+          type="checkbox"
+          checked={value === 'true'}
+          onChange={(e) => {
+            return onChange(e.target.checked ? 'true' : 'false');
+          }}
+          className="h-4 w-4 rounded border-input"
+        />
+      </div>
+    );
+  }
+  if (isLongTextSchema(schema)) {
+    return (
+      <TextareaField
+        id={id}
+        value={value}
+        onChange={onChange}
+        placeholder={schema.description}
+      />
+    );
+  }
+  return (
+    <Input
+      id={id}
+      type={getInputType(schema)}
+      value={value}
+      onChange={(e) => {
+        return onChange(e.target.value);
+      }}
+      placeholder={schema.description}
+    />
+  );
+};
+
+export const FieldEditor = ({
+  name,
+  schema,
+  value,
+  onChange,
+  required,
+}: FieldEditorProps): React.ReactElement => {
+  const id = `field-${name}`;
+  const label = humanizeKey(name);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Label htmlFor={id}>
+        {label}
+        {required && <span className="ml-1 text-destructive">{'*'}</span>}
+      </Label>
+      <FieldInput id={id} schema={schema} value={value} onChange={onChange} />
+    </div>
+  );
+};

--- a/packages/app/src/engine/formView.tsx
+++ b/packages/app/src/engine/formView.tsx
@@ -1,0 +1,223 @@
+import * as React from 'react';
+
+import { apiFetch } from '@/api/client';
+import { useAuth } from '@/auth/authContext';
+import { Button } from '@/components/ui/button';
+
+import { FieldEditor } from './fieldEditor';
+import { useNavigation } from './navigationContext';
+import { buildUrl, resolveSchema } from './specUtils';
+import type {
+  JsonObject,
+  JsonValue,
+  ModuleInfo,
+  OpenApiSchema,
+  OpenApiSpec,
+} from './types';
+
+const getRequestSchema = (
+  module: ModuleInfo,
+  mode: 'create' | 'edit',
+  spec: OpenApiSpec
+): OpenApiSchema | undefined => {
+  const op = mode === 'create' ? module.createOp : module.updateOp;
+  const rawSchema =
+    op?.operation?.requestBody?.content?.['application/json']?.schema;
+  return resolveSchema(rawSchema, spec);
+};
+
+const initFormData = (
+  schema: OpenApiSchema | undefined,
+  prefill: JsonObject
+): Record<string, string> => {
+  const properties = schema?.properties ?? {};
+  const result: Record<string, string> = {};
+  for (const key of Object.keys(properties)) {
+    const prefillValue = prefill[key];
+    result[key] =
+      prefillValue !== undefined && prefillValue !== null
+        ? String(prefillValue)
+        : '';
+  }
+  return result;
+};
+
+type BodyBuildResult =
+  | { ok: true; body: JsonObject }
+  | { ok: false; error: string };
+
+type FieldConvertResult = { value: JsonValue } | { error: string };
+
+const convertFieldValue = (
+  fieldType: string | undefined,
+  rawValue: string,
+  fieldKey: string
+): FieldConvertResult => {
+  if (fieldType === 'boolean') return { value: rawValue === 'true' };
+  if (fieldType === 'integer' || fieldType === 'number') {
+    return { value: rawValue ? Number(rawValue) : null };
+  }
+  if (fieldType === 'object' || fieldType === 'array') {
+    try {
+      return { value: JSON.parse(rawValue) as JsonValue };
+    } catch {
+      return { error: `Invalid JSON in field "${fieldKey}"` };
+    }
+  }
+  return { value: rawValue };
+};
+
+const buildRequestBody = (
+  formData: Record<string, string>,
+  schema: OpenApiSchema | undefined
+): BodyBuildResult => {
+  const body: JsonObject = {};
+  const properties = schema?.properties ?? {};
+  const requiredFields = schema?.required ?? [];
+  for (const [key, rawValue] of Object.entries(formData)) {
+    if (!rawValue && !requiredFields.includes(key)) continue;
+    const result = convertFieldValue(properties[key]?.type, rawValue, key);
+    if ('error' in result) {
+      return { ok: false, error: result.error };
+    }
+    body[key] = result.value;
+  }
+  return { ok: true, body };
+};
+
+type FormActionsProps = {
+  submitting: boolean;
+  mode: 'create' | 'edit';
+  onCancel: () => void;
+};
+
+const FormActions = ({ submitting, mode, onCancel }: FormActionsProps) => {
+  return (
+    <div className="flex gap-2 pt-2">
+      <Button type="submit" disabled={submitting}>
+        {submitting ? 'Saving…' : mode === 'create' ? 'Create' : 'Save'}
+      </Button>
+      <Button type="button" variant="outline" onClick={onCancel}>
+        {'Cancel'}
+      </Button>
+    </div>
+  );
+};
+
+type FormViewProps = {
+  module: ModuleInfo;
+  spec: OpenApiSpec;
+  pathParams: Record<string, string>;
+  mode: 'create' | 'edit';
+  prefill?: JsonObject;
+};
+
+export const FormView = ({
+  module,
+  spec,
+  pathParams,
+  mode,
+  prefill = {},
+}: FormViewProps) => {
+  const { state } = useAuth();
+  const { navigate } = useNavigation();
+  const schema = getRequestSchema(module, mode, spec);
+  const [formData, setFormData] = React.useState<Record<string, string>>(() => {
+    return initFormData(schema, prefill);
+  });
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const token = state.status === 'authenticated' ? state.token : '';
+  const op = mode === 'create' ? module.createOp : module.updateOp;
+  const title =
+    mode === 'create' ? `Create ${module.label}` : `Edit ${module.label}`;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!op || !token) return;
+    setSubmitting(true);
+    setError(null);
+
+    const bodyResult = buildRequestBody(formData, schema);
+    if (!bodyResult.ok) {
+      setError(bodyResult.error);
+      setSubmitting(false);
+      return;
+    }
+
+    const url = buildUrl(op.pathTemplate, pathParams);
+    const method = mode === 'create' ? 'POST' : 'PUT';
+    const result = await apiFetch<JsonObject>({
+      url,
+      method,
+      body: bodyResult.body,
+      token,
+    });
+
+    setSubmitting(false);
+    if (!result.ok) {
+      setError(result.error.message);
+      return;
+    }
+
+    navigate(null);
+  };
+
+  if (!schema?.properties) {
+    return (
+      <div className="text-muted-foreground text-sm">
+        {'No form schema available for this operation.'}
+      </div>
+    );
+  }
+
+  const properties = schema.properties;
+  const required = new Set(schema.required ?? []);
+
+  const handleCancel = () => {
+    return navigate(null);
+  };
+
+  return (
+    <div className="flex flex-col gap-6 max-w-lg">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">{title}</h2>
+        <Button variant="outline" size="sm" onClick={handleCancel}>
+          {'Cancel'}
+        </Button>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {Object.entries(properties).map(([name, fieldSchema]) => {
+          return (
+            <FieldEditor
+              key={name}
+              name={name}
+              schema={fieldSchema}
+              value={formData[name] ?? ''}
+              onChange={(v) => {
+                return setFormData((prev) => {
+                  return { ...prev, [name]: v };
+                });
+              }}
+              required={required.has(name)}
+            />
+          );
+        })}
+
+        <FormActions
+          submitting={submitting}
+          mode={mode}
+          onCancel={handleCancel}
+        />
+      </form>
+    </div>
+  );
+};

--- a/packages/app/src/engine/listView.tsx
+++ b/packages/app/src/engine/listView.tsx
@@ -1,0 +1,212 @@
+import * as React from 'react';
+
+import { apiFetch } from '@/api/client';
+import { useAuth } from '@/auth/authContext';
+import { Button } from '@/components/ui/button';
+
+import { useNavigation } from './navigationContext';
+import {
+  buildUrl,
+  extractItems,
+  formatValue,
+  humanizeKey,
+  isSensitiveKey,
+} from './specUtils';
+import type { JsonObject, JsonValue, ModuleInfo, OpenApiSpec } from './types';
+
+const HIDDEN_COLUMNS = new Set(['id']);
+const MAX_COLUMNS = 6;
+
+const deriveColumns = (items: JsonObject[]): string[] => {
+  if (items.length === 0) return [];
+  const keys = Object.keys(items[0]);
+  return keys
+    .filter((k) => {
+      return !HIDDEN_COLUMNS.has(k) && !isSensitiveKey(k);
+    })
+    .slice(0, MAX_COLUMNS);
+};
+
+const CellValue = ({ colKey, value }: { colKey: string; value: JsonValue }) => {
+  if (isSensitiveKey(colKey)) {
+    return <span className="text-muted-foreground italic">{'[hidden]'}</span>;
+  }
+  const formatted = formatValue(colKey, value);
+  if (formatted.length > 60) {
+    return <span title={formatted}>{`${formatted.slice(0, 57)}…`}</span>;
+  }
+  return <span>{formatted}</span>;
+};
+
+type ListViewProps = {
+  module: ModuleInfo;
+  spec: OpenApiSpec;
+  pathParams: Record<string, string>;
+};
+
+type ViewState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'ok'; items: JsonObject[] };
+
+export const ListView = ({
+  module,
+  spec: _spec,
+  pathParams,
+}: ListViewProps) => {
+  const { state } = useAuth();
+  const { navigate } = useNavigation();
+  const [viewState, setViewState] = React.useState<ViewState>({
+    status: 'loading',
+  });
+
+  const token = state.status === 'authenticated' ? state.token : '';
+
+  const fetchData = React.useCallback(() => {
+    if (!module.listOp || !token) return;
+    const url = buildUrl(module.listOp.pathTemplate, pathParams);
+    apiFetch<unknown>({ url, token })
+      .then((result) => {
+        if (!result.ok) {
+          setViewState({ status: 'error', message: result.error.message });
+          return;
+        }
+        setViewState({ status: 'ok', items: extractItems(result.data) });
+      })
+      .catch((error: unknown) => {
+        setViewState({ status: 'error', message: String(error) });
+      });
+  }, [module.listOp, pathParams, token]);
+
+  const load = React.useCallback(() => {
+    setViewState({ status: 'loading' });
+    fetchData();
+  }, [fetchData]);
+
+  React.useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const handleRowClick = (item: JsonObject) => {
+    if (!module.getOp) return;
+    const id = String(item.id ?? '');
+    if (!id) return;
+    const idParam = module.getOp.pathTemplate.split('/').find((p) => {
+      return p.startsWith('{') && !pathParams[p.slice(1, -1)];
+    });
+    const newParam = idParam ? idParam.slice(1, -1) : 'id';
+    navigate({
+      tag: module.tag,
+      operationId: module.getOp.operation.operationId,
+      pathParams: { ...pathParams, [newParam]: id },
+      mode: 'detail',
+    });
+  };
+
+  const handleCreate = () => {
+    if (!module.createOp) return;
+    navigate({
+      tag: module.tag,
+      operationId: module.createOp.operation.operationId,
+      pathParams,
+      mode: 'create',
+    });
+  };
+
+  if (viewState.status === 'loading') {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        {'Loading…'}
+      </div>
+    );
+  }
+
+  if (viewState.status === 'error') {
+    return (
+      <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+        {viewState.message}
+      </div>
+    );
+  }
+
+  const { items } = viewState;
+  const columns = deriveColumns(items);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">{module.label}</h2>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={load}>
+            {'Refresh'}
+          </Button>
+          {module.createOp && (
+            <Button size="sm" onClick={handleCreate}>
+              {'Create'}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="py-8 text-center text-muted-foreground">
+          {'No items found.'}
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/50">
+                {columns.map((col) => {
+                  return (
+                    <th
+                      key={col}
+                      className="px-4 py-2 text-left font-medium text-muted-foreground"
+                    >
+                      {humanizeKey(col)}
+                    </th>
+                  );
+                })}
+                {module.getOp && <th className="px-4 py-2" />}
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item, idx) => {
+                return (
+                  <tr
+                    key={String(item.id ?? idx)}
+                    className="border-b last:border-0 hover:bg-muted/30 transition-colors"
+                  >
+                    {columns.map((col) => {
+                      return (
+                        <td key={col} className="px-4 py-2">
+                          <CellValue
+                            colKey={col}
+                            value={item[col] ?? (null as JsonValue)}
+                          />
+                        </td>
+                      );
+                    })}
+                    {module.getOp && (
+                      <td className="px-4 py-2 text-right">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            return handleRowClick(item);
+                          }}
+                        >
+                          {'View →'}
+                        </Button>
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/app/src/engine/navigationContext.tsx
+++ b/packages/app/src/engine/navigationContext.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+
+import type { ViewDescriptor } from './types';
+
+type NavigationContextValue = {
+  view: ViewDescriptor | null;
+  activeProjectId: string | null;
+  navigate: (descriptor: ViewDescriptor | null) => void;
+  setProject: (projectId: string | null) => void;
+};
+
+const NavigationContext = React.createContext<NavigationContextValue>({
+  view: null,
+  activeProjectId: null,
+  navigate: () => {},
+  setProject: () => {},
+});
+
+export const NavigationProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [view, setView] = React.useState<ViewDescriptor | null>(null);
+  const [activeProjectId, setActiveProjectId] = React.useState<string | null>(
+    null
+  );
+
+  const navigate = React.useCallback((descriptor: ViewDescriptor | null) => {
+    setView(descriptor);
+  }, []);
+
+  const setProject = React.useCallback(
+    (projectId: string | null) => {
+      setActiveProjectId(projectId);
+      navigate(null);
+    },
+    [navigate]
+  );
+
+  return (
+    <NavigationContext.Provider
+      value={{ view, activeProjectId, navigate, setProject }}
+    >
+      {children}
+    </NavigationContext.Provider>
+  );
+};
+
+export const useNavigation = (): NavigationContextValue => {
+  return React.useContext(NavigationContext);
+};

--- a/packages/app/src/engine/specContext.tsx
+++ b/packages/app/src/engine/specContext.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+
+import { parseModules } from './specUtils';
+import type { ModuleInfo, OpenApiSpec } from './types';
+
+type SpecState = {
+  spec: OpenApiSpec | null;
+  modules: ModuleInfo[];
+  loading: boolean;
+  error: string | null;
+};
+
+type SpecContextValue = SpecState & {
+  reload: () => void;
+};
+
+const SpecContext = React.createContext<SpecContextValue>({
+  spec: null,
+  modules: [],
+  loading: false,
+  error: null,
+  reload: () => {},
+});
+
+const fetchSpec = async (token: string): Promise<OpenApiSpec> => {
+  const res = await fetch('/api/v1/openapi.json', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`Failed to load spec: ${res.status}`);
+  return res.json() as Promise<OpenApiSpec>;
+};
+
+export const SpecProvider = ({
+  children,
+  token,
+}: {
+  children: React.ReactNode;
+  token: string;
+}) => {
+  const [state, setState] = React.useState<Omit<SpecState, 'modules'>>({
+    spec: null,
+    loading: true,
+    error: null,
+  });
+
+  const fetchData = React.useCallback(() => {
+    if (!token) return;
+    fetchSpec(token)
+      .then((spec) => {
+        return setState({ spec, loading: false, error: null });
+      })
+      .catch((error: unknown) => {
+        setState({ spec: null, loading: false, error: String(error) });
+      });
+  }, [token]);
+
+  const load = React.useCallback(() => {
+    setState((s) => {
+      return { ...s, loading: true, error: null };
+    });
+    fetchData();
+  }, [fetchData]);
+
+  React.useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const modules = React.useMemo(() => {
+    return state.spec ? parseModules(state.spec) : [];
+  }, [state.spec]);
+
+  return (
+    <SpecContext.Provider value={{ ...state, modules, reload: load }}>
+      {children}
+    </SpecContext.Provider>
+  );
+};
+
+export const useSpec = (): SpecContextValue => {
+  return React.useContext(SpecContext);
+};

--- a/packages/app/src/engine/specUtils.ts
+++ b/packages/app/src/engine/specUtils.ts
@@ -1,0 +1,183 @@
+import type {
+  JsonObject,
+  JsonValue,
+  ModuleInfo,
+  ModuleOp,
+  OpenApiOperation,
+  OpenApiSchema,
+  OpenApiSpec,
+} from './types';
+
+type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
+
+const SKIP_TAGS = new Set(['Sessions', 'Generations', 'Actor Tags']);
+
+const toLabel = (tag: string): string => {
+  return tag
+    .replace(/([A-Z])/g, (_m, p1: string, offset: number) => {
+      return offset > 0 ? ` ${p1}` : p1;
+    })
+    .trim();
+};
+
+const isCollectionPath = (pathTemplate: string): boolean => {
+  const segments = pathTemplate.split('/');
+  const last = segments[segments.length - 1];
+  return !last.startsWith('{');
+};
+
+export const buildUrl = (
+  pathTemplate: string,
+  params: Record<string, string>
+): string => {
+  let url = pathTemplate;
+  for (const [key, value] of Object.entries(params)) {
+    url = url.replace(`{${key}}`, encodeURIComponent(value));
+  }
+  return url;
+};
+
+export const humanizeKey = (key: string): string => {
+  return key.replace(/_/g, ' ').replace(/\b\w/g, (c) => {
+    return c.toUpperCase();
+  });
+};
+
+type OpKey = 'listOp' | 'getOp' | 'createOp' | 'updateOp' | 'deleteOp';
+
+const classifyOp = (method: string, pathTemplate: string): OpKey | null => {
+  if (method === 'get') {
+    return isCollectionPath(pathTemplate) ? 'listOp' : 'getOp';
+  }
+  if (method === 'post' && isCollectionPath(pathTemplate)) return 'createOp';
+  if (method === 'put' || method === 'patch') return 'updateOp';
+  if (method === 'delete') return 'deleteOp';
+  return null;
+};
+
+const assignOp = (
+  module: ModuleInfo,
+  method: HttpMethod,
+  op: ModuleOp
+): void => {
+  const key = classifyOp(method, op.pathTemplate);
+  if (key && !module[key]) {
+    module[key] = op;
+  }
+};
+
+const processTag = (
+  tag: string,
+  method: HttpMethod,
+  pathTemplate: string,
+  operation: OpenApiOperation,
+  tagMap: Map<string, ModuleInfo>
+): void => {
+  if (!tagMap.has(tag)) {
+    tagMap.set(tag, { tag, label: toLabel(tag), isProjectScoped: false });
+  }
+  const module = tagMap.get(tag)!;
+  if (pathTemplate.includes('{project_id}')) {
+    module.isProjectScoped = true;
+  }
+  assignOp(module, method, { method, pathTemplate, operation });
+};
+
+const processOperation = (
+  pathTemplate: string,
+  method: HttpMethod,
+  operation: OpenApiOperation | undefined,
+  tagMap: Map<string, ModuleInfo>
+): void => {
+  if (!operation?.operationId) return;
+  const tags = operation.tags ?? ['Other'];
+  for (const tag of tags) {
+    if (!SKIP_TAGS.has(tag)) {
+      processTag(tag, method, pathTemplate, operation, tagMap);
+    }
+  }
+};
+
+export const parseModules = (spec: OpenApiSpec): ModuleInfo[] => {
+  const tagMap = new Map<string, ModuleInfo>();
+  const methods = ['get', 'post', 'put', 'patch', 'delete'] as const;
+
+  for (const [pathTemplate, pathItem] of Object.entries(spec.paths ?? {})) {
+    for (const method of methods) {
+      processOperation(pathTemplate, method, pathItem[method], tagMap);
+    }
+  }
+
+  return Array.from(tagMap.values());
+};
+
+export const getIdParamName = (getPath: string, listPath: string): string => {
+  const getParts = getPath.split('/');
+  const listParts = listPath.split('/');
+  const extra = getParts.find((p, i) => {
+    return p !== listParts[i] && p.startsWith('{');
+  });
+  return extra ? extra.slice(1, -1) : 'id';
+};
+
+const resolveRef = (
+  ref: string,
+  spec: OpenApiSpec
+): OpenApiSchema | undefined => {
+  const parts = ref.replace(/^#\//, '').split('/');
+  let current: Record<string, unknown> = spec as Record<string, unknown>;
+  for (const part of parts) {
+    current = current[part] as Record<string, unknown>;
+    if (!current) return undefined;
+  }
+  return current as OpenApiSchema;
+};
+
+export const resolveSchema = (
+  schema: OpenApiSchema | undefined,
+  spec: OpenApiSpec
+): OpenApiSchema | undefined => {
+  if (!schema) return undefined;
+  if (schema.$ref) return resolveRef(schema.$ref, spec);
+  return schema;
+};
+
+const isJsonObject = (v: unknown): v is JsonObject => {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+};
+
+export const extractItems = (data: unknown): JsonObject[] => {
+  if (Array.isArray(data)) return data.filter(isJsonObject);
+  if (isJsonObject(data)) {
+    for (const value of Object.values(data)) {
+      if (Array.isArray(value)) return value.filter(isJsonObject);
+    }
+  }
+  return [];
+};
+
+const SENSITIVE_KEYS = /secret|password|key|token/i;
+
+export const isSensitiveKey = (key: string): boolean => {
+  return SENSITIVE_KEYS.test(key);
+};
+
+const DATE_KEYS = /created_at|updated_at|_at$/i;
+
+const formatDateValue = (value: string): string => {
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+};
+
+export const formatValue = (key: string, value: JsonValue): string => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'object') return JSON.stringify(value, null, 2);
+  if (DATE_KEYS.test(key) && typeof value === 'string') {
+    return formatDateValue(value);
+  }
+  return String(value);
+};

--- a/packages/app/src/engine/types.ts
+++ b/packages/app/src/engine/types.ts
@@ -1,0 +1,90 @@
+export type ViewMode = 'list' | 'detail' | 'create' | 'edit';
+
+export type ViewDescriptor = {
+  tag: string;
+  operationId: string;
+  pathParams: Record<string, string>;
+  mode: ViewMode;
+};
+
+export type OpenApiSchema = {
+  type?: string;
+  format?: string;
+  enum?: string[];
+  items?: OpenApiSchema;
+  properties?: Record<string, OpenApiSchema>;
+  required?: string[];
+  description?: string;
+  $ref?: string;
+};
+
+export type OpenApiParameter = {
+  name: string;
+  in: string;
+  required?: boolean;
+  schema?: OpenApiSchema;
+  description?: string;
+};
+
+export type OpenApiOperation = {
+  operationId: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  parameters?: OpenApiParameter[];
+  requestBody?: {
+    required?: boolean;
+    content?: {
+      'application/json'?: { schema?: OpenApiSchema };
+    };
+  };
+  responses?: Record<
+    string,
+    {
+      content?: { 'application/json'?: { schema?: OpenApiSchema } };
+    }
+  >;
+};
+
+export type OpenApiPathItem = {
+  get?: OpenApiOperation;
+  post?: OpenApiOperation;
+  put?: OpenApiOperation;
+  patch?: OpenApiOperation;
+  delete?: OpenApiOperation;
+};
+
+export type OpenApiSpec = {
+  openapi?: string;
+  info?: { title?: string; version?: string };
+  paths?: Record<string, OpenApiPathItem>;
+  components?: {
+    schemas?: Record<string, OpenApiSchema>;
+  };
+};
+
+export type ModuleOp = {
+  method: 'get' | 'post' | 'put' | 'patch' | 'delete';
+  pathTemplate: string;
+  operation: OpenApiOperation;
+};
+
+export type ModuleInfo = {
+  tag: string;
+  label: string;
+  isProjectScoped: boolean;
+  listOp?: ModuleOp;
+  getOp?: ModuleOp;
+  createOp?: ModuleOp;
+  updateOp?: ModuleOp;
+  deleteOp?: ModuleOp;
+};
+
+export type JsonObject = { [key: string]: JsonValue };
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | JsonObject;

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -2,26 +2,88 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * SOAT theme — derived from BRANDBOOK.md (Vector Galaxy palette).
+ * Dual-theme by design: light mode uses Electric Blue as the functional
+ * primary; dark mode shifts to Core Cyan. Colors are stored as HSL channels
+ * so Tailwind can compose them with opacity modifiers.
+ */
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    /* Light Mode — Accessibility First */
+    --background: 0 0% 100%; /* Pure White #FFFFFF */
+    --foreground: 222 26% 14%; /* Deep Space Grey #1A1F2C */
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
+    --card-foreground: 222 26% 14%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222 26% 14%;
+    --primary: 214 82% 51%; /* Electric Blue #1A73E8 */
+    --primary-foreground: 0 0% 100%;
+    --secondary: 216 33% 97%; /* Pale Cosmos #F5F7FA */
+    --secondary-foreground: 222 26% 14%;
+    --muted: 216 33% 97%; /* Pale Cosmos #F5F7FA */
+    --muted-foreground: 215 16% 47%;
+    --accent: 216 33% 97%;
+    --accent-foreground: 222 26% 14%;
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 214 32% 91%;
+    --input: 214 32% 91%;
+    --ring: 214 82% 51%; /* Electric Blue focus ring */
+    /* Brand DNA — decorative only in light mode (never functional text) */
+    --brand-violet: 282 44% 47%; /* Deep Violet #8E44AD */
+    --brand-cyan: 186 100% 50%; /* Core Cyan #00E5FF */
     --radius: 0.5rem;
+  }
+
+  .dark {
+    /* Dark Mode — Glow & Contrast (native environment) */
+    --background: 220 43% 6%; /* Space Black #080C14 */
+    --foreground: 208 100% 97%; /* Starlight White #F0F8FF */
+    --card: 215 21% 11%; /* Nebula Navy #161B22 */
+    --card-foreground: 208 100% 97%;
+    --popover: 215 21% 11%;
+    --popover-foreground: 208 100% 97%;
+    --primary: 186 100% 50%; /* Core Cyan #00E5FF */
+    --primary-foreground: 220 43% 6%; /* Space Black text on cyan */
+    --secondary: 215 21% 11%; /* Nebula Navy #161B22 */
+    --secondary-foreground: 208 100% 97%;
+    --muted: 215 21% 11%;
+    --muted-foreground: 215 16% 65%;
+    --accent: 215 21% 14%;
+    --accent-foreground: 208 100% 97%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 208 100% 97%;
+    --border: 215 21% 18%;
+    --input: 215 21% 18%;
+    --ring: 186 100% 50%; /* Core Cyan focus ring */
+    --brand-violet: 282 44% 47%;
+    --brand-cyan: 186 100% 50%;
+  }
+
+  /* Respect the OS preference out of the box when no theme class is set. */
+  @media (prefers-color-scheme: dark) {
+    :root:not(.light) {
+      --background: 220 43% 6%;
+      --foreground: 208 100% 97%;
+      --card: 215 21% 11%;
+      --card-foreground: 208 100% 97%;
+      --popover: 215 21% 11%;
+      --popover-foreground: 208 100% 97%;
+      --primary: 186 100% 50%;
+      --primary-foreground: 220 43% 6%;
+      --secondary: 215 21% 11%;
+      --secondary-foreground: 208 100% 97%;
+      --muted: 215 21% 11%;
+      --muted-foreground: 215 16% 65%;
+      --accent: 215 21% 14%;
+      --accent-foreground: 208 100% 97%;
+      --destructive: 0 72% 51%;
+      --destructive-foreground: 208 100% 97%;
+      --border: 215 21% 18%;
+      --input: 215 21% 18%;
+      --ring: 186 100% 50%;
+    }
   }
 }
 
@@ -29,7 +91,31 @@
   * {
     @apply border-border;
   }
+
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
+    font-feature-settings:
+      'rlig' 1,
+      'calt' 1;
+  }
+
+  /*
+   * Headings use Space Grotesk for engineered precision, with slightly
+   * increased letter-spacing per the brandbook typography hierarchy.
+   */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-heading tracking-tight;
+  }
+
+  code,
+  pre,
+  kbd,
+  samp {
+    @apply font-mono;
   }
 }

--- a/packages/app/src/views/workspace.tsx
+++ b/packages/app/src/views/workspace.tsx
@@ -77,7 +77,7 @@ const NavItem = ({
         'w-full rounded-md px-3 py-1.5 text-left text-sm transition-colors',
         indent ? 'pl-6' : '',
         active
-          ? 'bg-primary text-primary-foreground'
+          ? 'bg-primary text-primary-foreground dark:shadow-glow'
           : 'text-foreground hover:bg-muted',
       ].join(' ')}
     >
@@ -203,7 +203,9 @@ const LeftNav = ({
   return (
     <nav className="flex h-full flex-col gap-4 overflow-y-auto py-4 px-2">
       <div className="px-3">
-        <h1 className="text-lg font-bold">{'SOAT'}</h1>
+        <h1 className="w-fit bg-galaxy-gradient bg-clip-text text-lg font-bold tracking-heading text-transparent">
+          {'SOAT'}
+        </h1>
       </div>
 
       <NavSection title={'Projects'}>

--- a/packages/app/src/views/workspace.tsx
+++ b/packages/app/src/views/workspace.tsx
@@ -1,0 +1,341 @@
+import * as React from 'react';
+
+import { apiFetch } from '@/api/client';
+import { useAuth } from '@/auth/authContext';
+import { Button } from '@/components/ui/button';
+import { EngineView } from '@/engine/engineView';
+import { useNavigation } from '@/engine/navigationContext';
+import { useSpec } from '@/engine/specContext';
+import type { JsonObject, ModuleInfo } from '@/engine/types';
+
+type Project = { id: string; name: string };
+
+const extractProjects = (data: unknown): Project[] => {
+  const list = Array.isArray(data) ? data : [];
+  return list
+    .filter((item): item is JsonObject => {
+      return typeof item === 'object' && item !== null && !Array.isArray(item);
+    })
+    .map((item) => {
+      return {
+        id: String(item.id ?? ''),
+        name: String(item.name ?? item.id ?? ''),
+      };
+    });
+};
+
+const useProjects = (token: string) => {
+  const [projects, setProjects] = React.useState<Project[]>([]);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    if (!token) return;
+    apiFetch<unknown>({ url: '/api/v1/projects', token })
+      .then((result) => {
+        if (result.ok) setProjects(extractProjects(result.data));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [token]);
+
+  return { projects, loading };
+};
+
+const NavSection = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) => {
+  return (
+    <div className="flex flex-col gap-1">
+      <p className="px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {title}
+      </p>
+      {children}
+    </div>
+  );
+};
+
+const NavItem = ({
+  label,
+  active,
+  onClick,
+  indent,
+}: {
+  label: string;
+  active?: boolean;
+  onClick: () => void;
+  indent?: boolean;
+}) => {
+  return (
+    <button
+      onClick={onClick}
+      className={[
+        'w-full rounded-md px-3 py-1.5 text-left text-sm transition-colors',
+        indent ? 'pl-6' : '',
+        active
+          ? 'bg-primary text-primary-foreground'
+          : 'text-foreground hover:bg-muted',
+      ].join(' ')}
+    >
+      {label}
+    </button>
+  );
+};
+
+const ADMIN_TAGS = new Set([
+  'Users',
+  'Policies',
+  'Ai Providers',
+  'AiProviders',
+  'AI Providers',
+]);
+
+type NavModuleListProps = {
+  modules: ModuleInfo[];
+  activeTag: string | null;
+  indent?: boolean;
+  onSelect: (m: ModuleInfo) => void;
+};
+
+const NavModuleList = ({
+  modules,
+  activeTag,
+  indent,
+  onSelect,
+}: NavModuleListProps) => {
+  return modules.map((m) => {
+    return (
+      <NavItem
+        key={m.tag}
+        label={m.label}
+        active={activeTag === m.tag}
+        indent={indent}
+        onClick={() => {
+          return onSelect(m);
+        }}
+      />
+    );
+  });
+};
+
+const buildPathParams = (
+  module: ModuleInfo,
+  projectId: string | null
+): Record<string, string> => {
+  const pathParams: Record<string, string> = {};
+  if (module.isProjectScoped && projectId) {
+    pathParams.project_id = projectId;
+  }
+  return pathParams;
+};
+
+const LeftNav = ({
+  projects,
+  projectsLoading,
+}: {
+  projects: Project[];
+  projectsLoading: boolean;
+}) => {
+  const { state, logout } = useAuth();
+  const { modules, spec } = useSpec();
+  const { view, activeProjectId, navigate, setProject } = useNavigation();
+  const user = state.status === 'authenticated' ? state.user : null;
+
+  const activeListTag = view?.mode === 'list' ? view.tag : null;
+
+  const projectModules = React.useMemo(() => {
+    return modules.filter((m) => {
+      return m.isProjectScoped;
+    });
+  }, [modules]);
+
+  const adminModules = React.useMemo(() => {
+    return modules.filter((m) => {
+      return (
+        !m.isProjectScoped && m.tag !== 'Projects' && !ADMIN_TAGS.has(m.label)
+      );
+    });
+  }, [modules]);
+
+  const adminOnlyModules = React.useMemo(() => {
+    return user?.role === 'admin'
+      ? modules.filter((m) => {
+          return (
+            !m.isProjectScoped &&
+            m.tag !== 'Projects' &&
+            ADMIN_TAGS.has(m.label)
+          );
+        })
+      : [];
+  }, [modules, user]);
+
+  const navigateToModule = React.useCallback(
+    (m: ModuleInfo) => {
+      if (!m.listOp) return;
+      navigate({
+        tag: m.tag,
+        operationId: m.listOp.operation.operationId,
+        pathParams: buildPathParams(m, activeProjectId),
+        mode: 'list',
+      });
+    },
+    [navigate, activeProjectId]
+  );
+
+  const navigateToProjects = React.useCallback(() => {
+    if (!spec) return;
+    const mod = modules.find((m) => {
+      return m.tag === 'Projects';
+    });
+    if (!mod?.listOp) return;
+    navigate({
+      tag: 'Projects',
+      operationId: mod.listOp.operation.operationId,
+      pathParams: {},
+      mode: 'list',
+    });
+  }, [spec, modules, navigate]);
+
+  return (
+    <nav className="flex h-full flex-col gap-4 overflow-y-auto py-4 px-2">
+      <div className="px-3">
+        <h1 className="text-lg font-bold">{'SOAT'}</h1>
+      </div>
+
+      <NavSection title={'Projects'}>
+        <NavItem
+          label={'All Projects'}
+          active={activeListTag === 'Projects'}
+          onClick={navigateToProjects}
+        />
+        {projectsLoading && (
+          <p className="px-3 text-xs text-muted-foreground">{'Loading…'}</p>
+        )}
+        {projects.map((p) => {
+          return (
+            <NavItem
+              key={p.id}
+              label={p.name}
+              active={activeProjectId === p.id && !view}
+              indent
+              onClick={() => {
+                return setProject(p.id);
+              }}
+            />
+          );
+        })}
+      </NavSection>
+
+      {activeProjectId && projectModules.length > 0 && (
+        <NavSection title={'Project'}>
+          <NavModuleList
+            modules={projectModules}
+            activeTag={activeListTag}
+            indent
+            onSelect={navigateToModule}
+          />
+        </NavSection>
+      )}
+
+      {adminModules.length > 0 && (
+        <NavSection title={'Other'}>
+          <NavModuleList
+            modules={adminModules}
+            activeTag={activeListTag}
+            onSelect={navigateToModule}
+          />
+        </NavSection>
+      )}
+
+      {adminOnlyModules.length > 0 && (
+        <NavSection title={'Admin'}>
+          <NavModuleList
+            modules={adminOnlyModules}
+            activeTag={activeListTag}
+            onSelect={navigateToModule}
+          />
+        </NavSection>
+      )}
+
+      <div className="mt-auto flex flex-col gap-1 border-t pt-4">
+        <p className="px-3 text-xs text-muted-foreground">
+          {user ? `${user.username} · ${user.role}` : ''}
+        </p>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="justify-start"
+          onClick={logout}
+        >
+          {'Sign out'}
+        </Button>
+      </div>
+    </nav>
+  );
+};
+
+const MainArea = () => {
+  const { view, activeProjectId } = useNavigation();
+  const { modules, spec, loading, error } = useSpec();
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        {'Loading workspace…'}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 text-sm text-destructive">
+        {`Failed to load spec: ${error}`}
+      </div>
+    );
+  }
+
+  if (view && spec) {
+    return <EngineView descriptor={view} modules={modules} spec={spec} />;
+  }
+
+  if (activeProjectId) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
+        <p className="text-lg font-medium text-foreground">
+          {'Project selected'}
+        </p>
+        <p className="text-sm">{'Choose a module from the left navigation.'}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
+      <p className="text-lg font-medium text-foreground">{'Welcome to SOAT'}</p>
+      <p className="text-sm">
+        {'Select a project or browse resources from the left navigation.'}
+      </p>
+    </div>
+  );
+};
+
+export const Workspace = () => {
+  const { state } = useAuth();
+  const token = state.status === 'authenticated' ? state.token : '';
+  const { projects, loading: projectsLoading } = useProjects(token);
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <aside className="w-56 shrink-0 border-r bg-muted/20">
+        <LeftNav projects={projects} projectsLoading={projectsLoading} />
+      </aside>
+      <main className="flex-1 overflow-y-auto p-6">
+        <MainArea />
+      </main>
+    </div>
+  );
+};

--- a/packages/app/tailwind.config.ts
+++ b/packages/app/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
     extend: {
@@ -30,10 +31,36 @@ const config: Config = {
           DEFAULT: 'hsl(var(--accent))',
           foreground: 'hsl(var(--accent-foreground))',
         },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
         card: {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
+        // Brand DNA — decorative accents (logo, gradients, glows).
+        brand: {
+          violet: 'hsl(var(--brand-violet))',
+          cyan: 'hsl(var(--brand-cyan))',
+        },
+      },
+      fontFamily: {
+        sans: ['Inter', 'system-ui', 'sans-serif'],
+        heading: ['"Space Grotesk"', 'Inter', 'system-ui', 'sans-serif'],
+        mono: ['"JetBrains Mono"', 'ui-monospace', 'monospace'],
+      },
+      letterSpacing: {
+        heading: '0.02em',
+      },
+      boxShadow: {
+        // Neon glow for active elements in dark mode (Core Cyan).
+        glow: '0 0 16px 0 hsl(var(--brand-cyan) / 0.45)',
+      },
+      backgroundImage: {
+        // Vector Galaxy flow gradient (Deep Violet -> primary).
+        'galaxy-gradient':
+          'linear-gradient(135deg, hsl(var(--brand-violet)), hsl(var(--primary)))',
       },
       borderRadius: {
         lg: 'var(--radius)',

--- a/packages/server/src/lib/openapiSpec.ts
+++ b/packages/server/src/lib/openapiSpec.ts
@@ -1,0 +1,78 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as url from 'node:url';
+
+import yaml from 'js-yaml';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+type SpecFile = {
+  paths?: Record<string, unknown>;
+  components?: {
+    schemas?: Record<string, unknown>;
+    securitySchemes?: Record<string, unknown>;
+  };
+};
+
+type MergedSpec = {
+  openapi: string;
+  info: { title: string; version: string };
+  paths: Record<string, unknown>;
+  components: {
+    schemas: Record<string, unknown>;
+    securitySchemes: Record<string, unknown>;
+  };
+};
+
+const getSpecDir = (): string => {
+  const candidate1 = path.resolve(__dirname, '../rest/openapi/v1');
+  const candidate2 = path.resolve(__dirname, 'rest/openapi/v1');
+  return fs.existsSync(candidate1) ? candidate1 : candidate2;
+};
+
+const loadSpecFile = (filePath: string): SpecFile | null => {
+  try {
+    return yaml.load(fs.readFileSync(filePath, 'utf-8')) as SpecFile;
+  } catch {
+    return null;
+  }
+};
+
+export const loadMergedOpenApiSpec = (): MergedSpec => {
+  const specDir = getSpecDir();
+  const merged: MergedSpec = {
+    openapi: '3.0.3',
+    info: { title: 'SOAT API', version: '1.0.0' },
+    paths: {},
+    components: { schemas: {}, securitySchemes: {} },
+  };
+
+  if (!fs.existsSync(specDir)) return merged;
+
+  const files = fs
+    .readdirSync(specDir)
+    .filter((f) => f.endsWith('.yaml'))
+    .sort();
+
+  for (const file of files) {
+    const spec = loadSpecFile(path.join(specDir, file));
+    if (!spec) continue;
+    Object.assign(merged.paths, spec.paths ?? {});
+    Object.assign(merged.components.schemas, spec.components?.schemas ?? {});
+    Object.assign(
+      merged.components.securitySchemes,
+      spec.components?.securitySchemes ?? {}
+    );
+  }
+
+  return merged;
+};
+
+let cachedSpec: MergedSpec | null = null;
+
+export const getMergedOpenApiSpec = (): MergedSpec => {
+  if (!cachedSpec) {
+    cachedSpec = loadMergedOpenApiSpec();
+  }
+  return cachedSpec;
+};

--- a/packages/server/src/lib/openapiSpec.ts
+++ b/packages/server/src/lib/openapiSpec.ts
@@ -51,7 +51,9 @@ export const loadMergedOpenApiSpec = (): MergedSpec => {
 
   const files = fs
     .readdirSync(specDir)
-    .filter((f) => f.endsWith('.yaml'))
+    .filter((f) => {
+      return f.endsWith('.yaml');
+    })
     .sort();
 
   for (const file of files) {

--- a/packages/server/src/rest/v1/index.ts
+++ b/packages/server/src/rest/v1/index.ts
@@ -13,6 +13,7 @@ import { formationsRouter } from './formations';
 import { generationsRouter } from './generations';
 import { knowledgeRouter } from './knowledge';
 import { memoriesRouter } from './memories';
+import { openapiRouter } from './openapi';
 import { orchestrationsRouter } from './orchestrations';
 import { policiesRouter } from './policies';
 import { projectsRouter } from './projects';
@@ -20,7 +21,6 @@ import { secretsRouter } from './secrets';
 import { toolsRouter } from './tools';
 import { tracesRouter } from './traces';
 import { usersRouter } from './users';
-import { openapiRouter } from './openapi';
 import { webhooksRouter } from './webhooks';
 
 const v1Router = new Router();

--- a/packages/server/src/rest/v1/index.ts
+++ b/packages/server/src/rest/v1/index.ts
@@ -20,6 +20,7 @@ import { secretsRouter } from './secrets';
 import { toolsRouter } from './tools';
 import { tracesRouter } from './traces';
 import { usersRouter } from './users';
+import { openapiRouter } from './openapi';
 import { webhooksRouter } from './webhooks';
 
 const v1Router = new Router();
@@ -45,5 +46,6 @@ v1Router.use(toolsRouter.routes());
 v1Router.use(tracesRouter.routes());
 v1Router.use(usersRouter.routes());
 v1Router.use(webhooksRouter.routes());
+v1Router.use(openapiRouter.routes());
 
 export { v1Router };

--- a/packages/server/src/rest/v1/openapi.ts
+++ b/packages/server/src/rest/v1/openapi.ts
@@ -1,5 +1,4 @@
 import { Router } from '@ttoss/http-server';
-
 import type { Context } from 'src/Context';
 import { getMergedOpenApiSpec } from 'src/lib/openapiSpec';
 

--- a/packages/server/src/rest/v1/openapi.ts
+++ b/packages/server/src/rest/v1/openapi.ts
@@ -1,0 +1,18 @@
+import { Router } from '@ttoss/http-server';
+
+import type { Context } from 'src/Context';
+import { getMergedOpenApiSpec } from 'src/lib/openapiSpec';
+
+const openapiRouter = new Router<Context>();
+
+openapiRouter.get('/openapi.json', async (ctx: Context) => {
+  if (!ctx.authUser) {
+    ctx.status = 401;
+    ctx.body = { error: 'Unauthorized' };
+    return;
+  }
+
+  ctx.body = getMergedOpenApiSpec();
+});
+
+export { openapiRouter };

--- a/packages/server/tests/unit/tests/lib/openapiSpec.test.ts
+++ b/packages/server/tests/unit/tests/lib/openapiSpec.test.ts
@@ -1,0 +1,182 @@
+type MergedSpec = {
+  openapi: string;
+  info: { title: string; version: string };
+  paths: Record<string, unknown>;
+  components: {
+    schemas: Record<string, unknown>;
+    securitySchemes: Record<string, unknown>;
+  };
+};
+
+type OpenapiSpecModule = {
+  loadMergedOpenApiSpec: () => MergedSpec;
+  getMergedOpenApiSpec: () => MergedSpec;
+};
+
+describe('openapiSpec', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.unmock('node:fs');
+    jest.unmock('js-yaml');
+  });
+
+  test('returns empty spec when specDir does not exist', () => {
+    jest.doMock('node:fs', () => {
+      return {
+        existsSync: jest.fn(() => {
+          return false;
+        }),
+        readdirSync: jest.fn(),
+        readFileSync: jest.fn(),
+      };
+    });
+
+    const { loadMergedOpenApiSpec } = jest.requireActual(
+      'src/lib/openapiSpec'
+    ) as OpenapiSpecModule;
+
+    const spec = loadMergedOpenApiSpec();
+    expect(spec.openapi).toBe('3.0.3');
+    expect(spec.paths).toEqual({});
+    expect(spec.components.schemas).toEqual({});
+    expect(spec.components.securitySchemes).toEqual({});
+  });
+
+  test('skips files that fail to parse and returns empty spec', () => {
+    jest.doMock('node:fs', () => {
+      return {
+        existsSync: jest.fn(() => {
+          return true;
+        }),
+        readdirSync: jest.fn(() => {
+          return ['broken.yaml'];
+        }),
+        readFileSync: jest.fn(() => {
+          throw new Error('read error');
+        }),
+      };
+    });
+
+    const { loadMergedOpenApiSpec } = jest.requireActual(
+      'src/lib/openapiSpec'
+    ) as OpenapiSpecModule;
+
+    const spec = loadMergedOpenApiSpec();
+    expect(spec.paths).toEqual({});
+  });
+
+  test('merges spec with no paths or components gracefully', () => {
+    jest.doMock('node:fs', () => {
+      return {
+        existsSync: jest.fn(() => {
+          return true;
+        }),
+        readdirSync: jest.fn(() => {
+          return ['minimal.yaml'];
+        }),
+        readFileSync: jest.fn(() => {
+          return 'openapi: 3.0.0';
+        }),
+      };
+    });
+
+    jest.doMock('js-yaml', () => {
+      return {
+        __esModule: true,
+        default: {
+          load: jest.fn(() => {
+            return { openapi: '3.0.0' };
+          }),
+        },
+      };
+    });
+
+    const { loadMergedOpenApiSpec } = jest.requireActual(
+      'src/lib/openapiSpec'
+    ) as OpenapiSpecModule;
+
+    const spec = loadMergedOpenApiSpec();
+    expect(spec.paths).toEqual({});
+    expect(spec.components.schemas).toEqual({});
+    expect(spec.components.securitySchemes).toEqual({});
+  });
+
+  test('merges spec with components but no securitySchemes', () => {
+    jest.doMock('node:fs', () => {
+      return {
+        existsSync: jest.fn(() => {
+          return true;
+        }),
+        readdirSync: jest.fn(() => {
+          return ['partial.yaml'];
+        }),
+        readFileSync: jest.fn(() => {
+          return '';
+        }),
+      };
+    });
+
+    jest.doMock('js-yaml', () => {
+      return {
+        __esModule: true,
+        default: {
+          load: jest.fn(() => {
+            return {
+              paths: { '/test': { get: {} } },
+              components: { schemas: { Foo: { type: 'object' } } },
+            };
+          }),
+        },
+      };
+    });
+
+    const { loadMergedOpenApiSpec } = jest.requireActual(
+      'src/lib/openapiSpec'
+    ) as OpenapiSpecModule;
+
+    const spec = loadMergedOpenApiSpec();
+    expect(spec.paths['/test']).toBeDefined();
+    expect(spec.components.schemas['Foo']).toBeDefined();
+    expect(spec.components.securitySchemes).toEqual({});
+  });
+
+  test('getMergedOpenApiSpec caches the result on second call', () => {
+    jest.doMock('node:fs', () => {
+      return {
+        existsSync: jest.fn(() => {
+          return true;
+        }),
+        readdirSync: jest.fn(() => {
+          return ['spec.yaml'];
+        }),
+        readFileSync: jest.fn(() => {
+          return '';
+        }),
+      };
+    });
+
+    jest.doMock('js-yaml', () => {
+      return {
+        __esModule: true,
+        default: {
+          load: jest.fn(() => {
+            return { paths: { '/cached': {} } };
+          }),
+        },
+      };
+    });
+
+    const { getMergedOpenApiSpec } = jest.requireActual(
+      'src/lib/openapiSpec'
+    ) as OpenapiSpecModule;
+
+    const first = getMergedOpenApiSpec();
+    const second = getMergedOpenApiSpec();
+    expect(first).toBe(second);
+  });
+});

--- a/packages/server/tests/unit/tests/rest/openapi.test.ts
+++ b/packages/server/tests/unit/tests/rest/openapi.test.ts
@@ -1,0 +1,40 @@
+import {
+  authenticatedTestClient,
+  loginAs,
+  testClient,
+} from '../../testClient';
+
+describe('GET /api/v1/openapi.json', () => {
+  let adminToken: string;
+
+  beforeAll(async () => {
+    await testClient
+      .post('/api/v1/users/bootstrap')
+      .send({ username: 'admin', password: 'supersecret' });
+    adminToken = await loginAs('admin', 'supersecret');
+  });
+
+  test('returns merged OpenAPI spec for authenticated user', async () => {
+    const res = await authenticatedTestClient(adminToken).get(
+      '/api/v1/openapi.json'
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.openapi).toBeDefined();
+    expect(typeof res.body.paths).toBe('object');
+    expect(typeof res.body.components).toBe('object');
+  });
+
+  test('spec contains known paths', async () => {
+    const res = await authenticatedTestClient(adminToken).get(
+      '/api/v1/openapi.json'
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.paths['/api/v1/projects']).toBeDefined();
+    expect(res.body.paths['/api/v1/users']).toBeDefined();
+  });
+
+  test('returns 401 for unauthenticated request', async () => {
+    const res = await testClient.get('/api/v1/openapi.json');
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/openapi.json` endpoint that serves the merged OpenAPI spec to the SPA at runtime
- Implements a generic rendering engine (`SpecContext`, `NavigationContext`, `ListView`, `DetailView`, `FormView`) driven entirely by the spec — no per-resource UI code needed
- Adds a full workspace shell with left nav showing projects, project-scoped modules, general modules, and admin-only modules (role-gated)

## Test plan

- [ ] `pnpm --filter @soat/app typecheck` passes
- [ ] `pnpm eslint src/` in `packages/app` passes (0 errors)
- [ ] `pnpm --filter @soat/server test --testPathPatterns=openapi.test.ts` passes
- [ ] Log in to the app and verify the left nav loads all modules from the live spec
- [ ] Select a project, navigate a module list, open a detail view, and create/edit a resource end-to-end

https://claude.ai/code/session_01JZhSnUiGYZGvUUiDmJcZ1g

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZhSnUiGYZGvUUiDmJcZ1g)_