### PR TITLE
chore(release): publish packages v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://github.com/ttoss/soat/compare/v0.9.1...v0.11.0) (2026-06-13)
+
+### Features
+
+* **app:** OpenAPI-driven generic UI engine with workspace shell ([#205](https://github.com/ttoss/soat/issues/205)) ([54a8272](https://github.com/ttoss/soat/commit/54a8272d3d73f1831fef4318895a1bc74c876807)), closes [#1A73E8](https://github.com/ttoss/soat/issues/1A73E8) [#00E5FF](https://github.com/ttoss/soat/issues/00E5FF)
+* debate mode — Phase 2 multi-perspective deliberation ([#202](https://github.com/ttoss/soat/issues/202)) ([d3e66c3](https://github.com/ttoss/soat/commit/d3e66c3e19aeafb941d285e4008b2eddede8ada8))
+* **server:** deep-thinking reasoning — PRD reframe + provider-native effort + reflect mode ([#200](https://github.com/ttoss/soat/issues/200)) ([dec6192](https://github.com/ttoss/soat/commit/dec61927979ac72bbce33f3b5c6428fa228a9a56))
+
 # [0.10.0](https://github.com/ttoss/soat/compare/v0.9.1...v0.10.0) (2026-06-13)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "npmClient": "pnpm",
   "stream": true,
   "command": {

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://127.0.0.1/45259/git/ttoss/compare/v0.9.1...v0.11.0) (2026-06-13)
+
+### Features
+
+* **app:** OpenAPI-driven generic UI engine with workspace shell ([#205](https://127.0.0.1/45259/git/ttoss/issues/205)) ([54a8272](https://127.0.0.1/45259/git/ttoss/commits/54a8272d3d73f1831fef4318895a1bc74c876807)), closes [#1A73E8](https://127.0.0.1/45259/git/ttoss/issues/1A73E8) [#00E5FF](https://127.0.0.1/45259/git/ttoss/issues/00E5FF)
+
 # [0.10.0](https://127.0.0.1/37241/git/ttoss/compare/v0.9.1...v0.10.0) (2026-06-13)
 
 ### Features

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/app",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://github.com/ttoss/soat/compare/v0.9.1...v0.11.0) (2026-06-13)
+
+**Note:** Version bump only for package @soat/cli
+
 # [0.10.0](https://github.com/ttoss/soat/compare/v0.9.1...v0.10.0) (2026-06-13)
 
 **Note:** Version bump only for package @soat/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "scripts": {
     "generate": "tsx scripts/generate.ts",

--- a/packages/postgresdb/CHANGELOG.md
+++ b/packages/postgresdb/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://127.0.0.1/45259/git/ttoss/compare/v0.9.1...v0.11.0) (2026-06-13)
+
+### Features
+
+* **server:** deep-thinking reasoning — PRD reframe + provider-native effort + reflect mode ([#200](https://127.0.0.1/45259/git/ttoss/issues/200)) ([dec6192](https://127.0.0.1/45259/git/ttoss/commits/dec61927979ac72bbce33f3b5c6428fa228a9a56))
+
 # [0.10.0](https://127.0.0.1/37241/git/ttoss/compare/v0.9.1...v0.10.0) (2026-06-13)
 
 ### Features

--- a/packages/postgresdb/package.json
+++ b/packages/postgresdb/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@soat/postgresdb",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Database models and operations for SOAT packages",
   "type": "module",
   "exports": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://github.com/ttoss/soat/compare/v0.9.1...v0.11.0) (2026-06-13)
+
+**Note:** Version bump only for package @soat/sdk
+
 # [0.10.0](https://github.com/ttoss/soat/compare/v0.9.1...v0.10.0) (2026-06-13)
 
 **Note:** Version bump only for package @soat/sdk

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/sdk",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "TypeScript SDK for the SOAT API",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://127.0.0.1/45259/git/ttoss/compare/v0.9.1...v0.11.0) (2026-06-13)
+
+### Features
+
+* **app:** OpenAPI-driven generic UI engine with workspace shell ([#205](https://127.0.0.1/45259/git/ttoss/issues/205)) ([54a8272](https://127.0.0.1/45259/git/ttoss/commits/54a8272d3d73f1831fef4318895a1bc74c876807)), closes [#1A73E8](https://127.0.0.1/45259/git/ttoss/issues/1A73E8) [#00E5FF](https://127.0.0.1/45259/git/ttoss/issues/00E5FF)
+* debate mode — Phase 2 multi-perspective deliberation ([#202](https://127.0.0.1/45259/git/ttoss/issues/202)) ([d3e66c3](https://127.0.0.1/45259/git/ttoss/commits/d3e66c3e19aeafb941d285e4008b2eddede8ada8))
+* **server:** deep-thinking reasoning — PRD reframe + provider-native effort + reflect mode ([#200](https://127.0.0.1/45259/git/ttoss/issues/200)) ([dec6192](https://127.0.0.1/45259/git/ttoss/commits/dec61927979ac72bbce33f3b5c6428fa228a9a56))
+
 # [0.10.0](https://127.0.0.1/37241/git/ttoss/compare/v0.9.1...v0.10.0) (2026-06-13)
 
 ### Bug Fixes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "dist/server.mjs",
   "scripts": {
     "build": "tsdown",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://127.0.0.1/45259/git/ttoss/compare/v0.9.1...v0.11.0) (2026-06-13)
+
+### Features
+
+* debate mode — Phase 2 multi-perspective deliberation ([#202](https://127.0.0.1/45259/git/ttoss/issues/202)) ([d3e66c3](https://127.0.0.1/45259/git/ttoss/commits/d3e66c3e19aeafb941d285e4008b2eddede8ada8))
+* **server:** deep-thinking reasoning — PRD reframe + provider-native effort + reflect mode ([#200](https://127.0.0.1/45259/git/ttoss/issues/200)) ([dec6192](https://127.0.0.1/45259/git/ttoss/commits/dec61927979ac72bbce33f3b5c6428fa228a9a56))
+
 # [0.10.0](https://127.0.0.1/37241/git/ttoss/compare/v0.9.1...v0.10.0) (2026-06-13)
 
 ### Features

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soat/website",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Summary

- Bumps all packages from `0.10.0` → `0.11.0` (minor bump driven by `feat` commits)
- Includes the OpenAPI-driven generic UI engine with workspace shell (`@soat/app`)
- Includes the SOAT brandbook theme alignment (`@soat/app`)
- Includes the `/api/v1/openapi.json` endpoint for serving the merged OpenAPI spec (`@soat/server`)

## Packages

| Package | Version |
|---------|---------|
| `@soat/cli` | `0.11.0` |
| `@soat/sdk` | `0.11.0` |
| `@soat/server` | `0.11.0` |
| `@soat/app` | `0.11.0` (private) |
| `@soat/postgresdb` | `0.11.0` (private) |
| `@soat/website` | `0.11.0` (private) |

https://claude.ai/code/session_01JZhSnUiGYZGvUUiDmJcZ1g

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZhSnUiGYZGvUUiDmJcZ1g)_