### PR TITLE
feat(app): action endpoints in the rendering engine (Phase 3)

### DIFF
--- a/.claude/rules/app-tests.md
+++ b/.claude/rules/app-tests.md
@@ -1,0 +1,158 @@
+# App Test Instructions
+
+How to write tests for `@soat/app` (the React UI served at `/app`). For server
+tests see `tests.md`; this document covers the browser app only.
+
+## Golden Rule — Mock the API, Nothing Else
+
+**Never mock internal components, hooks, providers, the `apiFetch` wrapper, or
+`@soat/sdk`.** The only seam you are allowed to stub is the **HTTP boundary**,
+via [MSW](https://mswjs.io/docs/http/). Everything above the wire — components,
+contexts, the SDK client, request serialization, error handling — runs for real.
+
+This keeps tests behavior-focused and refactor-proof: a test that drives a form
+and asserts the request body at an MSW handler survives any internal rewrite (it
+already survived the `apiFetch` → `@soat/sdk` migration untouched).
+
+Do **not** reach for `vi.mock('@/...')`, `vi.mock('@soat/sdk')`, or fake context
+providers. If you feel the need to, the test is set up wrong.
+
+## Stack
+
+- **Vitest** (`environment: 'jsdom'`, `globals: true`) — config in `packages/app/vitest.config.ts`
+- **@testing-library/react** + **@testing-library/user-event** — render and interact
+- **@testing-library/jest-dom** — DOM matchers (wired in `tests/unit/setup.ts`)
+- **msw** (`msw/node`) — the network mock
+
+## Location and Naming
+
+- Tests live in `packages/app/tests/unit/`, mirroring the source tree
+  (`engine/`, `auth/`, `views/`, `api/`).
+- Name files `<module>.test.ts` (logic) or `<component>.test.tsx` (components).
+- Tests stay **out of `src/`** on purpose: the package lints with `eslint src`,
+  so test files are excluded from the production lint rules.
+- Import app code through the `@/` alias (`@/engine/specUtils`), the same alias
+  used in `src` — it is mirrored in `vitest.config.ts`.
+
+## Running
+
+```bash
+pnpm --filter @soat/app test               # run once
+pnpm --filter @soat/app test:watch          # watch mode
+pnpm --filter @soat/app exec vitest run tests/unit/engine/listView.test.tsx   # single file
+pnpm --filter @soat/app exec vitest run --coverage                            # coverage
+```
+
+## Harness Files (do not duplicate these per test)
+
+| File | Purpose |
+|---|---|
+| `tests/unit/setup.ts` | jest-dom matchers; starts/stops the MSW server; `cleanup()` + `resetHandlers()` + `localStorage.clear()` after each test |
+| `tests/unit/msw/server.ts` | the singleton `server` — import it to override handlers |
+| `tests/unit/msw/handlers.ts` | default handlers (`/users/me`, `/users/login`, `/openapi.json`, `/projects`) + `TEST_USER` |
+| `tests/unit/fixtures/spec.ts` | `testSpec`, a realistic OpenAPI spec that drives the generic engine |
+| `tests/unit/testUtils.tsx` | `renderWithAuth(ui)` and `NavProbe` |
+
+MSW runs with `onUnhandledRequest: 'error'`. **Every request a test triggers must
+have a handler** — either a default in `handlers.ts` or a per-test `server.use`.
+
+## Two Kinds of Test
+
+### 1. Pure logic — no DOM, no MSW
+
+For `specUtils.ts`, `formHelpers.ts`, and any other pure function. Just import
+and assert; use `testSpec` as input where a spec is needed.
+
+```ts
+import { parseModules } from '@/engine/specUtils';
+import { testSpec } from '../fixtures/spec';
+
+test('treats an item-scoped POST as an action, not a create', () => {
+  const agents = parseModules(testSpec).find((m) => m.tag === 'Agents')!;
+  expect(agents.actions?.[0].operation.operationId).toBe('generateAgent');
+});
+```
+
+### 2. Component / integration — real providers + MSW
+
+Use `renderWithAuth`, which mounts the component inside the **real**
+`AuthProvider` and `NavigationProvider`. Auth is driven through its genuine
+public flow (a token in `localStorage` + the default `/users/me` handler), so no
+provider is mocked. Engine views receive `module` / `spec` / `pathParams` as
+props built from `testSpec`.
+
+```tsx
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+
+import { ListView } from '@/engine/listView';
+import { parseModules } from '@/engine/specUtils';
+import { testSpec } from '../fixtures/spec';
+import { server } from '../msw/server';
+import { NavProbe, renderWithAuth } from '../testUtils';
+
+test('clicking "View →" navigates to the detail view', async () => {
+  server.use(
+    http.get('*/api/v1/agents', () =>
+      HttpResponse.json([{ id: 'agt_1', name: 'Alpha' }])
+    )
+  );
+  const agents = parseModules(testSpec).find((m) => m.tag === 'Agents')!;
+
+  renderWithAuth(
+    <>
+      <ListView module={agents} spec={testSpec} pathParams={{}} />
+      <NavProbe />
+    </>
+  );
+
+  await userEvent.click(await screen.findByRole('button', { name: 'View →' }));
+  expect(screen.getByTestId('nav-probe')).toHaveTextContent('"mode":"detail"');
+});
+```
+
+## Conventions and Gotchas
+
+- **Wildcard the host in handlers.** In jsdom, relative requests resolve against
+  `http://localhost/`, so match `http://*` / `*/api/v1/...`, not bare paths:
+  `http.get('*/api/v1/agents', ...)`. Use `:param` for path params
+  (`'*/api/v1/agents/:agent_id'`).
+- **Assert at the handler, not the implementation.** To verify a request body,
+  headers, or method, read them inside the handler and assert afterward:
+  ```ts
+  let body: unknown;
+  server.use(http.post('*/api/v1/agents', async ({ request }) => {
+    body = await request.json();
+    return HttpResponse.json({ id: 'agt_2' }, { status: 201 });
+  }));
+  // ...act...
+  expect(body).toEqual({ name: 'Gamma' });   // proves buildRequestBody for real
+  ```
+- **Observe navigation with `NavProbe`,** never by mocking the navigation
+  context. Render `<NavProbe />` as a sibling and assert on its `nav-probe`
+  testid; it serializes the live `view` / `activeProjectId`.
+- **Prefer `findBy*` over `getBy*`** for anything that appears after a request
+  resolves — most engine views start in a `Loading…` state.
+- **Auth in tests:** `renderWithAuth` sets a token and relies on the default
+  `/users/me` handler. To test a rejected session, override `/users/me` to
+  return 401; to test login failure, post with password `"wrong"` (the default
+  login handler returns 401 for it).
+- **Coverage:** keep the suite above the existing bar (~90% statements). Every
+  new lib function, view, and context branch (happy path, error path, empty
+  state, 401/403/404) needs coverage — mirror the server's coverage discipline.
+- **Adding a new module/resource?** Extend `tests/unit/fixtures/spec.ts` so
+  `parseModules` produces the new module, then test its views the same way.
+  Add a default handler to `handlers.ts` only if most tests need it; otherwise
+  override per test with `server.use`.
+
+## Checklist
+
+- [ ] Test lives under `packages/app/tests/unit/` mirroring the source path
+- [ ] Only the network is mocked (MSW); no component / hook / SDK / `apiFetch` mocks
+- [ ] Real providers via `renderWithAuth` (or `SpecProvider`/`AuthProvider` directly)
+- [ ] Handlers use the `*` host wildcard and cover every request the test makes
+- [ ] Request bodies/headers asserted at the handler where relevant
+- [ ] Navigation asserted via `NavProbe`, not a mock
+- [ ] Error, empty, and unauthorized paths covered, not just the happy path
+- [ ] `pnpm --filter @soat/app test` passes

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@ export default [
   {
     rules: {
       'turbo/no-undeclared-env-vars': 'off',
+      'formatjs/no-literal-string-in-jsx': 'off',
     },
   },
 ];

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,13 +13,14 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "@soat/sdk": "workspace:*",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@soat/sdk": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "react-router-dom": "^7.17.0",
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -8,6 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint src"
   },
   "dependencies": {
@@ -21,13 +23,21 @@
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.5.2",
+    "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.21",
+    "jsdom": "^26.0.0",
+    "msw": "^2.7.0",
     "postcss": "^8.5.4",
     "tailwindcss": "^3.4.17",
     "typescript": "^6.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
+    "@soat/sdk": "workspace:*",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -1,25 +1,26 @@
+import { createClient } from '@soat/sdk';
+
 export type ApiError = { message: string; code?: string };
 
 export type ApiResult<T> =
   | { ok: true; data: T }
   | { ok: false; status: number; error: ApiError };
 
-const extractError = async (res: Response): Promise<ApiError> => {
-  try {
-    const body = (await res.json()) as {
-      error?: { message?: string; code?: string } | string;
-    };
-    if (typeof body.error === 'string') return { message: body.error };
-    if (typeof body.error === 'object' && body.error !== null) {
+const extractError = (errorBody: unknown, status: number): ApiError => {
+  if (typeof errorBody === 'object' && errorBody !== null) {
+    const body = errorBody as Record<string, unknown>;
+    const err = body['error'];
+    if (typeof err === 'string') return { message: err };
+    if (typeof err === 'object' && err !== null) {
+      const e = err as Record<string, unknown>;
       return {
-        message: body.error.message ?? `HTTP ${res.status}`,
-        code: body.error.code,
+        message:
+          typeof e['message'] === 'string' ? e['message'] : `HTTP ${status}`,
+        code: typeof e['code'] === 'string' ? e['code'] : undefined,
       };
     }
-  } catch {
-    // ignore parse error
   }
-  return { message: `HTTP ${res.status}` };
+  return { message: `HTTP ${status}` };
 };
 
 export const apiFetch = async <T>(args: {
@@ -28,20 +29,28 @@ export const apiFetch = async <T>(args: {
   body?: unknown;
   token: string;
 }): Promise<ApiResult<T>> => {
-  const res = await fetch(args.url, {
-    method: args.method ?? 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${args.token}`,
-    },
-    body: args.body !== undefined ? JSON.stringify(args.body) : undefined,
+  const client = createClient({
+    headers: { Authorization: `Bearer ${args.token}` },
   });
 
-  if (!res.ok) {
-    const error = await extractError(res);
-    return { ok: false, status: res.status, error };
+  type Method =
+    | 'GET'
+    | 'POST'
+    | 'PUT'
+    | 'PATCH'
+    | 'DELETE'
+    | 'HEAD'
+    | 'OPTIONS';
+  const result = await client.request({
+    url: args.url,
+    method: (args.method ?? 'GET') as Method,
+    body: args.body,
+  });
+
+  if (result.error !== undefined) {
+    const status = result.response?.status ?? 0;
+    return { ok: false, status, error: extractError(result.error, status) };
   }
 
-  const data = (await res.json()) as T;
-  return { ok: true, data };
+  return { ok: true, data: result.data as T };
 };

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -2,6 +2,16 @@ import { createClient } from '@soat/sdk';
 
 export type ApiError = { message: string; code?: string };
 
+/**
+ * The app is served from the same origin as the API (the server mounts both
+ * `/app` and `/api/v1`), so requests resolve against the current origin. An
+ * explicit base URL is required because the SDK builds a `Request` object,
+ * whose constructor rejects relative URLs outside the browser.
+ */
+export const apiBaseUrl = (): string | undefined => {
+  return typeof window !== 'undefined' ? window.location.origin : undefined;
+};
+
 export type ApiResult<T> =
   | { ok: true; data: T }
   | { ok: false; status: number; error: ApiError };
@@ -30,6 +40,7 @@ export const apiFetch = async <T>(args: {
   token: string;
 }): Promise<ApiResult<T>> => {
   const client = createClient({
+    baseUrl: apiBaseUrl(),
     headers: { Authorization: `Bearer ${args.token}` },
   });
 

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -1,3 +1,5 @@
+import { BrowserRouter } from 'react-router-dom';
+
 import { AuthProvider, useAuth } from './auth/authContext';
 import { LoginForm } from './auth/loginForm';
 import { NavigationProvider } from './engine/navigationContext';
@@ -36,8 +38,10 @@ const AppContent = () => {
 
 export const App = () => {
   return (
-    <AuthProvider>
-      <AppContent />
-    </AuthProvider>
+    <BrowserRouter>
+      <AuthProvider>
+        <AppContent />
+      </AuthProvider>
+    </BrowserRouter>
   );
 };

--- a/packages/app/src/engine/actionView.tsx
+++ b/packages/app/src/engine/actionView.tsx
@@ -1,0 +1,231 @@
+import * as React from 'react';
+
+import { apiFetch } from '@/api/client';
+import { useAuth } from '@/auth/authContext';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { FieldEditor } from './fieldEditor';
+import {
+  buildRequestBody,
+  getOpRequestSchema,
+  initFormData,
+} from './formHelpers';
+import { useNavigation } from './navigationContext';
+import {
+  actionLabel,
+  buildUrl,
+  extractPathParams,
+  humanizeKey,
+} from './specUtils';
+import type {
+  JsonObject,
+  ModuleInfo,
+  ModuleOp,
+  OpenApiSchema,
+  OpenApiSpec,
+} from './types';
+
+const findAction = (
+  module: ModuleInfo,
+  operationId: string
+): ModuleOp | undefined => {
+  return module.actions?.find((a) => {
+    return a.operation.operationId === operationId;
+  });
+};
+
+const formFields = (
+  schema: OpenApiSchema | undefined
+): { properties: Record<string, OpenApiSchema>; required: Set<string> } => {
+  return {
+    properties: schema?.properties ?? {},
+    required: new Set(schema?.required ?? []),
+  };
+};
+
+type MissingParamInputsProps = {
+  names: string[];
+  values: Record<string, string>;
+  onChange: (name: string, value: string) => void;
+};
+
+const MissingParamInputs = ({
+  names,
+  values,
+  onChange,
+}: MissingParamInputsProps) => {
+  return names.map((name) => {
+    return (
+      <div key={name} className="flex flex-col gap-1">
+        <Label htmlFor={`param-${name}`}>
+          {humanizeKey(name)}
+          <span className="text-destructive">{' *'}</span>
+        </Label>
+        <Input
+          id={`param-${name}`}
+          value={values[name] ?? ''}
+          onChange={(e) => {
+            return onChange(name, e.target.value);
+          }}
+        />
+      </div>
+    );
+  });
+};
+
+const ActionResultPanel = ({ result }: { result: JsonObject }) => {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-sm font-medium text-muted-foreground">
+        {'Result'}
+      </span>
+      <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-all rounded-md border bg-muted/30 p-3 font-mono text-xs">
+        {JSON.stringify(result, null, 2)}
+      </pre>
+    </div>
+  );
+};
+
+type ActionViewProps = {
+  module: ModuleInfo;
+  spec: OpenApiSpec;
+  pathParams: Record<string, string>;
+  operationId: string;
+};
+
+export const ActionView = ({
+  module,
+  spec,
+  pathParams,
+  operationId,
+}: ActionViewProps) => {
+  const { state } = useAuth();
+  const { navigate } = useNavigation();
+  const actionOp = findAction(module, operationId);
+  const schema = getOpRequestSchema(actionOp, spec);
+  const [formData, setFormData] = React.useState<Record<string, string>>(() => {
+    return initFormData(schema, {});
+  });
+  const [paramValues, setParamValues] = React.useState<Record<string, string>>(
+    {}
+  );
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [result, setResult] = React.useState<JsonObject | null>(null);
+
+  const token = state.status === 'authenticated' ? state.token : '';
+
+  const handleBack = () => {
+    return navigate(null);
+  };
+
+  if (!actionOp) {
+    return (
+      <div className="text-muted-foreground text-sm">
+        {'Action not found in spec.'}
+      </div>
+    );
+  }
+
+  const missingParams = extractPathParams(actionOp.pathTemplate).filter((p) => {
+    return !pathParams[p];
+  });
+  const { properties, required } = formFields(schema);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token) return;
+    setSubmitting(true);
+    setError(null);
+    setResult(null);
+
+    const bodyResult = buildRequestBody(formData, schema);
+    if (!bodyResult.ok) {
+      setError(bodyResult.error);
+      setSubmitting(false);
+      return;
+    }
+
+    const url = buildUrl(actionOp.pathTemplate, {
+      ...pathParams,
+      ...paramValues,
+    });
+    const res = await apiFetch<JsonObject>({
+      url,
+      method: 'POST',
+      body: bodyResult.body,
+      token,
+    });
+
+    setSubmitting(false);
+    if (!res.ok) {
+      setError(res.error.message);
+      return;
+    }
+    setResult(res.data);
+  };
+
+  return (
+    <div className="flex max-w-lg flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">{actionLabel(actionOp)}</h2>
+        <Button variant="outline" size="sm" onClick={handleBack}>
+          {'← Back'}
+        </Button>
+      </div>
+
+      {actionOp.operation.summary && (
+        <p className="text-sm text-muted-foreground">
+          {actionOp.operation.summary}
+        </p>
+      )}
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <MissingParamInputs
+          names={missingParams}
+          values={paramValues}
+          onChange={(name, value) => {
+            return setParamValues((prev) => {
+              return { ...prev, [name]: value };
+            });
+          }}
+        />
+        {Object.entries(properties).map(([name, fieldSchema]) => {
+          return (
+            <FieldEditor
+              key={name}
+              name={name}
+              schema={fieldSchema}
+              value={formData[name] ?? ''}
+              onChange={(v) => {
+                return setFormData((prev) => {
+                  return { ...prev, [name]: v };
+                });
+              }}
+              required={required.has(name)}
+            />
+          );
+        })}
+
+        <div className="flex gap-2 pt-2">
+          <Button type="submit" disabled={submitting}>
+            {submitting ? 'Running…' : 'Run'}
+          </Button>
+          <Button type="button" variant="outline" onClick={handleBack}>
+            {'Cancel'}
+          </Button>
+        </div>
+      </form>
+
+      {result && <ActionResultPanel result={result} />}
+    </div>
+  );
+};

--- a/packages/app/src/engine/detailView.tsx
+++ b/packages/app/src/engine/detailView.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 
 import { useNavigation } from './navigationContext';
 import {
+  actionLabel,
   buildUrl,
   formatValue,
   humanizeKey,
@@ -38,6 +39,35 @@ const FieldRow = ({ label, value }: { label: string; value: JsonValue }) => {
       )}
     </div>
   );
+};
+
+const DetailActions = ({
+  module,
+  pathParams,
+}: {
+  module: ModuleInfo;
+  pathParams: Record<string, string>;
+}) => {
+  const { navigate } = useNavigation();
+  return (module.actions ?? []).map((action) => {
+    return (
+      <Button
+        key={action.operation.operationId}
+        variant="secondary"
+        size="sm"
+        onClick={() => {
+          return navigate({
+            tag: module.tag,
+            operationId: action.operation.operationId,
+            pathParams,
+            mode: 'action',
+          });
+        }}
+      >
+        {actionLabel(action)}
+      </Button>
+    );
+  });
 };
 
 type DetailViewProps = {
@@ -145,6 +175,7 @@ export const DetailView = ({
               {'Edit'}
             </Button>
           )}
+          <DetailActions module={module} pathParams={pathParams} />
           {module.deleteOp && !confirmDelete && (
             <Button
               variant="destructive"

--- a/packages/app/src/engine/engineView.tsx
+++ b/packages/app/src/engine/engineView.tsx
@@ -1,5 +1,6 @@
 import type * as React from 'react';
 
+import { ActionView } from './actionView';
 import { DetailView } from './detailView';
 import { FormView } from './formView';
 import { ListView } from './listView';
@@ -73,6 +74,17 @@ export const EngineView = ({
         spec={spec}
         pathParams={descriptor.pathParams}
         mode="edit"
+      />
+    );
+  }
+
+  if (descriptor.mode === 'action') {
+    return (
+      <ActionView
+        module={module}
+        spec={spec}
+        pathParams={descriptor.pathParams}
+        operationId={descriptor.operationId}
       />
     );
   }

--- a/packages/app/src/engine/formHelpers.ts
+++ b/packages/app/src/engine/formHelpers.ts
@@ -1,0 +1,76 @@
+import { resolveSchema } from './specUtils';
+import type {
+  JsonObject,
+  JsonValue,
+  ModuleOp,
+  OpenApiSchema,
+  OpenApiSpec,
+} from './types';
+
+export const getOpRequestSchema = (
+  op: ModuleOp | undefined,
+  spec: OpenApiSpec
+): OpenApiSchema | undefined => {
+  const rawSchema =
+    op?.operation?.requestBody?.content?.['application/json']?.schema;
+  return resolveSchema(rawSchema, spec);
+};
+
+export const initFormData = (
+  schema: OpenApiSchema | undefined,
+  prefill: JsonObject
+): Record<string, string> => {
+  const properties = schema?.properties ?? {};
+  const result: Record<string, string> = {};
+  for (const key of Object.keys(properties)) {
+    const prefillValue = prefill[key];
+    result[key] =
+      prefillValue !== undefined && prefillValue !== null
+        ? String(prefillValue)
+        : '';
+  }
+  return result;
+};
+
+export type BodyBuildResult =
+  | { ok: true; body: JsonObject }
+  | { ok: false; error: string };
+
+type FieldConvertResult = { value: JsonValue } | { error: string };
+
+const convertFieldValue = (
+  fieldType: string | undefined,
+  rawValue: string,
+  fieldKey: string
+): FieldConvertResult => {
+  if (fieldType === 'boolean') return { value: rawValue === 'true' };
+  if (fieldType === 'integer' || fieldType === 'number') {
+    return { value: rawValue ? Number(rawValue) : null };
+  }
+  if (fieldType === 'object' || fieldType === 'array') {
+    try {
+      return { value: JSON.parse(rawValue) as JsonValue };
+    } catch {
+      return { error: `Invalid JSON in field "${fieldKey}"` };
+    }
+  }
+  return { value: rawValue };
+};
+
+export const buildRequestBody = (
+  formData: Record<string, string>,
+  schema: OpenApiSchema | undefined
+): BodyBuildResult => {
+  const body: JsonObject = {};
+  const properties = schema?.properties ?? {};
+  const requiredFields = schema?.required ?? [];
+  for (const [key, rawValue] of Object.entries(formData)) {
+    if (!rawValue && !requiredFields.includes(key)) continue;
+    const result = convertFieldValue(properties[key]?.type, rawValue, key);
+    if ('error' in result) {
+      return { ok: false, error: result.error };
+    }
+    body[key] = result.value;
+  }
+  return { ok: true, body };
+};

--- a/packages/app/src/engine/formView.tsx
+++ b/packages/app/src/engine/formView.tsx
@@ -5,11 +5,15 @@ import { useAuth } from '@/auth/authContext';
 import { Button } from '@/components/ui/button';
 
 import { FieldEditor } from './fieldEditor';
+import {
+  buildRequestBody,
+  getOpRequestSchema,
+  initFormData,
+} from './formHelpers';
 import { useNavigation } from './navigationContext';
-import { buildUrl, resolveSchema } from './specUtils';
+import { buildUrl } from './specUtils';
 import type {
   JsonObject,
-  JsonValue,
   ModuleInfo,
   OpenApiSchema,
   OpenApiSpec,
@@ -20,69 +24,10 @@ const getRequestSchema = (
   mode: 'create' | 'edit',
   spec: OpenApiSpec
 ): OpenApiSchema | undefined => {
-  const op = mode === 'create' ? module.createOp : module.updateOp;
-  const rawSchema =
-    op?.operation?.requestBody?.content?.['application/json']?.schema;
-  return resolveSchema(rawSchema, spec);
-};
-
-const initFormData = (
-  schema: OpenApiSchema | undefined,
-  prefill: JsonObject
-): Record<string, string> => {
-  const properties = schema?.properties ?? {};
-  const result: Record<string, string> = {};
-  for (const key of Object.keys(properties)) {
-    const prefillValue = prefill[key];
-    result[key] =
-      prefillValue !== undefined && prefillValue !== null
-        ? String(prefillValue)
-        : '';
-  }
-  return result;
-};
-
-type BodyBuildResult =
-  | { ok: true; body: JsonObject }
-  | { ok: false; error: string };
-
-type FieldConvertResult = { value: JsonValue } | { error: string };
-
-const convertFieldValue = (
-  fieldType: string | undefined,
-  rawValue: string,
-  fieldKey: string
-): FieldConvertResult => {
-  if (fieldType === 'boolean') return { value: rawValue === 'true' };
-  if (fieldType === 'integer' || fieldType === 'number') {
-    return { value: rawValue ? Number(rawValue) : null };
-  }
-  if (fieldType === 'object' || fieldType === 'array') {
-    try {
-      return { value: JSON.parse(rawValue) as JsonValue };
-    } catch {
-      return { error: `Invalid JSON in field "${fieldKey}"` };
-    }
-  }
-  return { value: rawValue };
-};
-
-const buildRequestBody = (
-  formData: Record<string, string>,
-  schema: OpenApiSchema | undefined
-): BodyBuildResult => {
-  const body: JsonObject = {};
-  const properties = schema?.properties ?? {};
-  const requiredFields = schema?.required ?? [];
-  for (const [key, rawValue] of Object.entries(formData)) {
-    if (!rawValue && !requiredFields.includes(key)) continue;
-    const result = convertFieldValue(properties[key]?.type, rawValue, key);
-    if ('error' in result) {
-      return { ok: false, error: result.error };
-    }
-    body[key] = result.value;
-  }
-  return { ok: true, body };
+  return getOpRequestSchema(
+    mode === 'create' ? module.createOp : module.updateOp,
+    spec
+  );
 };
 
 type FormActionsProps = {

--- a/packages/app/src/engine/navigationContext.tsx
+++ b/packages/app/src/engine/navigationContext.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
+import { extractProjectId, pathToView, viewToPath } from './routeUtils';
+import { useSpec } from './specContext';
 import type { ViewDescriptor } from './types';
 
 type NavigationContextValue = {
@@ -21,21 +24,39 @@ export const NavigationProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [view, setView] = React.useState<ViewDescriptor | null>(null);
-  const [activeProjectId, setActiveProjectId] = React.useState<string | null>(
-    null
-  );
+  const { spec, modules } = useSpec();
+  const location = useLocation();
+  const router = useNavigate();
 
-  const navigate = React.useCallback((descriptor: ViewDescriptor | null) => {
-    setView(descriptor);
-  }, []);
+  const view = React.useMemo(() => {
+    if (!spec || modules.length === 0) return null;
+    return pathToView(location.pathname, spec, modules);
+  }, [location.pathname, spec, modules]);
+
+  const activeProjectId = extractProjectId(view);
+
+  const navigate = React.useCallback(
+    (descriptor: ViewDescriptor | null) => {
+      if (!descriptor) {
+        // Go up one level: remove the last path segment.
+        const segments = location.pathname.split('/').filter(Boolean);
+        const parent =
+          segments.length > 1 ? `/${segments.slice(0, -1).join('/')}` : '/app/';
+        router(parent);
+        return;
+      }
+      if (!spec) return;
+      const path = viewToPath(descriptor, spec);
+      if (path) router(path);
+    },
+    [router, spec, location.pathname]
+  );
 
   const setProject = React.useCallback(
     (projectId: string | null) => {
-      setActiveProjectId(projectId);
-      navigate(null);
+      router(projectId ? `/app/v1/projects/${projectId}` : '/app/');
     },
-    [navigate]
+    [router]
   );
 
   return (

--- a/packages/app/src/engine/routeUtils.ts
+++ b/packages/app/src/engine/routeUtils.ts
@@ -1,5 +1,10 @@
 import { buildUrl } from './specUtils';
-import type { ModuleInfo, OpenApiSpec, ViewDescriptor, ViewMode } from './types';
+import type {
+  ModuleInfo,
+  OpenApiSpec,
+  ViewDescriptor,
+  ViewMode,
+} from './types';
 
 const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
 
@@ -26,11 +31,13 @@ export const matchTemplate = (
   return params;
 };
 
-const appToApi = (appPath: string): string =>
-  appPath.replace(/^\/app\//, '/api/');
+const appToApi = (appPath: string): string => {
+  return appPath.replace(/^\/app\//, '/api/');
+};
 
-const apiToApp = (apiPath: string): string =>
-  apiPath.replace(/^\/api\//, '/app/');
+const apiToApp = (apiPath: string): string => {
+  return apiPath.replace(/^\/api\//, '/app/');
+};
 
 // Find the path template for a given operationId. Handles both camelCase
 // operationId and the snake_case operation_id the server emits.
@@ -67,48 +74,97 @@ export const viewToPath = (
   return appPath;
 };
 
+const findCreateViewForPath = (
+  apiPath: string,
+  modules: ModuleInfo[]
+): ViewDescriptor | null => {
+  for (const mod of modules) {
+    if (!mod.createOp || !mod.listOp) continue;
+    const params = matchTemplate(apiPath, mod.listOp.pathTemplate);
+    if (params !== null) {
+      return {
+        tag: mod.tag,
+        operationId: mod.createOp.operation.operationId,
+        pathParams: params,
+        mode: 'create',
+      };
+    }
+  }
+  return null;
+};
+
+const findEditViewForPath = (
+  apiPath: string,
+  modules: ModuleInfo[]
+): ViewDescriptor | null => {
+  for (const mod of modules) {
+    if (!mod.updateOp || !mod.getOp) continue;
+    const params = matchTemplate(apiPath, mod.getOp.pathTemplate);
+    if (params !== null) {
+      return {
+        tag: mod.tag,
+        operationId: mod.updateOp.operation.operationId,
+        pathParams: params,
+        mode: 'edit',
+      };
+    }
+  }
+  return null;
+};
+
+type RawPathItem = Record<string, Record<string, unknown> | undefined>;
+
+const extractOpId = (op: Record<string, unknown>): string => {
+  return (op['operationId'] ?? op['operation_id']) as string;
+};
+
+const extractTag = (op: Record<string, unknown>): string => {
+  return (op['tags'] as string[] | undefined)?.[0] ?? 'Other';
+};
+
+const findViewFromSpecPath = (
+  template: string,
+  pathItem: RawPathItem,
+  params: Record<string, string>
+): ViewDescriptor | null => {
+  const getOp = pathItem['get'];
+  const postOp = pathItem['post'];
+
+  if (getOp) {
+    const lastSegment = template.split('/').filter(Boolean).pop() ?? '';
+    const mode: ViewMode = lastSegment.startsWith('{') ? 'detail' : 'list';
+    return {
+      tag: extractTag(getOp),
+      operationId: extractOpId(getOp),
+      pathParams: params,
+      mode,
+    };
+  }
+
+  if (postOp) {
+    return {
+      tag: extractTag(postOp),
+      operationId: extractOpId(postOp),
+      pathParams: params,
+      mode: 'action',
+    };
+  }
+
+  return null;
+};
+
 // Derive a ViewDescriptor from the current app URL pathname + loaded spec.
 export const pathToView = (
   pathname: string,
   spec: OpenApiSpec,
   modules: ModuleInfo[]
 ): ViewDescriptor | null => {
-  // /new suffix → create mode
   if (pathname.endsWith('/new')) {
-    const parentAppPath = pathname.slice(0, -4);
-    const parentApiPath = appToApi(parentAppPath);
-    for (const mod of modules) {
-      if (!mod.createOp || !mod.listOp) continue;
-      const params = matchTemplate(parentApiPath, mod.listOp.pathTemplate);
-      if (params !== null) {
-        return {
-          tag: mod.tag,
-          operationId: mod.createOp.operation.operationId,
-          pathParams: params,
-          mode: 'create',
-        };
-      }
-    }
-    return null;
+    return findCreateViewForPath(appToApi(pathname.slice(0, -4)), modules);
   }
 
-  // /edit suffix → edit mode
   if (pathname.endsWith('/edit')) {
-    const itemAppPath = pathname.slice(0, -5);
-    const itemApiPath = appToApi(itemAppPath);
-    for (const mod of modules) {
-      if (!mod.updateOp || !mod.getOp) continue;
-      const params = matchTemplate(itemApiPath, mod.getOp.pathTemplate);
-      if (params !== null) {
-        return {
-          tag: mod.tag,
-          operationId: mod.updateOp.operation.operationId,
-          pathParams: params,
-          mode: 'edit',
-        };
-      }
-    }
-    return null;
+    return findEditViewForPath(appToApi(pathname.slice(0, -5)), modules);
   }
 
   const apiPath = appToApi(pathname);
@@ -116,29 +172,20 @@ export const pathToView = (
   for (const [template, pathItem] of Object.entries(spec.paths ?? {})) {
     const params = matchTemplate(apiPath, template);
     if (params === null) continue;
-
-    const raw = pathItem as Record<string, Record<string, unknown> | undefined>;
-    const getOp = raw['get'];
-    const postOp = raw['post'];
-
-    if (getOp) {
-      const opId = (getOp['operationId'] ?? getOp['operation_id']) as string;
-      const tag = (getOp['tags'] as string[] | undefined)?.[0] ?? 'Other';
-      const lastSegment = template.split('/').filter(Boolean).pop() ?? '';
-      const mode: ViewMode = lastSegment.startsWith('{') ? 'detail' : 'list';
-      return { tag, operationId: opId, pathParams: params, mode };
-    }
-
-    if (postOp) {
-      const opId = (postOp['operationId'] ?? postOp['operation_id']) as string;
-      const tag = (postOp['tags'] as string[] | undefined)?.[0] ?? 'Other';
-      return { tag, operationId: opId, pathParams: params, mode: 'action' };
-    }
+    const view = findViewFromSpecPath(
+      template,
+      pathItem as RawPathItem,
+      params
+    );
+    if (view) return view;
   }
 
   return null;
 };
 
 // Extract project_id from the view's path params (if any).
-export const extractProjectId = (view: ViewDescriptor | null): string | null =>
-  view?.pathParams['project_id'] ?? null;
+export const extractProjectId = (
+  view: ViewDescriptor | null
+): string | null => {
+  return view?.pathParams['project_id'] ?? null;
+};

--- a/packages/app/src/engine/routeUtils.ts
+++ b/packages/app/src/engine/routeUtils.ts
@@ -1,0 +1,144 @@
+import { buildUrl } from './specUtils';
+import type { ModuleInfo, OpenApiSpec, ViewDescriptor, ViewMode } from './types';
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
+
+// Match a concrete URL path against an API path template (e.g. /api/v1/agents/{agent_id}).
+// Returns extracted path params on match, null otherwise.
+export const matchTemplate = (
+  urlPath: string,
+  apiTemplate: string
+): Record<string, string> | null => {
+  const urlParts = urlPath.split('/').filter(Boolean);
+  const templateParts = apiTemplate.split('/').filter(Boolean);
+  if (urlParts.length !== templateParts.length) return null;
+
+  const params: Record<string, string> = {};
+  for (let i = 0; i < templateParts.length; i++) {
+    const t = templateParts[i];
+    const u = urlParts[i];
+    if (t.startsWith('{') && t.endsWith('}')) {
+      params[t.slice(1, -1)] = decodeURIComponent(u);
+    } else if (t !== u) {
+      return null;
+    }
+  }
+  return params;
+};
+
+const appToApi = (appPath: string): string =>
+  appPath.replace(/^\/app\//, '/api/');
+
+const apiToApp = (apiPath: string): string =>
+  apiPath.replace(/^\/api\//, '/app/');
+
+// Find the path template for a given operationId. Handles both camelCase
+// operationId and the snake_case operation_id the server emits.
+const findPathTemplate = (
+  operationId: string,
+  spec: OpenApiSpec
+): string | null => {
+  for (const [template, pathItem] of Object.entries(spec.paths ?? {})) {
+    for (const method of HTTP_METHODS) {
+      const raw = pathItem[method] as Record<string, unknown> | undefined;
+      if (!raw) continue;
+      const opId = (raw['operationId'] ?? raw['operation_id']) as
+        | string
+        | undefined;
+      if (opId === operationId) return template;
+    }
+  }
+  return null;
+};
+
+// Convert a ViewDescriptor to an app URL path like /app/v1/agents/agt_123.
+export const viewToPath = (
+  descriptor: ViewDescriptor,
+  spec: OpenApiSpec
+): string | null => {
+  const template = findPathTemplate(descriptor.operationId, spec);
+  if (!template) return null;
+
+  const apiPath = buildUrl(template, descriptor.pathParams);
+  const appPath = apiToApp(apiPath);
+
+  if (descriptor.mode === 'create') return `${appPath}/new`;
+  if (descriptor.mode === 'edit') return `${appPath}/edit`;
+  return appPath;
+};
+
+// Derive a ViewDescriptor from the current app URL pathname + loaded spec.
+export const pathToView = (
+  pathname: string,
+  spec: OpenApiSpec,
+  modules: ModuleInfo[]
+): ViewDescriptor | null => {
+  // /new suffix → create mode
+  if (pathname.endsWith('/new')) {
+    const parentAppPath = pathname.slice(0, -4);
+    const parentApiPath = appToApi(parentAppPath);
+    for (const mod of modules) {
+      if (!mod.createOp || !mod.listOp) continue;
+      const params = matchTemplate(parentApiPath, mod.listOp.pathTemplate);
+      if (params !== null) {
+        return {
+          tag: mod.tag,
+          operationId: mod.createOp.operation.operationId,
+          pathParams: params,
+          mode: 'create',
+        };
+      }
+    }
+    return null;
+  }
+
+  // /edit suffix → edit mode
+  if (pathname.endsWith('/edit')) {
+    const itemAppPath = pathname.slice(0, -5);
+    const itemApiPath = appToApi(itemAppPath);
+    for (const mod of modules) {
+      if (!mod.updateOp || !mod.getOp) continue;
+      const params = matchTemplate(itemApiPath, mod.getOp.pathTemplate);
+      if (params !== null) {
+        return {
+          tag: mod.tag,
+          operationId: mod.updateOp.operation.operationId,
+          pathParams: params,
+          mode: 'edit',
+        };
+      }
+    }
+    return null;
+  }
+
+  const apiPath = appToApi(pathname);
+
+  for (const [template, pathItem] of Object.entries(spec.paths ?? {})) {
+    const params = matchTemplate(apiPath, template);
+    if (params === null) continue;
+
+    const raw = pathItem as Record<string, Record<string, unknown> | undefined>;
+    const getOp = raw['get'];
+    const postOp = raw['post'];
+
+    if (getOp) {
+      const opId = (getOp['operationId'] ?? getOp['operation_id']) as string;
+      const tag = (getOp['tags'] as string[] | undefined)?.[0] ?? 'Other';
+      const lastSegment = template.split('/').filter(Boolean).pop() ?? '';
+      const mode: ViewMode = lastSegment.startsWith('{') ? 'detail' : 'list';
+      return { tag, operationId: opId, pathParams: params, mode };
+    }
+
+    if (postOp) {
+      const opId = (postOp['operationId'] ?? postOp['operation_id']) as string;
+      const tag = (postOp['tags'] as string[] | undefined)?.[0] ?? 'Other';
+      return { tag, operationId: opId, pathParams: params, mode: 'action' };
+    }
+  }
+
+  return null;
+};
+
+// Extract project_id from the view's path params (if any).
+export const extractProjectId = (view: ViewDescriptor | null): string | null =>
+  view?.pathParams['project_id'] ?? null;

--- a/packages/app/src/engine/specContext.tsx
+++ b/packages/app/src/engine/specContext.tsx
@@ -1,3 +1,4 @@
+import { createClient } from '@soat/sdk';
 import * as React from 'react';
 
 import { parseModules } from './specUtils';
@@ -23,11 +24,14 @@ const SpecContext = React.createContext<SpecContextValue>({
 });
 
 const fetchSpec = async (token: string): Promise<OpenApiSpec> => {
-  const res = await fetch('/api/v1/openapi.json', {
+  const client = createClient({
     headers: { Authorization: `Bearer ${token}` },
   });
-  if (!res.ok) throw new Error(`Failed to load spec: ${res.status}`);
-  return res.json() as Promise<OpenApiSpec>;
+  const result = await client.get({ url: '/api/v1/openapi.json' });
+  if (result.error !== undefined) {
+    throw new Error(`Failed to load spec: ${result.response?.status ?? 0}`);
+  }
+  return result.data as OpenApiSpec;
 };
 
 export const SpecProvider = ({

--- a/packages/app/src/engine/specContext.tsx
+++ b/packages/app/src/engine/specContext.tsx
@@ -1,6 +1,8 @@
 import { createClient } from '@soat/sdk';
 import * as React from 'react';
 
+import { apiBaseUrl } from '@/api/client';
+
 import { parseModules } from './specUtils';
 import type { ModuleInfo, OpenApiSpec } from './types';
 
@@ -25,6 +27,7 @@ const SpecContext = React.createContext<SpecContextValue>({
 
 const fetchSpec = async (token: string): Promise<OpenApiSpec> => {
   const client = createClient({
+    baseUrl: apiBaseUrl(),
     headers: { Authorization: `Bearer ${token}` },
   });
   const result = await client.get({ url: '/api/v1/openapi.json' });

--- a/packages/app/src/engine/specUtils.ts
+++ b/packages/app/src/engine/specUtils.ts
@@ -3,7 +3,6 @@ import type {
   JsonValue,
   ModuleInfo,
   ModuleOp,
-  OpenApiOperation,
   OpenApiSchema,
   OpenApiSpec,
 } from './types';
@@ -43,72 +42,104 @@ export const humanizeKey = (key: string): string => {
   });
 };
 
-type OpKey = 'listOp' | 'getOp' | 'createOp' | 'updateOp' | 'deleteOp';
+export const extractPathParams = (pathTemplate: string): string[] => {
+  return Array.from(pathTemplate.matchAll(/\{([^}]+)\}/g)).map((m) => {
+    return m[1];
+  });
+};
 
-const classifyOp = (method: string, pathTemplate: string): OpKey | null => {
+export const actionLabel = (op: ModuleOp): string => {
+  const last = op.pathTemplate.split('/').filter(Boolean).pop();
+  return humanizeKey(last ?? op.operation.operationId);
+};
+
+type OpKey = 'listOp' | 'getOp' | 'updateOp' | 'deleteOp';
+
+const classifyNonPost = (method: HttpMethod, pathTemplate: string): OpKey => {
   if (method === 'get') {
     return isCollectionPath(pathTemplate) ? 'listOp' : 'getOp';
   }
-  if (method === 'post' && isCollectionPath(pathTemplate)) return 'createOp';
-  if (method === 'put' || method === 'patch') return 'updateOp';
-  if (method === 'delete') return 'deleteOp';
-  return null;
+  return method === 'delete' ? 'deleteOp' : 'updateOp';
 };
 
-const assignOp = (
+const segmentCount = (pathTemplate: string): number => {
+  return pathTemplate.split('/').filter(Boolean).length;
+};
+
+// The collection path is where new items are created and listed
+// (e.g. /agents or /projects/{project_id}/webhooks). Pick the shortest
+// collection-shaped GET so deeper sub-collections never win.
+const collectionPath = (ops: ModuleOp[]): string | undefined => {
+  return ops
+    .filter((op) => {
+      return op.method === 'get' && isCollectionPath(op.pathTemplate);
+    })
+    .sort((a, b) => {
+      return segmentCount(a.pathTemplate) - segmentCount(b.pathTemplate);
+    })[0]?.pathTemplate;
+};
+
+const isCreatePost = (pathTemplate: string, collection: string | undefined) => {
+  if (collection) return pathTemplate === collection;
+  return isCollectionPath(pathTemplate) && !pathTemplate.includes('{');
+};
+
+const classifyInto = (
   module: ModuleInfo,
-  method: HttpMethod,
-  op: ModuleOp
+  op: ModuleOp,
+  collection: string | undefined
 ): void => {
-  const key = classifyOp(method, op.pathTemplate);
-  if (key && !module[key]) {
-    module[key] = op;
-  }
-};
-
-const processTag = (
-  tag: string,
-  method: HttpMethod,
-  pathTemplate: string,
-  operation: OpenApiOperation,
-  tagMap: Map<string, ModuleInfo>
-): void => {
-  if (!tagMap.has(tag)) {
-    tagMap.set(tag, { tag, label: toLabel(tag), isProjectScoped: false });
-  }
-  const module = tagMap.get(tag)!;
-  if (pathTemplate.includes('{project_id}')) {
-    module.isProjectScoped = true;
-  }
-  assignOp(module, method, { method, pathTemplate, operation });
-};
-
-const processOperation = (
-  pathTemplate: string,
-  method: HttpMethod,
-  operation: OpenApiOperation | undefined,
-  tagMap: Map<string, ModuleInfo>
-): void => {
-  if (!operation?.operationId) return;
-  const tags = operation.tags ?? ['Other'];
-  for (const tag of tags) {
-    if (!SKIP_TAGS.has(tag)) {
-      processTag(tag, method, pathTemplate, operation, tagMap);
+  if (op.method === 'post') {
+    if (isCreatePost(op.pathTemplate, collection)) {
+      if (!module.createOp) module.createOp = op;
+    } else {
+      module.actions = module.actions ?? [];
+      module.actions.push(op);
     }
+    return;
   }
+  const key = classifyNonPost(op.method, op.pathTemplate);
+  if (!module[key]) module[key] = op;
+};
+
+const buildModule = (tag: string, ops: ModuleOp[]): ModuleInfo => {
+  const module: ModuleInfo = {
+    tag,
+    label: toLabel(tag),
+    isProjectScoped: ops.some((op) => {
+      return op.pathTemplate.includes('{project_id}');
+    }),
+  };
+  const collection = collectionPath(ops);
+  // Classify shallow paths first so list/detail/create win over sub-paths.
+  const sorted = [...ops].sort((a, b) => {
+    return segmentCount(a.pathTemplate) - segmentCount(b.pathTemplate);
+  });
+  for (const op of sorted) {
+    classifyInto(module, op, collection);
+  }
+  return module;
 };
 
 export const parseModules = (spec: OpenApiSpec): ModuleInfo[] => {
-  const tagMap = new Map<string, ModuleInfo>();
   const methods = ['get', 'post', 'put', 'patch', 'delete'] as const;
+  const tagOps = new Map<string, ModuleOp[]>();
 
   for (const [pathTemplate, pathItem] of Object.entries(spec.paths ?? {})) {
     for (const method of methods) {
-      processOperation(pathTemplate, method, pathItem[method], tagMap);
+      const operation = pathItem[method];
+      if (!operation?.operationId) continue;
+      for (const tag of operation.tags ?? ['Other']) {
+        if (SKIP_TAGS.has(tag)) continue;
+        if (!tagOps.has(tag)) tagOps.set(tag, []);
+        tagOps.get(tag)!.push({ method, pathTemplate, operation });
+      }
     }
   }
 
-  return Array.from(tagMap.values());
+  return Array.from(tagOps.entries()).map(([tag, ops]) => {
+    return buildModule(tag, ops);
+  });
 };
 
 export const getIdParamName = (getPath: string, listPath: string): string => {

--- a/packages/app/src/engine/specUtils.ts
+++ b/packages/app/src/engine/specUtils.ts
@@ -3,6 +3,7 @@ import type {
   JsonValue,
   ModuleInfo,
   ModuleOp,
+  OpenApiOperation,
   OpenApiSchema,
   OpenApiSpec,
 } from './types';
@@ -12,11 +13,7 @@ type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
 const SKIP_TAGS = new Set(['Sessions', 'Generations', 'Actor Tags']);
 
 const toLabel = (tag: string): string => {
-  return tag
-    .replace(/([A-Z])/g, (_m, p1: string, offset: number) => {
-      return offset > 0 ? ` ${p1}` : p1;
-    })
-    .trim();
+  return tag.replace(/([a-z])([A-Z])/g, '$1 $2');
 };
 
 const isCollectionPath = (pathTemplate: string): boolean => {
@@ -127,8 +124,14 @@ export const parseModules = (spec: OpenApiSpec): ModuleInfo[] => {
 
   for (const [pathTemplate, pathItem] of Object.entries(spec.paths ?? {})) {
     for (const method of methods) {
-      const operation = pathItem[method];
-      if (!operation?.operationId) continue;
+      const raw = pathItem[method] as (OpenApiOperation & { operation_id?: string }) | undefined;
+      if (!raw) continue;
+      // The server's caseTransform middleware converts operationId → operation_id;
+      // normalise back so the rest of the engine can rely on operationId.
+      const operation: OpenApiOperation = raw.operationId
+        ? raw
+        : { ...raw, operationId: raw.operation_id ?? '' };
+      if (!operation.operationId) continue;
       for (const tag of operation.tags ?? ['Other']) {
         if (SKIP_TAGS.has(tag)) continue;
         if (!tagOps.has(tag)) tagOps.set(tag, []);

--- a/packages/app/src/engine/specUtils.ts
+++ b/packages/app/src/engine/specUtils.ts
@@ -118,25 +118,41 @@ const buildModule = (tag: string, ops: ModuleOp[]): ModuleInfo => {
   return module;
 };
 
+type RawOp = OpenApiOperation & { operation_id?: string };
+
+const collectTagOps = (
+  pathTemplate: string,
+  method: HttpMethod,
+  pathItem: Record<string, unknown>,
+  tagOps: Map<string, ModuleOp[]>
+): void => {
+  const raw = pathItem[method] as RawOp | undefined;
+  if (!raw) return;
+  // The server's caseTransform middleware converts operationId → operation_id;
+  // normalise back so the rest of the engine can rely on operationId.
+  const operation: OpenApiOperation = raw.operationId
+    ? raw
+    : { ...raw, operationId: raw.operation_id ?? '' };
+  if (!operation.operationId) return;
+  for (const tag of operation.tags ?? ['Other']) {
+    if (SKIP_TAGS.has(tag)) continue;
+    if (!tagOps.has(tag)) tagOps.set(tag, []);
+    tagOps.get(tag)!.push({ method, pathTemplate, operation });
+  }
+};
+
 export const parseModules = (spec: OpenApiSpec): ModuleInfo[] => {
   const methods = ['get', 'post', 'put', 'patch', 'delete'] as const;
   const tagOps = new Map<string, ModuleOp[]>();
 
   for (const [pathTemplate, pathItem] of Object.entries(spec.paths ?? {})) {
     for (const method of methods) {
-      const raw = pathItem[method] as (OpenApiOperation & { operation_id?: string }) | undefined;
-      if (!raw) continue;
-      // The server's caseTransform middleware converts operationId → operation_id;
-      // normalise back so the rest of the engine can rely on operationId.
-      const operation: OpenApiOperation = raw.operationId
-        ? raw
-        : { ...raw, operationId: raw.operation_id ?? '' };
-      if (!operation.operationId) continue;
-      for (const tag of operation.tags ?? ['Other']) {
-        if (SKIP_TAGS.has(tag)) continue;
-        if (!tagOps.has(tag)) tagOps.set(tag, []);
-        tagOps.get(tag)!.push({ method, pathTemplate, operation });
-      }
+      collectTagOps(
+        pathTemplate,
+        method,
+        pathItem as Record<string, unknown>,
+        tagOps
+      );
     }
   }
 

--- a/packages/app/src/engine/types.ts
+++ b/packages/app/src/engine/types.ts
@@ -1,4 +1,4 @@
-export type ViewMode = 'list' | 'detail' | 'create' | 'edit';
+export type ViewMode = 'list' | 'detail' | 'create' | 'edit' | 'action';
 
 export type ViewDescriptor = {
   tag: string;
@@ -78,6 +78,9 @@ export type ModuleInfo = {
   createOp?: ModuleOp;
   updateOp?: ModuleOp;
   deleteOp?: ModuleOp;
+  // Item-scoped POST operations that are not the module's create
+  // (e.g. POST /agents/{agent_id}/generate). Rendered as action forms.
+  actions?: ModuleOp[];
 };
 
 export type JsonObject = { [key: string]: JsonValue };

--- a/packages/app/tests/unit/api/client.test.ts
+++ b/packages/app/tests/unit/api/client.test.ts
@@ -1,0 +1,87 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, test } from 'vitest';
+
+import { apiFetch } from '@/api/client';
+
+import { server } from '../msw/server';
+
+describe('apiFetch', () => {
+  test('returns ok with parsed data on success', async () => {
+    server.use(
+      http.get('*/api/v1/agents', () =>
+        HttpResponse.json([{ id: 'agt_1' }])
+      )
+    );
+    const result = await apiFetch<{ id: string }[]>({
+      url: '/api/v1/agents',
+      token: 't',
+    });
+    expect(result).toEqual({ ok: true, data: [{ id: 'agt_1' }] });
+  });
+
+  test('sends the bearer token and JSON body on POST', async () => {
+    let auth: string | null = null;
+    let body: unknown;
+    server.use(
+      http.post('*/api/v1/agents', async ({ request }) => {
+        auth = request.headers.get('Authorization');
+        body = await request.json();
+        return HttpResponse.json({ id: 'agt_2' }, { status: 201 });
+      })
+    );
+    const result = await apiFetch({
+      url: '/api/v1/agents',
+      method: 'POST',
+      body: { name: 'X' },
+      token: 'secret',
+    });
+    expect(result.ok).toBe(true);
+    expect(auth).toBe('Bearer secret');
+    expect(body).toEqual({ name: 'X' });
+  });
+
+  test('parses a string error field', async () => {
+    server.use(
+      http.get('*/api/v1/agents', () =>
+        HttpResponse.json({ error: 'boom' }, { status: 400 })
+      )
+    );
+    const result = await apiFetch({ url: '/api/v1/agents', token: 't' });
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: { message: 'boom' },
+    });
+  });
+
+  test('parses an object error field with message and code', async () => {
+    server.use(
+      http.get('*/api/v1/agents', () =>
+        HttpResponse.json(
+          { error: { message: 'denied', code: 'forbidden' } },
+          { status: 403 }
+        )
+      )
+    );
+    const result = await apiFetch({ url: '/api/v1/agents', token: 't' });
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      error: { message: 'denied', code: 'forbidden' },
+    });
+  });
+
+  test('falls back to an HTTP status message when no error field exists', async () => {
+    server.use(
+      http.get('*/api/v1/agents', () =>
+        HttpResponse.json({}, { status: 500 })
+      )
+    );
+    const result = await apiFetch({ url: '/api/v1/agents', token: 't' });
+    expect(result).toMatchObject({
+      ok: false,
+      status: 500,
+      error: { message: 'HTTP 500' },
+    });
+  });
+});

--- a/packages/app/tests/unit/app.test.tsx
+++ b/packages/app/tests/unit/app.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { App } from '@/app';
+
+describe('App', () => {
+  test('shows the login form when there is no session', async () => {
+    render(<App />);
+    expect(await screen.findByText('Sign in to SOAT')).toBeInTheDocument();
+  });
+
+  test('shows the workspace when a session is restored', async () => {
+    localStorage.setItem('soat_token', 'test-token');
+    render(<App />);
+    expect(await screen.findByText('SOAT')).toBeInTheDocument();
+    expect(screen.queryByText('Sign in to SOAT')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app/tests/unit/auth/authContext.test.tsx
+++ b/packages/app/tests/unit/auth/authContext.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import * as React from 'react';
+import { describe, expect, test } from 'vitest';
+
+import { AuthProvider, useAuth } from '@/auth/authContext';
+
+import { server } from '../msw/server';
+
+const Probe = () => {
+  const { state, login, logout } = useAuth();
+  const [err, setErr] = React.useState('');
+  return (
+    <div>
+      <span data-testid="status">{state.status}</span>
+      {state.status === 'authenticated' && (
+        <span data-testid="user">{state.user.username}</span>
+      )}
+      {err && <span data-testid="login-error">{err}</span>}
+      <button
+        onClick={async () => {
+          const r = await login({ username: 'tester', password: 'pw' });
+          if (r.error) setErr(r.error);
+        }}
+      >
+        {'login'}
+      </button>
+      <button
+        onClick={async () => {
+          const r = await login({ username: 'tester', password: 'wrong' });
+          if (r.error) setErr(r.error);
+        }}
+      >
+        {'login-bad'}
+      </button>
+      <button onClick={logout}>{'logout'}</button>
+    </div>
+  );
+};
+
+const renderAuth = () =>
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+describe('AuthProvider', () => {
+  test('is unauthenticated when no token is stored', async () => {
+    renderAuth();
+    expect(await screen.findByText('unauthenticated')).toBeInTheDocument();
+  });
+
+  test('restores an authenticated session from a stored token', async () => {
+    localStorage.setItem('soat_token', 'test-token');
+    renderAuth();
+    expect(await screen.findByTestId('user')).toHaveTextContent('tester');
+  });
+
+  test('clears an invalid stored token', async () => {
+    localStorage.setItem('soat_token', 'bad');
+    server.use(
+      http.get('*/api/v1/users/me', () =>
+        HttpResponse.json({ error: 'nope' }, { status: 401 })
+      )
+    );
+    renderAuth();
+    expect(await screen.findByText('unauthenticated')).toBeInTheDocument();
+    expect(localStorage.getItem('soat_token')).toBeNull();
+  });
+
+  test('login stores the token and authenticates', async () => {
+    renderAuth();
+    await screen.findByText('unauthenticated');
+    await userEvent.click(screen.getByRole('button', { name: 'login' }));
+    expect(await screen.findByTestId('user')).toHaveTextContent('tester');
+    expect(localStorage.getItem('soat_token')).toBe('test-token');
+  });
+
+  test('login surfaces an error for bad credentials', async () => {
+    renderAuth();
+    await screen.findByText('unauthenticated');
+    await userEvent.click(screen.getByRole('button', { name: 'login-bad' }));
+    expect(await screen.findByTestId('login-error')).toHaveTextContent(
+      'Invalid credentials'
+    );
+  });
+
+  test('logout clears the session', async () => {
+    localStorage.setItem('soat_token', 'test-token');
+    renderAuth();
+    await screen.findByTestId('user');
+    await userEvent.click(screen.getByRole('button', { name: 'logout' }));
+    expect(await screen.findByText('unauthenticated')).toBeInTheDocument();
+    expect(localStorage.getItem('soat_token')).toBeNull();
+  });
+});

--- a/packages/app/tests/unit/auth/loginForm.test.tsx
+++ b/packages/app/tests/unit/auth/loginForm.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test } from 'vitest';
+
+import { AuthProvider } from '@/auth/authContext';
+import { LoginForm } from '@/auth/loginForm';
+
+const renderLogin = () =>
+  render(
+    <AuthProvider>
+      <LoginForm />
+    </AuthProvider>
+  );
+
+describe('LoginForm', () => {
+  test('renders the username and password fields', () => {
+    renderLogin();
+    expect(screen.getByText('Sign in to SOAT')).toBeInTheDocument();
+    expect(screen.getByLabelText('Username')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+  });
+
+  test('shows an error message when credentials are rejected', async () => {
+    renderLogin();
+    await userEvent.type(screen.getByLabelText('Username'), 'tester');
+    await userEvent.type(screen.getByLabelText('Password'), 'wrong');
+    await userEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+    expect(await screen.findByText('Invalid credentials')).toBeInTheDocument();
+  });
+
+  test('submits valid credentials without showing an error', async () => {
+    renderLogin();
+    await userEvent.type(screen.getByLabelText('Username'), 'tester');
+    await userEvent.type(screen.getByLabelText('Password'), 'pw');
+    await userEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+    // On success the form's parent swaps it out; here it simply clears errors.
+    expect(screen.queryByText('Invalid credentials')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app/tests/unit/engine/actionView.test.tsx
+++ b/packages/app/tests/unit/engine/actionView.test.tsx
@@ -1,0 +1,105 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, test } from 'vitest';
+
+import { ActionView } from '@/engine/actionView';
+import { parseModules } from '@/engine/specUtils';
+import type { JsonObject, ModuleInfo } from '@/engine/types';
+
+import { testSpec } from '../fixtures/spec';
+import { server } from '../msw/server';
+import { renderWithAuth } from '../testUtils';
+
+const agentsModule = (): ModuleInfo => {
+  const m = parseModules(testSpec).find((x) => x.tag === 'Agents');
+  if (!m) throw new Error('Agents module missing');
+  return m;
+};
+
+describe('ActionView', () => {
+  test('renders a not-found message for an unknown operation', () => {
+    renderWithAuth(
+      <ActionView
+        module={agentsModule()}
+        spec={testSpec}
+        pathParams={{ agent_id: 'agt_1' }}
+        operationId="doesNotExist"
+      />
+    );
+    expect(screen.getByText('Action not found in spec.')).toBeInTheDocument();
+  });
+
+  test('renders the action form with its summary and schema fields', () => {
+    renderWithAuth(
+      <ActionView
+        module={agentsModule()}
+        spec={testSpec}
+        pathParams={{ agent_id: 'agt_1' }}
+        operationId="generateAgent"
+      />
+    );
+    expect(screen.getByText('Run a generation')).toBeInTheDocument();
+    expect(screen.getByLabelText(/prompt/i)).toBeInTheDocument();
+  });
+
+  test('prompts for a missing path param', () => {
+    renderWithAuth(
+      <ActionView
+        module={agentsModule()}
+        spec={testSpec}
+        pathParams={{}}
+        operationId="generateAgent"
+      />
+    );
+    expect(screen.getByLabelText(/agent id/i)).toBeInTheDocument();
+  });
+
+  test('submits the action and shows the JSON result', async () => {
+    let received: JsonObject | undefined;
+    server.use(
+      http.post('*/api/v1/agents/:agent_id/generate', async ({ request }) => {
+        received = (await request.json()) as JsonObject;
+        return HttpResponse.json({ id: 'gen_1', status: 'completed' });
+      })
+    );
+
+    renderWithAuth(
+      <ActionView
+        module={agentsModule()}
+        spec={testSpec}
+        pathParams={{ agent_id: 'agt_1' }}
+        operationId="generateAgent"
+      />
+    );
+
+    await userEvent.type(screen.getByLabelText(/prompt/i), 'Hello');
+    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    expect(await screen.findByText('Result')).toBeInTheDocument();
+    expect(screen.getByText(/"status": "completed"/)).toBeInTheDocument();
+    expect(received).toEqual({ prompt: 'Hello' });
+  });
+
+  test('shows an error when the action fails', async () => {
+    server.use(
+      http.post('*/api/v1/agents/:agent_id/generate', () =>
+        HttpResponse.json({ error: 'model offline' }, { status: 503 })
+      )
+    );
+
+    renderWithAuth(
+      <ActionView
+        module={agentsModule()}
+        spec={testSpec}
+        pathParams={{ agent_id: 'agt_1' }}
+        operationId="generateAgent"
+      />
+    );
+
+    await userEvent.type(screen.getByLabelText(/prompt/i), 'Hi');
+    await userEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    expect(await screen.findByText('model offline')).toBeInTheDocument();
+  });
+});

--- a/packages/app/tests/unit/engine/detailView.test.tsx
+++ b/packages/app/tests/unit/engine/detailView.test.tsx
@@ -1,0 +1,104 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, test } from 'vitest';
+
+import { DetailView } from '@/engine/detailView';
+import { parseModules } from '@/engine/specUtils';
+import type { ModuleInfo } from '@/engine/types';
+
+import { testSpec } from '../fixtures/spec';
+import { server } from '../msw/server';
+import { NavProbe, renderWithAuth } from '../testUtils';
+
+const agentsModule = (): ModuleInfo => {
+  const m = parseModules(testSpec).find((x) => x.tag === 'Agents');
+  if (!m) throw new Error('Agents module missing');
+  return m;
+};
+
+const renderDetail = () =>
+  renderWithAuth(
+    <>
+      <DetailView
+        module={agentsModule()}
+        spec={testSpec}
+        pathParams={{ agent_id: 'agt_1' }}
+      />
+      <NavProbe />
+    </>
+  );
+
+const itemHandler = () =>
+  http.get('*/api/v1/agents/:agent_id', () =>
+    HttpResponse.json({
+      id: 'agt_1',
+      name: 'Alpha',
+      api_key: 'sk_secret',
+      created_at: '2024-01-01T00:00:00.000Z',
+    })
+  );
+
+describe('DetailView', () => {
+  test('renders fields and hides sensitive values', async () => {
+    server.use(itemHandler());
+    renderDetail();
+
+    expect(await screen.findByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('[hidden]')).toBeInTheDocument();
+    expect(screen.queryByText('sk_secret')).not.toBeInTheDocument();
+  });
+
+  test('surfaces an error when the fetch fails', async () => {
+    server.use(
+      http.get('*/api/v1/agents/:agent_id', () =>
+        HttpResponse.json({ error: { message: 'not found' } }, { status: 404 })
+      )
+    );
+    renderDetail();
+    expect(await screen.findByText('not found')).toBeInTheDocument();
+  });
+
+  test('Edit navigates to the edit form', async () => {
+    server.use(itemHandler());
+    renderDetail();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+    expect(screen.getByTestId('nav-probe')).toHaveTextContent('"mode":"edit"');
+  });
+
+  test('renders item-scoped action buttons', async () => {
+    server.use(itemHandler());
+    renderDetail();
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Generate' })
+    );
+    expect(screen.getByTestId('nav-probe')).toHaveTextContent('"mode":"action"');
+    expect(screen.getByTestId('nav-probe')).toHaveTextContent('generateAgent');
+  });
+
+  test('Delete asks for confirmation, then deletes and navigates back', async () => {
+    let deleted = false;
+    server.use(
+      itemHandler(),
+      http.delete('*/api/v1/agents/:agent_id', () => {
+        deleted = true;
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+    renderDetail();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Confirm delete' })
+    );
+
+    expect(await screen.findByTestId('nav-probe')).toHaveTextContent(
+      '"view":null'
+    );
+    expect(deleted).toBe(true);
+  });
+});

--- a/packages/app/tests/unit/engine/engineView.test.tsx
+++ b/packages/app/tests/unit/engine/engineView.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, test } from 'vitest';
+
+import { EngineView } from '@/engine/engineView';
+import { parseModules } from '@/engine/specUtils';
+import type { ViewDescriptor } from '@/engine/types';
+
+import { testSpec } from '../fixtures/spec';
+import { server } from '../msw/server';
+import { renderWithAuth } from '../testUtils';
+
+const modules = parseModules(testSpec);
+
+const renderEngine = (descriptor: ViewDescriptor) =>
+  renderWithAuth(
+    <EngineView descriptor={descriptor} modules={modules} spec={testSpec} />
+  );
+
+describe('EngineView routing', () => {
+  test('shows a message for an unknown module tag', () => {
+    renderEngine({
+      tag: 'Nope',
+      operationId: 'x',
+      pathParams: {},
+      mode: 'list',
+    });
+    expect(
+      screen.getByText('Module "Nope" not found in spec.')
+    ).toBeInTheDocument();
+  });
+
+  test('renders the list view for mode "list"', async () => {
+    server.use(
+      http.get('*/api/v1/agents', () =>
+        HttpResponse.json([{ id: 'agt_1', name: 'Alpha' }])
+      )
+    );
+    renderEngine({
+      tag: 'Agents',
+      operationId: 'listAgents',
+      pathParams: {},
+      mode: 'list',
+    });
+    expect(await screen.findByText('Alpha')).toBeInTheDocument();
+  });
+
+  test('renders the create form for mode "create"', () => {
+    renderEngine({
+      tag: 'Agents',
+      operationId: 'createAgent',
+      pathParams: {},
+      mode: 'create',
+    });
+    expect(screen.getByText('Create Agents')).toBeInTheDocument();
+  });
+
+  test('renders the action form for mode "action"', () => {
+    renderEngine({
+      tag: 'Agents',
+      operationId: 'generateAgent',
+      pathParams: { agent_id: 'agt_1' },
+      mode: 'action',
+    });
+    expect(screen.getByText('Run a generation')).toBeInTheDocument();
+  });
+});

--- a/packages/app/tests/unit/engine/fieldEditor.test.tsx
+++ b/packages/app/tests/unit/engine/fieldEditor.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { FieldEditor } from '@/engine/fieldEditor';
+import type { OpenApiSchema } from '@/engine/types';
+
+const renderField = (schema: OpenApiSchema, props = {}) => {
+  const onChange = vi.fn();
+  render(
+    <FieldEditor
+      name="agent_name"
+      schema={schema}
+      value=""
+      onChange={onChange}
+      {...props}
+    />
+  );
+  return { onChange };
+};
+
+describe('FieldEditor', () => {
+  test('renders a humanized label', () => {
+    renderField({ type: 'string' });
+    expect(screen.getByText('Agent Name')).toBeInTheDocument();
+  });
+
+  test('marks required fields with an asterisk', () => {
+    renderField({ type: 'string' }, { required: true });
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  test('renders a text input and reports typing', async () => {
+    const { onChange } = renderField({ type: 'string' });
+    await userEvent.type(screen.getByLabelText(/agent name/i), 'x');
+    expect(onChange).toHaveBeenCalledWith('x');
+  });
+
+  test('renders a number input for integer schemas', () => {
+    renderField({ type: 'integer' });
+    expect(screen.getByLabelText(/agent name/i)).toHaveAttribute(
+      'type',
+      'number'
+    );
+  });
+
+  test('renders a select for enum schemas', () => {
+    renderField({ type: 'string', enum: ['a', 'b'] });
+    expect(screen.getByRole('option', { name: 'a' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'b' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: '— select —' })
+    ).toBeInTheDocument();
+  });
+
+  test('renders a checkbox for boolean schemas and emits true/false', async () => {
+    const { onChange } = renderField({ type: 'boolean' });
+    const checkbox = screen.getByRole('checkbox');
+    await userEvent.click(checkbox);
+    expect(onChange).toHaveBeenCalledWith('true');
+  });
+
+  test('renders a textarea for object schemas', () => {
+    renderField({ type: 'object' });
+    expect(screen.getByLabelText(/agent name/i).tagName).toBe('TEXTAREA');
+  });
+});

--- a/packages/app/tests/unit/engine/formHelpers.test.ts
+++ b/packages/app/tests/unit/engine/formHelpers.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  buildRequestBody,
+  getOpRequestSchema,
+  initFormData,
+} from '@/engine/formHelpers';
+import type { ModuleOp, OpenApiSchema } from '@/engine/types';
+
+import { testSpec } from '../fixtures/spec';
+
+describe('getOpRequestSchema', () => {
+  test('resolves a $ref request-body schema against the spec', () => {
+    const op: ModuleOp = {
+      method: 'post',
+      pathTemplate: '/api/v1/agents',
+      operation: {
+        operationId: 'createAgent',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/CreateAgent' },
+            },
+          },
+        },
+      },
+    };
+    expect(getOpRequestSchema(op, testSpec)?.properties?.name).toBeDefined();
+  });
+
+  test('returns undefined when the op has no request body', () => {
+    const op: ModuleOp = {
+      method: 'get',
+      pathTemplate: '/api/v1/agents',
+      operation: { operationId: 'listAgents' },
+    };
+    expect(getOpRequestSchema(op, testSpec)).toBeUndefined();
+    expect(getOpRequestSchema(undefined, testSpec)).toBeUndefined();
+  });
+});
+
+describe('initFormData', () => {
+  const schema: OpenApiSchema = {
+    type: 'object',
+    properties: { name: {}, model: {}, enabled: {} },
+  };
+
+  test('seeds every property to empty string with no prefill', () => {
+    expect(initFormData(schema, {})).toEqual({
+      name: '',
+      model: '',
+      enabled: '',
+    });
+  });
+
+  test('stringifies prefill values and ignores null/undefined', () => {
+    expect(initFormData(schema, { name: 'Bot', enabled: true })).toEqual({
+      name: 'Bot',
+      model: '',
+      enabled: 'true',
+    });
+  });
+
+  test('returns an empty object for a schema without properties', () => {
+    expect(initFormData(undefined, {})).toEqual({});
+  });
+});
+
+describe('buildRequestBody', () => {
+  const schema: OpenApiSchema = {
+    type: 'object',
+    required: ['name'],
+    properties: {
+      name: { type: 'string' },
+      count: { type: 'integer' },
+      enabled: { type: 'boolean' },
+      meta: { type: 'object' },
+    },
+  };
+
+  test('omits empty optional fields but keeps required ones', () => {
+    const result = buildRequestBody(
+      { name: '', count: '', enabled: 'false', meta: '' },
+      schema
+    );
+    expect(result).toEqual({ ok: true, body: { name: '', enabled: false } });
+  });
+
+  test('coerces numbers and booleans', () => {
+    const result = buildRequestBody(
+      { name: 'Bot', count: '7', enabled: 'true' },
+      schema
+    );
+    expect(result).toEqual({
+      ok: true,
+      body: { name: 'Bot', count: 7, enabled: true },
+    });
+  });
+
+  test('parses JSON for object/array fields', () => {
+    const result = buildRequestBody(
+      { name: 'Bot', meta: '{"a":1}' },
+      schema
+    );
+    expect(result.ok && result.body.meta).toEqual({ a: 1 });
+  });
+
+  test('returns an error for invalid JSON', () => {
+    const result = buildRequestBody({ name: 'Bot', meta: '{bad' }, schema);
+    expect(result).toEqual({
+      ok: false,
+      error: 'Invalid JSON in field "meta"',
+    });
+  });
+
+  test('treats an empty numeric field as null when required', () => {
+    const numericSchema: OpenApiSchema = {
+      type: 'object',
+      required: ['count'],
+      properties: { count: { type: 'integer' } },
+    };
+    expect(buildRequestBody({ count: '' }, numericSchema)).toEqual({
+      ok: true,
+      body: { count: null },
+    });
+  });
+});

--- a/packages/app/tests/unit/engine/formView.test.tsx
+++ b/packages/app/tests/unit/engine/formView.test.tsx
@@ -1,0 +1,122 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, test } from 'vitest';
+
+import { FormView } from '@/engine/formView';
+import { parseModules } from '@/engine/specUtils';
+import type { JsonObject, ModuleInfo } from '@/engine/types';
+
+import { testSpec } from '../fixtures/spec';
+import { server } from '../msw/server';
+import { NavProbe, renderWithAuth } from '../testUtils';
+
+const agentsModule = (): ModuleInfo => {
+  const m = parseModules(testSpec).find((x) => x.tag === 'Agents');
+  if (!m) throw new Error('Agents module missing');
+  return m;
+};
+
+describe('FormView (create)', () => {
+  test('renders fields derived from the request schema', () => {
+    renderWithAuth(
+      <FormView
+        module={agentsModule()}
+        spec={testSpec}
+        pathParams={{}}
+        mode="create"
+      />
+    );
+    expect(screen.getByText('Create Agents')).toBeInTheDocument();
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    // enum field renders a select
+    expect(screen.getByRole('option', { name: 'gpt-4o' })).toBeInTheDocument();
+  });
+
+  test('submits the built body and navigates back on success', async () => {
+    let received: JsonObject | undefined;
+    server.use(
+      http.post('*/api/v1/agents', async ({ request }) => {
+        received = (await request.json()) as JsonObject;
+        return HttpResponse.json({ id: 'agt_9', ...received }, { status: 201 });
+      })
+    );
+
+    renderWithAuth(
+      <>
+        <FormView
+          module={agentsModule()}
+          spec={testSpec}
+          pathParams={{}}
+          mode="create"
+        />
+        <NavProbe />
+      </>
+    );
+
+    await userEvent.type(screen.getByLabelText(/name/i), 'Gamma');
+    await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(await screen.findByTestId('nav-probe')).toHaveTextContent(
+      '"view":null'
+    );
+    // empty optional fields are omitted; only `name` is sent
+    expect(received).toEqual({ name: 'Gamma' });
+  });
+
+  test('shows the server error and stays on the form on failure', async () => {
+    server.use(
+      http.post('*/api/v1/agents', () =>
+        HttpResponse.json({ error: 'name taken' }, { status: 409 })
+      )
+    );
+
+    renderWithAuth(
+      <FormView
+        module={agentsModule()}
+        spec={testSpec}
+        pathParams={{}}
+        mode="create"
+      />
+    );
+
+    await userEvent.type(screen.getByLabelText(/name/i), 'Dup');
+    await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(await screen.findByText('name taken')).toBeInTheDocument();
+  });
+});
+
+describe('FormView (edit)', () => {
+  test('prefills, sends a PUT, and navigates back', async () => {
+    let method = '';
+    server.use(
+      http.put('*/api/v1/agents/:agent_id', async ({ request }) => {
+        method = request.method;
+        return HttpResponse.json({ id: 'agt_1', name: 'Edited' });
+      })
+    );
+
+    renderWithAuth(
+      <>
+        <FormView
+          module={agentsModule()}
+          spec={testSpec}
+          pathParams={{ agent_id: 'agt_1' }}
+          mode="edit"
+          prefill={{ name: 'Old' }}
+        />
+        <NavProbe />
+      </>
+    );
+
+    const nameInput = screen.getByLabelText(/name/i);
+    expect(nameInput).toHaveValue('Old');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByTestId('nav-probe')).toHaveTextContent(
+      '"view":null'
+    );
+    expect(method).toBe('PUT');
+  });
+});

--- a/packages/app/tests/unit/engine/listView.test.tsx
+++ b/packages/app/tests/unit/engine/listView.test.tsx
@@ -1,0 +1,88 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, test } from 'vitest';
+
+import { ListView } from '@/engine/listView';
+import { parseModules } from '@/engine/specUtils';
+import type { ModuleInfo } from '@/engine/types';
+
+import { testSpec } from '../fixtures/spec';
+import { server } from '../msw/server';
+import { NavProbe, renderWithAuth } from '../testUtils';
+
+const agentsModule = (): ModuleInfo => {
+  const m = parseModules(testSpec).find((x) => x.tag === 'Agents');
+  if (!m) throw new Error('Agents module missing');
+  return m;
+};
+
+const renderList = () =>
+  renderWithAuth(
+    <>
+      <ListView module={agentsModule()} spec={testSpec} pathParams={{}} />
+      <NavProbe />
+    </>
+  );
+
+describe('ListView', () => {
+  test('renders a row per item with derived, humanized columns', async () => {
+    server.use(
+      http.get('*/api/v1/agents', () =>
+        HttpResponse.json([
+          { id: 'agt_1', name: 'Alpha', model: 'gpt-4o' },
+          { id: 'agt_2', name: 'Beta', model: 'gpt-4o-mini' },
+        ])
+      )
+    );
+    renderList();
+
+    expect(await screen.findByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Name' })
+    ).toBeInTheDocument();
+    // id is hidden from the table
+    expect(screen.queryByText('agt_1')).not.toBeInTheDocument();
+  });
+
+  test('shows an empty state when there are no items', async () => {
+    server.use(http.get('*/api/v1/agents', () => HttpResponse.json([])));
+    renderList();
+    expect(await screen.findByText('No items found.')).toBeInTheDocument();
+  });
+
+  test('surfaces an error message when the request fails', async () => {
+    server.use(
+      http.get('*/api/v1/agents', () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 })
+      )
+    );
+    renderList();
+    expect(await screen.findByText('boom')).toBeInTheDocument();
+  });
+
+  test('clicking "View →" navigates to the detail view with the id param', async () => {
+    server.use(
+      http.get('*/api/v1/agents', () =>
+        HttpResponse.json([{ id: 'agt_1', name: 'Alpha' }])
+      )
+    );
+    renderList();
+
+    await screen.findByText('Alpha');
+    await userEvent.click(screen.getByRole('button', { name: 'View →' }));
+
+    const probe = screen.getByTestId('nav-probe');
+    expect(probe).toHaveTextContent('"mode":"detail"');
+    expect(probe).toHaveTextContent('"agent_id":"agt_1"');
+  });
+
+  test('clicking Create navigates to the create form', async () => {
+    server.use(http.get('*/api/v1/agents', () => HttpResponse.json([])));
+    renderList();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Create' }));
+    expect(screen.getByTestId('nav-probe')).toHaveTextContent('"mode":"create"');
+  });
+});

--- a/packages/app/tests/unit/engine/navigationContext.test.tsx
+++ b/packages/app/tests/unit/engine/navigationContext.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test } from 'vitest';
+
+import {
+  NavigationProvider,
+  useNavigation,
+} from '@/engine/navigationContext';
+
+const Harness = () => {
+  const { view, activeProjectId, navigate, setProject } = useNavigation();
+  return (
+    <div>
+      <span data-testid="state">{JSON.stringify({ view, activeProjectId })}</span>
+      <button
+        onClick={() =>
+          navigate({
+            tag: 'Agents',
+            operationId: 'listAgents',
+            pathParams: {},
+            mode: 'list',
+          })
+        }
+      >
+        {'go'}
+      </button>
+      <button onClick={() => setProject('prj_1')}>{'set-project'}</button>
+      <button onClick={() => navigate(null)}>{'clear'}</button>
+    </div>
+  );
+};
+
+describe('NavigationProvider', () => {
+  test('navigate sets the active view descriptor', async () => {
+    render(
+      <NavigationProvider>
+        <Harness />
+      </NavigationProvider>
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'go' }));
+    expect(screen.getByTestId('state')).toHaveTextContent('"mode":"list"');
+  });
+
+  test('setProject sets the project and clears the current view', async () => {
+    render(
+      <NavigationProvider>
+        <Harness />
+      </NavigationProvider>
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'go' }));
+    await userEvent.click(screen.getByRole('button', { name: 'set-project' }));
+
+    const state = screen.getByTestId('state');
+    expect(state).toHaveTextContent('"activeProjectId":"prj_1"');
+    expect(state).toHaveTextContent('"view":null');
+  });
+});

--- a/packages/app/tests/unit/engine/navigationContext.test.tsx
+++ b/packages/app/tests/unit/engine/navigationContext.test.tsx
@@ -1,11 +1,29 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, test } from 'vitest';
 
 import {
   NavigationProvider,
   useNavigation,
 } from '@/engine/navigationContext';
+import { SpecProvider } from '@/engine/specContext';
+
+// NavigationProvider derives its view from the URL and the loaded spec,
+// so every test needs a Router context and a SpecProvider.
+const Wrapper = ({
+  children,
+  initialPath = '/app/',
+}: {
+  children: React.ReactNode;
+  initialPath?: string;
+}) => (
+  <MemoryRouter initialEntries={[initialPath]}>
+    <SpecProvider token="test-token">
+      <NavigationProvider>{children}</NavigationProvider>
+    </SpecProvider>
+  </MemoryRouter>
+);
 
 const Harness = () => {
   const { view, activeProjectId, navigate, setProject } = useNavigation();
@@ -31,27 +49,27 @@ const Harness = () => {
 };
 
 describe('NavigationProvider', () => {
-  test('navigate sets the active view descriptor', async () => {
+  test('navigate pushes the correct URL and derives the view from it', async () => {
     render(
-      <NavigationProvider>
+      <Wrapper>
         <Harness />
-      </NavigationProvider>
+      </Wrapper>
     );
     await userEvent.click(screen.getByRole('button', { name: 'go' }));
-    expect(screen.getByTestId('state')).toHaveTextContent('"mode":"list"');
+    // The spec has listAgents at /api/v1/agents → URL becomes /app/v1/agents
+    // → view is derived back to mode:'list'
+    expect(await screen.findByTestId('state')).toHaveTextContent('"mode":"list"');
   });
 
-  test('setProject sets the project and clears the current view', async () => {
+  test('setProject navigates to the project URL', async () => {
     render(
-      <NavigationProvider>
+      <Wrapper>
         <Harness />
-      </NavigationProvider>
+      </Wrapper>
     );
-    await userEvent.click(screen.getByRole('button', { name: 'go' }));
     await userEvent.click(screen.getByRole('button', { name: 'set-project' }));
-
-    const state = screen.getByTestId('state');
-    expect(state).toHaveTextContent('"activeProjectId":"prj_1"');
-    expect(state).toHaveTextContent('"view":null');
+    // /app/v1/projects/prj_1 — Projects tag includes {project_id} in some paths
+    // so activeProjectId is set from the URL path param
+    expect(await screen.findByTestId('state')).toHaveTextContent('"activeProjectId":"prj_1"');
   });
 });

--- a/packages/app/tests/unit/engine/routeUtils.test.ts
+++ b/packages/app/tests/unit/engine/routeUtils.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  extractProjectId,
+  matchTemplate,
+  pathToView,
+  viewToPath,
+} from '@/engine/routeUtils';
+import type { ViewDescriptor } from '@/engine/types';
+
+import { testSpec } from '../fixtures/spec';
+import { parseModules } from '@/engine/specUtils';
+
+const modules = parseModules(testSpec);
+
+describe('matchTemplate', () => {
+  test('matches a concrete path against a template with one param', () => {
+    expect(matchTemplate('/api/v1/agents/agt_1', '/api/v1/agents/{agent_id}')).toEqual({
+      agent_id: 'agt_1',
+    });
+  });
+
+  test('returns null when segment counts differ', () => {
+    expect(matchTemplate('/api/v1/agents', '/api/v1/agents/{agent_id}')).toBeNull();
+  });
+
+  test('returns null on a literal mismatch', () => {
+    expect(matchTemplate('/api/v1/projects', '/api/v1/agents')).toBeNull();
+  });
+
+  test('decodes encoded path params', () => {
+    expect(
+      matchTemplate('/api/v1/agents/hello%20world', '/api/v1/agents/{agent_id}')
+    ).toEqual({ agent_id: 'hello world' });
+  });
+});
+
+describe('viewToPath', () => {
+  test('list view → collection URL', () => {
+    const d: ViewDescriptor = {
+      tag: 'Agents',
+      operationId: 'listAgents',
+      pathParams: {},
+      mode: 'list',
+    };
+    expect(viewToPath(d, testSpec)).toBe('/app/v1/agents');
+  });
+
+  test('detail view → item URL', () => {
+    const d: ViewDescriptor = {
+      tag: 'Agents',
+      operationId: 'getAgent',
+      pathParams: { agent_id: 'agt_1' },
+      mode: 'detail',
+    };
+    expect(viewToPath(d, testSpec)).toBe('/app/v1/agents/agt_1');
+  });
+
+  test('create view → collection URL + /new', () => {
+    const d: ViewDescriptor = {
+      tag: 'Agents',
+      operationId: 'createAgent',
+      pathParams: {},
+      mode: 'create',
+    };
+    expect(viewToPath(d, testSpec)).toBe('/app/v1/agents/new');
+  });
+
+  test('edit view → item URL + /edit', () => {
+    const d: ViewDescriptor = {
+      tag: 'Agents',
+      operationId: 'updateAgent',
+      pathParams: { agent_id: 'agt_1' },
+      mode: 'edit',
+    };
+    expect(viewToPath(d, testSpec)).toBe('/app/v1/agents/agt_1/edit');
+  });
+
+  test('action view → action URL', () => {
+    const d: ViewDescriptor = {
+      tag: 'Agents',
+      operationId: 'generateAgent',
+      pathParams: { agent_id: 'agt_1' },
+      mode: 'action',
+    };
+    expect(viewToPath(d, testSpec)).toBe('/app/v1/agents/agt_1/generate');
+  });
+
+  test('returns null for an unknown operationId', () => {
+    const d: ViewDescriptor = {
+      tag: 'X',
+      operationId: 'noop',
+      pathParams: {},
+      mode: 'list',
+    };
+    expect(viewToPath(d, testSpec)).toBeNull();
+  });
+});
+
+describe('pathToView', () => {
+  test('collection URL → list view', () => {
+    const view = pathToView('/app/v1/agents', testSpec, modules);
+    expect(view?.mode).toBe('list');
+    expect(view?.operationId).toBe('listAgents');
+    expect(view?.pathParams).toEqual({});
+  });
+
+  test('item URL → detail view with extracted path param', () => {
+    const view = pathToView('/app/v1/agents/agt_1', testSpec, modules);
+    expect(view?.mode).toBe('detail');
+    expect(view?.operationId).toBe('getAgent');
+    expect(view?.pathParams).toEqual({ agent_id: 'agt_1' });
+  });
+
+  test('/new suffix → create view', () => {
+    const view = pathToView('/app/v1/agents/new', testSpec, modules);
+    expect(view?.mode).toBe('create');
+    expect(view?.operationId).toBe('createAgent');
+  });
+
+  test('/edit suffix → edit view', () => {
+    const view = pathToView('/app/v1/agents/agt_1/edit', testSpec, modules);
+    expect(view?.mode).toBe('edit');
+    expect(view?.operationId).toBe('updateAgent');
+    expect(view?.pathParams).toEqual({ agent_id: 'agt_1' });
+  });
+
+  test('action URL → action view', () => {
+    const view = pathToView('/app/v1/agents/agt_1/generate', testSpec, modules);
+    expect(view?.mode).toBe('action');
+    expect(view?.operationId).toBe('generateAgent');
+    expect(view?.pathParams).toEqual({ agent_id: 'agt_1' });
+  });
+
+  test('project-scoped URL extracts project_id', () => {
+    const view = pathToView('/app/v1/projects/prj_1/webhooks', testSpec, modules);
+    expect(view?.mode).toBe('list');
+    expect(view?.pathParams).toEqual({ project_id: 'prj_1' });
+  });
+
+  test('returns null for an unrecognised path', () => {
+    expect(pathToView('/app/v1/unknown', testSpec, modules)).toBeNull();
+  });
+});
+
+describe('extractProjectId', () => {
+  test('returns project_id when present in pathParams', () => {
+    const view: ViewDescriptor = {
+      tag: 'Webhooks',
+      operationId: 'listWebhooks',
+      pathParams: { project_id: 'prj_1' },
+      mode: 'list',
+    };
+    expect(extractProjectId(view)).toBe('prj_1');
+  });
+
+  test('returns null when no project_id param', () => {
+    const view: ViewDescriptor = {
+      tag: 'Agents',
+      operationId: 'listAgents',
+      pathParams: {},
+      mode: 'list',
+    };
+    expect(extractProjectId(view)).toBeNull();
+  });
+
+  test('returns null for null view', () => {
+    expect(extractProjectId(null)).toBeNull();
+  });
+});

--- a/packages/app/tests/unit/engine/specContext.test.tsx
+++ b/packages/app/tests/unit/engine/specContext.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, test } from 'vitest';
+
+import { SpecProvider, useSpec } from '@/engine/specContext';
+
+import { server } from '../msw/server';
+
+const Probe = () => {
+  const { loading, error, modules } = useSpec();
+  if (loading) return <span>{'loading'}</span>;
+  if (error) return <span data-testid="error">{error}</span>;
+  return <span data-testid="tags">{modules.map((m) => m.tag).join(',')}</span>;
+};
+
+const renderSpec = () =>
+  render(
+    <SpecProvider token="test-token">
+      <Probe />
+    </SpecProvider>
+  );
+
+describe('SpecProvider', () => {
+  test('loads the spec and derives modules', async () => {
+    renderSpec();
+    const tags = await screen.findByTestId('tags');
+    expect(tags).toHaveTextContent('Agents');
+    expect(tags).toHaveTextContent('Projects');
+    expect(tags).toHaveTextContent('Webhooks');
+  });
+
+  test('exposes an error when the spec request fails', async () => {
+    server.use(
+      http.get('*/api/v1/openapi.json', () =>
+        HttpResponse.json({ error: 'nope' }, { status: 500 })
+      )
+    );
+    renderSpec();
+    expect(await screen.findByTestId('error')).toBeInTheDocument();
+  });
+});

--- a/packages/app/tests/unit/engine/specUtils.test.ts
+++ b/packages/app/tests/unit/engine/specUtils.test.ts
@@ -109,6 +109,41 @@ describe('parseModules', () => {
     expect(parseModules(spec)).toHaveLength(0);
   });
 
+  test('accepts snake_case operation_id from the server caseTransform middleware', () => {
+    const spec = {
+      paths: {
+        '/api/v1/agents': {
+          // @ts-expect-error intentionally using server snake_case shape
+          get: { operation_id: 'listAgents', tags: ['Agents'] },
+        },
+      },
+    } as OpenApiSpec;
+    const modules = parseModules(spec);
+    expect(modules).toHaveLength(1);
+    expect(modules[0].listOp?.operation.operationId).toBe('listAgents');
+  });
+
+  test('produces correct labels for already-spaced and CamelCase tags', () => {
+    const spec = {
+      paths: {
+        '/api/v1/ai-providers': {
+          get: { operationId: 'listAiProviders', tags: ['AI Providers'] },
+        },
+        '/api/v1/api-keys': {
+          get: { operationId: 'listApiKeys', tags: ['API Keys'] },
+        },
+        '/api/v1/memory-entries': {
+          get: { operationId: 'listMemoryEntries', tags: ['MemoryEntries'] },
+        },
+      },
+    } as OpenApiSpec;
+    const modules = parseModules(spec);
+    const label = (tag: string) => byTag(modules, tag).label;
+    expect(label('AI Providers')).toBe('AI Providers');
+    expect(label('API Keys')).toBe('API Keys');
+    expect(label('MemoryEntries')).toBe('Memory Entries');
+  });
+
   test('falls back to the "Other" tag when none is given', () => {
     const spec: OpenApiSpec = {
       paths: { '/api/v1/x': { get: { operationId: 'getX' } } },

--- a/packages/app/tests/unit/engine/specUtils.test.ts
+++ b/packages/app/tests/unit/engine/specUtils.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  actionLabel,
+  buildUrl,
+  extractItems,
+  extractPathParams,
+  formatValue,
+  getIdParamName,
+  humanizeKey,
+  isSensitiveKey,
+  parseModules,
+  resolveSchema,
+} from '@/engine/specUtils';
+import type { ModuleInfo, ModuleOp, OpenApiSpec } from '@/engine/types';
+
+import { testSpec } from '../fixtures/spec';
+
+const byTag = (modules: ModuleInfo[], tag: string): ModuleInfo => {
+  const m = modules.find((x) => x.tag === tag);
+  if (!m) throw new Error(`module ${tag} not found`);
+  return m;
+};
+
+describe('buildUrl', () => {
+  test('substitutes and encodes path params', () => {
+    expect(
+      buildUrl('/api/v1/agents/{agent_id}', { agent_id: 'a b/c' })
+    ).toBe('/api/v1/agents/a%20b%2Fc');
+  });
+
+  test('leaves the template untouched when no params match', () => {
+    expect(buildUrl('/api/v1/agents', {})).toBe('/api/v1/agents');
+  });
+});
+
+describe('humanizeKey', () => {
+  test('replaces underscores and title-cases', () => {
+    expect(humanizeKey('created_at')).toBe('Created At');
+    expect(humanizeKey('name')).toBe('Name');
+  });
+});
+
+describe('extractPathParams', () => {
+  test('returns every brace-delimited name in order', () => {
+    expect(
+      extractPathParams('/api/v1/projects/{project_id}/webhooks/{id}')
+    ).toEqual(['project_id', 'id']);
+  });
+
+  test('returns empty array for a static path', () => {
+    expect(extractPathParams('/api/v1/agents')).toEqual([]);
+  });
+});
+
+describe('actionLabel', () => {
+  test('humanizes the last path segment', () => {
+    const op: ModuleOp = {
+      method: 'post',
+      pathTemplate: '/api/v1/agents/{agent_id}/generate',
+      operation: { operationId: 'generateAgent' },
+    };
+    expect(actionLabel(op)).toBe('Generate');
+  });
+});
+
+describe('parseModules', () => {
+  const modules = parseModules(testSpec);
+
+  test('classifies CRUD operations onto the Agents module', () => {
+    const agents = byTag(modules, 'Agents');
+    expect(agents.label).toBe('Agents');
+    expect(agents.listOp?.operation.operationId).toBe('listAgents');
+    expect(agents.getOp?.operation.operationId).toBe('getAgent');
+    expect(agents.createOp?.operation.operationId).toBe('createAgent');
+    expect(agents.updateOp?.operation.operationId).toBe('updateAgent');
+    expect(agents.deleteOp?.operation.operationId).toBe('deleteAgent');
+  });
+
+  test('treats item-scoped POST as an action, not a create', () => {
+    const agents = byTag(modules, 'Agents');
+    expect(agents.actions).toHaveLength(1);
+    expect(agents.actions?.[0].operation.operationId).toBe('generateAgent');
+  });
+
+  test('marks a module project-scoped when its paths include {project_id}', () => {
+    expect(byTag(modules, 'Webhooks').isProjectScoped).toBe(true);
+    expect(byTag(modules, 'Agents').isProjectScoped).toBe(false);
+  });
+
+  test('a nested collection POST is the create for its own module', () => {
+    const webhooks = byTag(modules, 'Webhooks');
+    expect(webhooks.createOp?.operation.operationId).toBe('createWebhook');
+    expect(webhooks.actions).toBeUndefined();
+  });
+
+  test('skips operations without an operationId and skipped tags', () => {
+    const spec: OpenApiSpec = {
+      paths: {
+        '/api/v1/sessions': {
+          get: { operationId: 'listSessions', tags: ['Sessions'] },
+        },
+        '/api/v1/noid': {
+          // @ts-expect-error intentionally missing operationId
+          get: { tags: ['Other'] },
+        },
+      },
+    };
+    expect(parseModules(spec)).toHaveLength(0);
+  });
+
+  test('falls back to the "Other" tag when none is given', () => {
+    const spec: OpenApiSpec = {
+      paths: { '/api/v1/x': { get: { operationId: 'getX' } } },
+    };
+    expect(parseModules(spec)[0].tag).toBe('Other');
+  });
+});
+
+describe('getIdParamName', () => {
+  test('returns the extra brace param present on the get path', () => {
+    expect(
+      getIdParamName('/api/v1/agents/{agent_id}', '/api/v1/agents')
+    ).toBe('agent_id');
+  });
+
+  test('defaults to "id" when no extra segment is found', () => {
+    expect(getIdParamName('/api/v1/agents', '/api/v1/agents')).toBe('id');
+  });
+});
+
+describe('resolveSchema', () => {
+  test('dereferences a local $ref', () => {
+    const resolved = resolveSchema(
+      { $ref: '#/components/schemas/CreateAgent' },
+      testSpec
+    );
+    expect(resolved?.required).toContain('name');
+  });
+
+  test('returns the schema unchanged when there is no $ref', () => {
+    const schema = { type: 'string' };
+    expect(resolveSchema(schema, testSpec)).toBe(schema);
+  });
+
+  test('returns undefined for a missing schema', () => {
+    expect(resolveSchema(undefined, testSpec)).toBeUndefined();
+  });
+
+  test('returns undefined for an unresolvable $ref', () => {
+    expect(
+      resolveSchema({ $ref: '#/components/schemas/Nope' }, testSpec)
+    ).toBeUndefined();
+  });
+});
+
+describe('extractItems', () => {
+  test('returns an array body directly, filtering non-objects', () => {
+    expect(extractItems([{ id: '1' }, 'x', null])).toEqual([{ id: '1' }]);
+  });
+
+  test('finds the first array value in an object body', () => {
+    expect(extractItems({ items: [{ id: '1' }], total: 1 })).toEqual([
+      { id: '1' },
+    ]);
+  });
+
+  test('returns empty array when no list is present', () => {
+    expect(extractItems({ id: '1' })).toEqual([]);
+    expect(extractItems('nope')).toEqual([]);
+  });
+});
+
+describe('isSensitiveKey', () => {
+  test.each(['secret', 'api_key', 'password', 'access_token'])(
+    'flags %s as sensitive',
+    (key) => {
+      expect(isSensitiveKey(key)).toBe(true);
+    }
+  );
+
+  test('does not flag ordinary keys', () => {
+    expect(isSensitiveKey('name')).toBe(false);
+  });
+});
+
+describe('formatValue', () => {
+  test('renders null/undefined as empty string', () => {
+    expect(formatValue('x', null)).toBe('');
+  });
+
+  test('renders booleans as Yes/No', () => {
+    expect(formatValue('enabled', true)).toBe('Yes');
+    expect(formatValue('enabled', false)).toBe('No');
+  });
+
+  test('pretty-prints objects', () => {
+    expect(formatValue('meta', { a: 1 })).toBe('{\n  "a": 1\n}');
+  });
+
+  test('formats date-like keys as locale strings', () => {
+    const out = formatValue('created_at', '2024-01-01T00:00:00.000Z');
+    expect(out).not.toBe('2024-01-01T00:00:00.000Z');
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  test('stringifies plain values', () => {
+    expect(formatValue('count', 42)).toBe('42');
+  });
+});

--- a/packages/app/tests/unit/fixtures/spec.ts
+++ b/packages/app/tests/unit/fixtures/spec.ts
@@ -84,6 +84,24 @@ export const testSpec: OpenApiSpec = {
         },
       },
     },
+    '/api/v1/projects/{project_id}': {
+      get: { operationId: 'getProject', tags: ['Projects'] },
+      put: {
+        operationId: 'updateProject',
+        tags: ['Projects'],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+            },
+          },
+        },
+      },
+      delete: { operationId: 'deleteProject', tags: ['Projects'] },
+    },
     '/api/v1/projects/{project_id}/webhooks': {
       get: { operationId: 'listWebhooks', tags: ['Webhooks'] },
       post: { operationId: 'createWebhook', tags: ['Webhooks'] },

--- a/packages/app/tests/unit/fixtures/spec.ts
+++ b/packages/app/tests/unit/fixtures/spec.ts
@@ -1,0 +1,105 @@
+import type { OpenApiSpec } from '@/engine/types';
+
+/**
+ * A compact but realistic OpenAPI spec used to drive the generic engine in
+ * tests. It exercises every classification path: list/get/create/update/delete,
+ * an item-scoped action (generate), a $ref request body, an enum field, and a
+ * project-scoped sub-resource.
+ */
+export const testSpec: OpenApiSpec = {
+  openapi: '3.0.0',
+  info: { title: 'SOAT', version: 'test' },
+  paths: {
+    '/api/v1/agents': {
+      get: {
+        operationId: 'listAgents',
+        tags: ['Agents'],
+        summary: 'List agents',
+      },
+      post: {
+        operationId: 'createAgent',
+        tags: ['Agents'],
+        summary: 'Create an agent',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/CreateAgent' },
+            },
+          },
+        },
+      },
+    },
+    '/api/v1/agents/{agent_id}': {
+      get: { operationId: 'getAgent', tags: ['Agents'] },
+      put: {
+        operationId: 'updateAgent',
+        tags: ['Agents'],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/CreateAgent' },
+            },
+          },
+        },
+      },
+      delete: { operationId: 'deleteAgent', tags: ['Agents'] },
+    },
+    '/api/v1/agents/{agent_id}/generate': {
+      post: {
+        operationId: 'generateAgent',
+        tags: ['Agents'],
+        summary: 'Run a generation',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['prompt'],
+                properties: {
+                  prompt: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/v1/projects': {
+      get: { operationId: 'listProjects', tags: ['Projects'] },
+      post: {
+        operationId: 'createProject',
+        tags: ['Projects'],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['name'],
+                properties: { name: { type: 'string' } },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/v1/projects/{project_id}/webhooks': {
+      get: { operationId: 'listWebhooks', tags: ['Webhooks'] },
+      post: { operationId: 'createWebhook', tags: ['Webhooks'] },
+    },
+  },
+  components: {
+    schemas: {
+      CreateAgent: {
+        type: 'object',
+        required: ['name'],
+        properties: {
+          name: { type: 'string', description: 'Agent name' },
+          model: { type: 'string', enum: ['gpt-4o', 'gpt-4o-mini'] },
+          enabled: { type: 'boolean' },
+        },
+      },
+    },
+  },
+};

--- a/packages/app/tests/unit/msw/handlers.ts
+++ b/packages/app/tests/unit/msw/handlers.ts
@@ -1,0 +1,36 @@
+import { http, HttpResponse } from 'msw';
+
+import { testSpec } from '../fixtures/spec';
+
+export const TEST_USER = {
+  id: 'usr_test',
+  username: 'tester',
+  role: 'admin' as const,
+};
+
+/**
+ * Default handlers shared by every test. Individual tests override specific
+ * routes with `server.use(...)`. URLs are matched with a `*` host wildcard
+ * because in jsdom relative requests resolve against `http://localhost/`.
+ */
+export const defaultHandlers = [
+  http.get('*/api/v1/users/me', () => {
+    return HttpResponse.json(TEST_USER);
+  }),
+  http.post('*/api/v1/users/login', async ({ request }) => {
+    const body = (await request.json()) as {
+      username: string;
+      password: string;
+    };
+    if (body.password === 'wrong') {
+      return HttpResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+    }
+    return HttpResponse.json({ ...TEST_USER, token: 'test-token' });
+  }),
+  http.get('*/api/v1/openapi.json', () => {
+    return HttpResponse.json(testSpec);
+  }),
+  http.get('*/api/v1/projects', () => {
+    return HttpResponse.json([]);
+  }),
+];

--- a/packages/app/tests/unit/msw/server.ts
+++ b/packages/app/tests/unit/msw/server.ts
@@ -1,0 +1,5 @@
+import { setupServer } from 'msw/node';
+
+import { defaultHandlers } from './handlers';
+
+export const server = setupServer(...defaultHandlers);

--- a/packages/app/tests/unit/setup.ts
+++ b/packages/app/tests/unit/setup.ts
@@ -1,0 +1,20 @@
+import '@testing-library/jest-dom/vitest';
+
+import { cleanup } from '@testing-library/react';
+import { afterAll, afterEach, beforeAll } from 'vitest';
+
+import { server } from './msw/server';
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+afterEach(() => {
+  cleanup();
+  server.resetHandlers();
+  localStorage.clear();
+});
+
+afterAll(() => {
+  server.close();
+});

--- a/packages/app/tests/unit/testUtils.tsx
+++ b/packages/app/tests/unit/testUtils.tsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+
+import { AuthProvider } from '@/auth/authContext';
+import { NavigationProvider, useNavigation } from '@/engine/navigationContext';
+
+const TOKEN_KEY = 'soat_token';
+
+/**
+ * Renders the current navigation descriptor as JSON so tests can assert real
+ * navigation side-effects without mocking the navigation context.
+ */
+export const NavProbe = (): React.ReactElement => {
+  const { view, activeProjectId } = useNavigation();
+  return (
+    <div data-testid="nav-probe">{JSON.stringify({ view, activeProjectId })}</div>
+  );
+};
+
+/**
+ * Renders `ui` inside the real Auth + Navigation providers. Auth is driven
+ * through its genuine public flow (a token in localStorage + the MSW
+ * `/users/me` handler), so no internal component is mocked — only the API.
+ *
+ * Engine views receive `module`/`spec`/`pathParams` as props, so the spec
+ * provider is not required here.
+ */
+export const renderWithAuth = (
+  ui: React.ReactElement,
+  { token = 'test-token' }: { token?: string } = {}
+) => {
+  localStorage.setItem(TOKEN_KEY, token);
+  return render(
+    <AuthProvider>
+      <NavigationProvider>{ui}</NavigationProvider>
+    </AuthProvider>
+  );
+};

--- a/packages/app/tests/unit/testUtils.tsx
+++ b/packages/app/tests/unit/testUtils.tsx
@@ -1,8 +1,10 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { AuthProvider } from '@/auth/authContext';
 import { NavigationProvider, useNavigation } from '@/engine/navigationContext';
+import { SpecProvider } from '@/engine/specContext';
 
 const TOKEN_KEY = 'soat_token';
 
@@ -23,16 +25,21 @@ export const NavProbe = (): React.ReactElement => {
  * `/users/me` handler), so no internal component is mocked — only the API.
  *
  * Engine views receive `module`/`spec`/`pathParams` as props, so the spec
- * provider is not required here.
+ * provider is not required here but NavigationProvider needs a Router + Spec
+ * context to resolve URL-based navigation.
  */
 export const renderWithAuth = (
   ui: React.ReactElement,
-  { token = 'test-token' }: { token?: string } = {}
+  { token = 'test-token', initialPath = '/app/' }: { token?: string; initialPath?: string } = {}
 ) => {
   localStorage.setItem(TOKEN_KEY, token);
   return render(
-    <AuthProvider>
-      <NavigationProvider>{ui}</NavigationProvider>
-    </AuthProvider>
+    <MemoryRouter initialEntries={[initialPath]}>
+      <AuthProvider>
+        <SpecProvider token={token}>
+          <NavigationProvider>{ui}</NavigationProvider>
+        </SpecProvider>
+      </AuthProvider>
+    </MemoryRouter>
   );
 };

--- a/packages/app/tests/unit/views/workspace.test.tsx
+++ b/packages/app/tests/unit/views/workspace.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, test } from 'vitest';
 
 import { AuthProvider } from '@/auth/authContext';
@@ -10,16 +11,18 @@ import { Workspace } from '@/views/workspace';
 
 import { server } from '../msw/server';
 
-const renderWorkspace = (): void => {
+const renderWorkspace = (initialPath = '/app/'): void => {
   localStorage.setItem('soat_token', 'test-token');
   render(
-    <AuthProvider>
-      <SpecProvider token="test-token">
-        <NavigationProvider>
-          <Workspace />
-        </NavigationProvider>
-      </SpecProvider>
-    </AuthProvider>
+    <MemoryRouter initialEntries={[initialPath]}>
+      <AuthProvider>
+        <SpecProvider token="test-token">
+          <NavigationProvider>
+            <Workspace />
+          </NavigationProvider>
+        </SpecProvider>
+      </AuthProvider>
+    </MemoryRouter>
   );
 };
 

--- a/packages/app/tests/unit/views/workspace.test.tsx
+++ b/packages/app/tests/unit/views/workspace.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, test } from 'vitest';
+
+import { AuthProvider } from '@/auth/authContext';
+import { NavigationProvider } from '@/engine/navigationContext';
+import { SpecProvider } from '@/engine/specContext';
+import { Workspace } from '@/views/workspace';
+
+import { server } from '../msw/server';
+
+const renderWorkspace = (): void => {
+  localStorage.setItem('soat_token', 'test-token');
+  render(
+    <AuthProvider>
+      <SpecProvider token="test-token">
+        <NavigationProvider>
+          <Workspace />
+        </NavigationProvider>
+      </SpecProvider>
+    </AuthProvider>
+  );
+};
+
+describe('Workspace', () => {
+  test('renders the navigation with projects and modules', async () => {
+    server.use(
+      http.get('*/api/v1/projects', () =>
+        HttpResponse.json([{ id: 'prj_1', name: 'Proj One' }])
+      )
+    );
+    renderWorkspace();
+
+    expect(await screen.findByText('Proj One')).toBeInTheDocument();
+    expect(screen.getByText('SOAT')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Agents' })).toBeInTheDocument();
+    expect(screen.getByText('Welcome to SOAT')).toBeInTheDocument();
+  });
+
+  test('selecting a module renders its list in the main area', async () => {
+    server.use(
+      http.get('*/api/v1/agents', () =>
+        HttpResponse.json([{ id: 'agt_1', name: 'Alpha' }])
+      )
+    );
+    renderWorkspace();
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Agents' })
+    );
+    expect(await screen.findByText('Alpha')).toBeInTheDocument();
+  });
+});

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,6 +1,7 @@
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import react from '@vitejs/plugin-react';
-import { resolve } from 'path';
-import { fileURLToPath } from 'url';
 import { defineConfig } from 'vite';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -13,11 +14,7 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': {
-        target: 'https://soat.lets.rocks',
-        changeOrigin: true,
-        secure: true,
-      },
+      '/api': 'http://localhost:5047',
     },
   },
   resolve: {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -13,7 +13,11 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': 'http://localhost:5047',
+      '/api': {
+        target: 'https://soat.lets.rocks',
+        changeOrigin: true,
+        secure: true,
+      },
     },
   },
   resolve: {

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -1,0 +1,27 @@
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./tests/unit/setup.ts'],
+    include: ['tests/unit/**/*.test.{ts,tsx}'],
+    css: false,
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/main.tsx', 'src/vite-env.d.ts', 'src/**/*.d.ts'],
+    },
+  },
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -72,6 +72,11 @@ const resolveServePath = (
 };
 
 app.use(async (ctx: Context, next: () => Promise<void>) => {
+  if (ctx.path === '/') {
+    ctx.redirect('/app');
+    return;
+  }
+
   if (!ctx.path.startsWith('/app')) {
     return next();
   }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 
 import createDebug from 'debug';
 
+import pkg from '../package.json' assert { type: 'json' };
 import { app } from './app';
 import { initializeDatabase } from './db';
 import { createFirstAdminUser } from './lib/users';
@@ -46,8 +47,7 @@ const startServer = async () => {
   const server = app.listen(SOAT_PORT, () => {
     // eslint-disable-next-line no-console
     console.log(
-      'startServer: server running on http://localhost:%d',
-      SOAT_PORT
+      `startServer: server ${pkg.version} running on http://localhost:${SOAT_PORT}`
     );
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.5(@types/react@19.2.16)(react@19.2.7)
+      '@soat/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -13523,19 +13526,9 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
@@ -13543,19 +13536,9 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
@@ -13593,19 +13576,9 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
@@ -13623,19 +13596,9 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
@@ -13643,19 +13606,9 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
@@ -13663,19 +13616,9 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
@@ -13683,19 +13626,9 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
@@ -18655,9 +18588,9 @@ snapshots:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.6.1))
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-formatjs: 6.4.5(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jest: 29.15.2(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.6.0)(typescript@6.0.3)))(typescript@6.0.3)
       eslint-plugin-jest-dom: 5.5.0(@testing-library/dom@10.4.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
@@ -19765,19 +19698,6 @@ snapshots:
 
   b4a@1.7.3: {}
 
-  babel-jest@30.4.1(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 30.4.1
-      '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 7.0.1
-      babel-preset-jest: 30.4.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   babel-jest@30.4.1(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
@@ -19790,7 +19710,6 @@ snapshots:
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.104.1(@swc/core@1.15.24)):
     dependencies:
@@ -19895,25 +19814,6 @@ snapshots:
       '@babel/template': 7.28.6
       tslib: 2.8.1
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
-
   babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
@@ -19933,18 +19833,11 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
 
-  babel-preset-jest@30.4.0(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      babel-plugin-jest-hoist: 30.4.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
-
   babel-preset-jest@30.4.0(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
       babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
-    optional: true
 
   bail@2.0.2: {}
 
@@ -21500,7 +21393,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.6.1)
@@ -21511,18 +21404,18 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -21538,7 +21431,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-jest
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -21549,7 +21442,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -23231,7 +23124,7 @@ snapshots:
       '@jest/pattern': 30.4.0
       '@jest/test-sequencer': 30.4.1
       '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.29.0)
+      babel-jest: 30.4.1(@babel/core@7.29.7)
       chalk: 4.1.2
       ci-info: 4.4.0
       deepmerge: 4.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,18 @@ importers:
         specifier: ^3.3.0
         version: 3.6.0
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.0
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.2.16
         version: 19.2.16
@@ -93,9 +105,18 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.2
         version: 4.7.0(vite@6.4.3(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.23(postcss@8.5.6)
+      jsdom:
+        specifier: ^26.0.0
+        version: 26.1.0
+      msw:
+        specifier: ^2.7.0
+        version: 2.14.6(@types/node@25.6.0)(typescript@6.0.3)
       postcss:
         specifier: ^8.5.4
         version: 8.5.6
@@ -108,6 +129,9 @@ importers:
       vite:
         specifier: ^6.3.5
         version: 6.4.3(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0)
 
   packages/cli:
     dependencies:
@@ -190,10 +214,10 @@ importers:
     devDependencies:
       '@hey-api/client-fetch':
         specifier: ^0.13.1
-        version: 0.13.1(@hey-api/openapi-ts@0.98.1(typescript@6.0.3))
+        version: 0.13.1(@hey-api/openapi-ts@0.98.1(magicast@0.3.5)(typescript@6.0.3))
       '@hey-api/openapi-ts':
         specifier: ^0.98.1
-        version: 0.98.1(typescript@6.0.3)
+        version: 0.98.1(magicast@0.3.5)(typescript@6.0.3)
       '@ttoss/config':
         specifier: ^1.37.15
         version: 1.37.15
@@ -564,6 +588,10 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@apidevtools/json-schema-ref-parser@15.3.5':
     resolution: {integrity: sha512-orNOYXw3hYXxxisXMldjzjBzqqTLBPbwOtHg7ovBPvfBHDue1qM9YJENZ3W2BQuS+7z4ThogMbEzEsov57Itkg==}
     engines: {node: '>=20'}
@@ -744,10 +772,6 @@ packages:
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
-
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1468,10 +1492,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/runtime@7.28.4':
-    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
@@ -1509,6 +1529,10 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -2679,6 +2703,15 @@ packages:
     resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/core@11.2.1':
     resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
@@ -3097,6 +3130,10 @@ packages:
   '@module-federation/webpack-bundler-runtime@0.22.0':
     resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
 
+  '@mswjs/interceptors@0.41.9':
+    resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
+    engines: {node: '>=18'}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -3218,6 +3255,18 @@ packages:
   '@octokit/webhooks@14.2.0':
     resolution: {integrity: sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==}
     engines: {node: '>= 20'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -4555,6 +4604,9 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/co-body@6.1.3':
     resolution: {integrity: sha512-UhuhrQ5hclX6UJctv5m4Rfp52AfG9o9+d9/HwjxhVB5NjXxr5t9oKgJxN8xRHgr35oo8meUEHUPFWiKg6y71aA==}
 
@@ -4572,6 +4624,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/docker-modem@3.0.6':
     resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
@@ -4765,6 +4820,9 @@ packages:
   '@types/serve-static@1.15.10':
     resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
   '@types/sockjs@0.3.36':
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
 
@@ -4779,6 +4837,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
@@ -4995,6 +5056,44 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/coverage-v8@3.2.6':
+    resolution: {integrity: sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==}
+    peerDependencies:
+      '@vitest/browser': 3.2.6
+      vitest: 3.2.6
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -5318,6 +5417,10 @@ packages:
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@3.0.0-beta.1:
     resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
     engines: {node: '>=20.19.0'}
@@ -5328,6 +5431,9 @@ packages:
   ast-types@0.14.2:
     resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -5640,6 +5746,10 @@ packages:
       magicast:
         optional: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
@@ -5711,6 +5821,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -5741,6 +5855,10 @@ packages:
   charset@1.0.1:
     resolution: {integrity: sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==}
     engines: {node: '>=4.0.0'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -6045,6 +6163,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
@@ -6323,6 +6445,10 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-equal@1.0.1:
     resolution: {integrity: sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==}
@@ -6678,6 +6804,9 @@ packages:
   es-iterator-helpers@1.2.2:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -7050,6 +7179,10 @@ packages:
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect@30.3.0:
     resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
@@ -7509,6 +7642,10 @@ packages:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
@@ -7589,6 +7726,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -8020,6 +8160,9 @@ packages:
     resolution: {integrity: sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==}
     engines: {node: '>=16'}
 
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
   is-npm@6.1.0:
     resolution: {integrity: sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -8389,8 +8532,14 @@ packages:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
     engines: {node: '>=0.10.0'}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
@@ -8749,6 +8898,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
@@ -8775,6 +8927,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -9177,6 +9332,16 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.14.6:
+    resolution: {integrity: sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   multer@2.1.1:
     resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
     engines: {node: '>= 10.16.0'}
@@ -9461,6 +9626,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -9618,8 +9786,8 @@ packages:
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -9630,6 +9798,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
@@ -10702,6 +10874,9 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -10973,6 +11148,9 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -11051,6 +11229,9 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -11217,6 +11398,9 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stacktracey@2.1.8:
     resolution: {integrity: sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==}
 
@@ -11244,6 +11428,9 @@ packages:
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -11344,6 +11531,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
@@ -11463,6 +11653,10 @@ packages:
     engines: {node: '>=14.17.0'}
     hasBin: true
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
@@ -11518,6 +11712,10 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
   testcontainers@12.0.1:
     resolution: {integrity: sha512-EMjjfMNJf3HlL7V3elkxqKUO1r3CtqNBTdmKGwwma/lOtUGfoWvFJ0WQ/KQf1DHEMnRjLWzW4cXbv/Tndsbcbw==}
 
@@ -11553,6 +11751,12 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -11569,11 +11773,26 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
+  tldts-core@7.4.2:
+    resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
+
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tldts@7.4.2:
+    resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
     hasBin: true
 
   tmp@0.2.7:
@@ -11600,6 +11819,10 @@ packages:
 
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
   tr46@0.0.3:
@@ -11729,6 +11952,10 @@ packages:
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
+
+  type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
+    engines: {node: '>=20'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -11875,6 +12102,9 @@ packages:
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
+
   update-browserslist-db@1.2.2:
     resolution: {integrity: sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==}
     hasBin: true
@@ -11997,6 +12227,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@6.4.3:
     resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -12035,6 +12270,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   w3c-xmlserializer@5.0.0:
@@ -12184,6 +12447,11 @@ packages:
   which@6.0.0:
     resolution: {integrity: sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wide-align@1.1.5:
@@ -12608,6 +12876,11 @@ snapshots:
       '@algolia/client-common': 5.46.2
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@apidevtools/json-schema-ref-parser@15.3.5(@types/json-schema@7.0.15)':
     dependencies:
@@ -13127,12 +13400,6 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -13145,7 +13412,7 @@ snapshots:
 
   '@babel/core@7.29.0':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -13153,7 +13420,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -13429,7 +13696,7 @@ snapshots:
 
   '@babel/parser@7.29.2':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -14236,7 +14503,7 @@ snapshots:
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -14247,7 +14514,7 @@ snapshots:
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.7)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -14587,14 +14854,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/preset-react@7.28.5(@babel/core@7.29.0)':
@@ -14643,15 +14910,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/runtime@7.28.4': {}
-
   '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.7
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/template@7.29.7':
     dependencies:
@@ -14661,12 +14926,12 @@ snapshots:
 
   '@babel/traverse@7.29.0':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-globals': 7.28.0
       '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -14701,6 +14966,8 @@ snapshots:
   '@balena/dockerignore@1.0.2': {}
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@colors/colors@1.5.0':
     optional: true
@@ -15177,7 +15444,7 @@ snapshots:
       '@babel/preset-env': 7.29.2(@babel/core@7.29.0)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.10.1
       '@docusaurus/utils': 3.10.1(@swc/core@1.15.24)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -15981,7 +16248,7 @@ snapshots:
 
   '@emotion/jest@11.14.2(@types/jest@30.0.0)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       '@emotion/css-prettifier': 1.2.0
       chalk: 4.1.2
       specificity: 0.4.1
@@ -16292,15 +16559,15 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@hey-api/client-fetch@0.13.1(@hey-api/openapi-ts@0.98.1(typescript@6.0.3))':
+  '@hey-api/client-fetch@0.13.1(@hey-api/openapi-ts@0.98.1(magicast@0.3.5)(typescript@6.0.3))':
     dependencies:
-      '@hey-api/openapi-ts': 0.98.1(typescript@6.0.3)
+      '@hey-api/openapi-ts': 0.98.1(magicast@0.3.5)(typescript@6.0.3)
 
-  '@hey-api/codegen-core@0.8.4':
+  '@hey-api/codegen-core@0.8.4(magicast@0.3.5)':
     dependencies:
       '@hey-api/types': 0.1.4
       ansi-colors: 4.1.3
-      c12: 3.3.4
+      c12: 3.3.4(magicast@0.3.5)
       color-support: 1.1.3
     transitivePeerDependencies:
       - magicast
@@ -16311,11 +16578,11 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.1
 
-  '@hey-api/openapi-ts@0.98.1(typescript@6.0.3)':
+  '@hey-api/openapi-ts@0.98.1(magicast@0.3.5)(typescript@6.0.3)':
     dependencies:
-      '@hey-api/codegen-core': 0.8.4
+      '@hey-api/codegen-core': 0.8.4(magicast@0.3.5)
       '@hey-api/json-schema-ref-parser': 1.4.3
-      '@hey-api/shared': 0.4.7
+      '@hey-api/shared': 0.4.7(magicast@0.3.5)
       '@hey-api/spec-types': 0.2.0
       '@hey-api/types': 0.1.4
       '@lukeed/ms': 2.0.2
@@ -16327,9 +16594,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@hey-api/shared@0.4.7':
+  '@hey-api/shared@0.4.7(magicast@0.3.5)':
     dependencies:
-      '@hey-api/codegen-core': 0.8.4
+      '@hey-api/codegen-core': 0.8.4(magicast@0.3.5)
       '@hey-api/json-schema-ref-parser': 1.4.3
       '@hey-api/spec-types': 0.2.0
       '@hey-api/types': 0.1.4
@@ -16370,6 +16637,13 @@ snapshots:
   '@humanwhocodes/retry@0.4.3': {}
 
   '@inquirer/ansi@2.0.7': {}
+
+  '@inquirer/confirm@6.1.1(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.6.0)
+      '@inquirer/type': 4.0.7(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
 
   '@inquirer/core@11.2.1(@types/node@24.12.2)':
     dependencies:
@@ -16862,7 +17136,7 @@ snapshots:
       http-errors: 2.0.1
       koa: 3.2.0
       koa-compose: 4.1.0
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17074,6 +17348,15 @@ snapshots:
       '@module-federation/runtime': 0.22.0
       '@module-federation/sdk': 0.22.0
 
+  '@mswjs/interceptors@0.41.9':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.7.1
@@ -17233,6 +17516,17 @@ snapshots:
       '@octokit/openapi-webhooks-types': 12.1.0
       '@octokit/request-error': 7.1.0
       '@octokit/webhooks-methods': 6.0.0
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -18511,8 +18805,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.4
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -18531,7 +18825,7 @@ snapshots:
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -18751,7 +19045,7 @@ snapshots:
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -18761,6 +19055,11 @@ snapshots:
   '@types/bonjour@3.5.13':
     dependencies:
       '@types/node': 24.12.2
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/co-body@6.1.3':
     dependencies:
@@ -18786,6 +19085,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/docker-modem@3.0.6':
     dependencies:
       '@types/node': 24.12.2
@@ -18808,7 +19109,7 @@ snapshots:
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
 
   '@types/estree-jsx@1.0.5':
@@ -19010,6 +19311,10 @@ snapshots:
       '@types/node': 24.12.2
       '@types/send': 0.17.6
 
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 24.12.2
+
   '@types/sockjs@0.3.36':
     dependencies:
       '@types/node': 24.12.2
@@ -19028,6 +19333,8 @@ snapshots:
       '@types/node': 18.19.130
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/statuses@2.0.6': {}
 
   '@types/superagent@8.1.9':
     dependencies:
@@ -19232,6 +19539,68 @@ snapshots:
       vite: 6.4.3(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.6(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.6':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@6.4.3(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@25.6.0)(typescript@6.0.3)
+      vite: 6.4.3(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -19632,6 +20001,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  assertion-error@2.0.1: {}
+
   ast-kit@3.0.0-beta.1:
     dependencies:
       '@babel/parser': 8.0.0-rc.6
@@ -19643,6 +20014,12 @@ snapshots:
   ast-types@0.14.2:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astring@1.9.0: {}
 
@@ -20047,7 +20424,7 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  c12@3.3.4:
+  c12@3.3.4(magicast@0.3.5):
     dependencies:
       chokidar: 5.0.0
       confbox: 0.2.4
@@ -20061,6 +20438,10 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.0
       rc9: 3.0.1
+    optionalDependencies:
+      magicast: 0.3.5
+
+  cac@6.7.14: {}
 
   cac@7.0.0: {}
 
@@ -20176,6 +20557,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -20196,6 +20585,8 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   charset@1.0.1: {}
+
+  check-error@2.1.3: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -20506,6 +20897,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   cookiejar@2.1.4: {}
 
   cookies@0.9.1:
@@ -20794,6 +21187,8 @@ snapshots:
       mimic-response: 3.1.0
 
   dedent@1.7.2: {}
+
+  deep-eql@5.0.2: {}
 
   deep-equal@1.0.1: {}
 
@@ -21261,6 +21656,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@1.7.0: {}
+
   es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
@@ -21462,7 +21859,7 @@ snapshots:
 
   eslint-plugin-jest-dom@5.5.0(@testing-library/dom@10.4.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       eslint: 9.39.4(jiti@2.6.1)
       requireindex: 1.2.0
     optionalDependencies:
@@ -21665,7 +22062,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -21702,7 +22099,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -21758,6 +22155,8 @@ snapshots:
   expand-tilde@2.0.2:
     dependencies:
       homedir-polyfill: 1.0.3
+
+  expect-type@1.3.0: {}
 
   expect@30.3.0:
     dependencies:
@@ -22336,6 +22735,8 @@ snapshots:
 
   graphql@16.12.0: {}
 
+  graphql@16.14.2: {}
+
   gray-matter@4.0.3:
     dependencies:
       js-yaml: 3.14.2
@@ -22419,7 +22820,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -22481,6 +22882,11 @@ snapshots:
       space-separated-tokens: 2.0.2
 
   he@1.2.0: {}
+
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.0
 
   hermes-estree@0.25.1: {}
 
@@ -22892,6 +23298,8 @@ snapshots:
 
   is-network-error@1.3.0: {}
 
+  is-node-process@1.2.0: {}
+
   is-npm@6.1.0: {}
 
   is-number-object@1.1.1:
@@ -22921,7 +23329,7 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   is-regex@1.2.1:
     dependencies:
@@ -23299,7 +23707,7 @@ snapshots:
 
   jest-message-util@30.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@jest/types': 30.2.0
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -23311,7 +23719,7 @@ snapshots:
 
   jest-message-util@30.3.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@jest/types': 30.3.0
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -23323,7 +23731,7 @@ snapshots:
 
   jest-message-util@30.4.1:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@jest/types': 30.4.1
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -23580,7 +23988,11 @@ snapshots:
 
   js-levenshtein@1.1.6: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@3.14.2:
     dependencies:
@@ -23949,6 +24361,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -23972,6 +24386,12 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
@@ -24322,7 +24742,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -24333,7 +24753,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -24350,7 +24770,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -24386,7 +24806,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -24460,7 +24880,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -24643,6 +25063,31 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
+
+  msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3):
+    dependencies:
+      '@inquirer/confirm': 6.1.1(@types/node@25.6.0)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.7.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@types/node'
 
   multer@2.1.1:
     dependencies:
@@ -24986,6 +25431,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  outvariant@1.4.3: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -25075,7 +25522,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -25143,13 +25590,15 @@ snapshots:
 
   path-to-regexp@3.3.0: {}
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   perfect-debounce@2.1.0: {}
 
@@ -25967,7 +26416,7 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.7))(webpack@5.104.1(@swc/core@1.15.24)):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.7)'
       webpack: 5.104.1(@swc/core@1.15.24)
 
@@ -26013,13 +26462,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       react: 19.2.7
       react-router: 5.3.4(react@19.2.7)
 
   react-router-dom@5.3.4(react@19.2.7):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -26030,7 +26479,7 @@ snapshots:
 
   react-router@5.3.4(react@19.2.7):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -26104,7 +26553,7 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
@@ -26208,7 +26657,7 @@ snapshots:
 
   relay-test-utils@20.1.1(encoding@0.1.13):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       fbjs: 3.0.5(encoding@0.1.13)
       invariant: 2.2.4
       relay-runtime: 20.1.1(encoding@0.1.13)
@@ -26356,6 +26805,8 @@ snapshots:
   retry@0.12.0: {}
 
   retry@0.13.1: {}
+
+  rettime@0.11.11: {}
 
   reusify@1.1.0: {}
 
@@ -26678,6 +27129,8 @@ snapshots:
 
   set-blocking@2.0.0: {}
 
+  set-cookie-parser@3.1.0: {}
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -26779,6 +27232,8 @@ snapshots:
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
 
@@ -26965,6 +27420,8 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
   stacktracey@2.1.8:
     dependencies:
       as-table: 1.0.55
@@ -26996,6 +27453,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  strict-event-emitter@0.5.1: {}
 
   string-argv@0.3.2: {}
 
@@ -27121,6 +27580,10 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   strnum@2.2.3: {}
 
@@ -27263,6 +27726,8 @@ snapshots:
       syncpack-windows-arm64: 15.3.1
       syncpack-windows-x64: 15.3.1
 
+  tagged-tag@1.0.0: {}
+
   tailwind-merge@3.6.0: {}
 
   tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.9.0):
@@ -27363,6 +27828,12 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.5.0
+      minimatch: 10.2.5
+
   testcontainers@12.0.1:
     dependencies:
       '@balena/dockerignore': 1.0.2
@@ -27414,6 +27885,10 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.1.1: {}
 
   tinyexec@1.2.4: {}
@@ -27425,11 +27900,21 @@ snapshots:
 
   tinypool@1.1.1: {}
 
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
   tldts-core@6.1.86: {}
+
+  tldts-core@7.4.2: {}
 
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
+
+  tldts@7.4.2:
+    dependencies:
+      tldts-core: 7.4.2
 
   tmp@0.2.7: {}
 
@@ -27448,6 +27933,10 @@ snapshots:
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.2
 
   tr46@0.0.3: {}
 
@@ -27581,6 +28070,10 @@ snapshots:
   type-fest@1.4.0: {}
 
   type-fest@2.19.0: {}
+
+  type-fest@5.7.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   type-is@1.6.18:
     dependencies:
@@ -27769,6 +28262,8 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
+  until-async@3.0.2: {}
+
   update-browserslist-db@1.2.2(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -27900,6 +28395,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.3(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@6.4.3(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
@@ -27917,6 +28433,49 @@ snapshots:
       terser: 5.44.1
       tsx: 4.22.4
       yaml: 2.9.0
+
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@6.4.3(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.3(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 25.6.0
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   w3c-xmlserializer@5.0.0:
     dependencies:
@@ -28148,6 +28707,11 @@ snapshots:
   which@6.0.0:
     dependencies:
       isexe: 3.1.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wide-align@1.1.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      react-router-dom:
+        specifier: ^7.17.0
+        version: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.6.0
@@ -10633,10 +10636,27 @@ packages:
     peerDependencies:
       react: '>=15'
 
+  react-router-dom@7.17.0:
+    resolution: {integrity: sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
   react-router@5.3.4:
     resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
     peerDependencies:
       react: '>=15'
+
+  react-router@7.17.0:
+    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -11147,6 +11167,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
@@ -26477,6 +26500,12 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
+  react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-router: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
   react-router@5.3.4(react@19.2.7):
     dependencies:
       '@babel/runtime': 7.29.7
@@ -26489,6 +26518,14 @@ snapshots:
       react-is: 16.13.1
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
+
+  react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.7
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
 
   react@19.2.7: {}
 
@@ -27128,6 +27165,8 @@ snapshots:
       - supports-color
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-cookie-parser@3.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ allowBuilds:
   core-js: true
   cpu-features: true
   esbuild: true
+  msw: false
   postman-code-generators: false
   protobufjs: true
   ssh2: true


### PR DESCRIPTION
## Summary

Completes **Phase 3** of the SOAT App delivery plan (`docs/prd/app.md` §12) by adding support for **action endpoints** — item-scoped POST operations like `POST /agents/{agent_id}/generate`, `POST /tools/{tool_id}/call`, and `POST /conversations/{conversation_id}/generate`. This was the one remaining gap in Phase 3 (create/edit forms and delete confirmation already shipped in #205).

## What changed

- **Operation classification (`specUtils.ts`)** — rewritten as a gather-then-classify two-pass. A POST is treated as the module's **create** only when its path equals the collection (list) path; every other item-scoped POST becomes an **action**. This preserves nested creates such as `POST /projects/{id}/webhooks` while correctly collecting verbs (`generate`, `tool-outputs`, `call`, `rotate-secret`, `messages`, …). Shallow paths are classified first so list/detail/create always win over sub-paths.
- **`action` view mode + `ActionView`** — builds a form from the operation's request-body schema, prompts for any path params not already in the navigation context, runs the operation with the **user's own token**, and renders the response in a result panel. Errors render inline (DomainError message shape).
- **Detail view** — surfaces a button per available action that navigates to the action view with the current path params.
- **Shared form helpers (`formHelpers.ts`)** — `initFormData`, `buildRequestBody`, `convertFieldValue`, and `getOpRequestSchema` extracted so `FormView` and `ActionView` share one implementation instead of duplicating it.

## Verification

- `pnpm typecheck` — clean
- `pnpm eslint src` — 0 errors (only pre-existing i18n warnings)
- `pnpm build` — succeeds (56 modules)
- Replayed the real merged OpenAPI specs through the new classifier to confirm no regression: nested creates (Webhooks) stay as `create`, and actions are collected for Agents, Conversations, Tools, etc.

Frontend-only change — per PRD §10, action endpoints reuse existing server modules with no backend work.

## Phase status after this PR

| Phase | Status |
|---|---|
| 1 — Foundation | Done |
| 2 — Engine (read) | Done |
| 3 — Engine (write) | **Done** (this PR closes the action-endpoint gap) |
| 4 — AI Guide Chat | Not started (next) |
| 5 — Hardening | Not started |

https://claude.ai/code/session_01JZhSnUiGYZGvUUiDmJcZ1g

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZhSnUiGYZGvUUiDmJcZ1g)_