### PR TITLE
refactor(webhooks): flatten routes to /webhooks, matching codebase convention

### DIFF
--- a/packages/server/src/lib/soatToolsHelpers.ts
+++ b/packages/server/src/lib/soatToolsHelpers.ts
@@ -8,6 +8,9 @@ import type { JSONSchema7 } from 'ai';
 import createDebug from 'debug';
 
 import {
+  buildBodyFn,
+  buildPathFn,
+  buildQueryFn,
   resolveParameter as resolveOpenApiParameter,
   resolveSchema as resolveOpenApiSchema,
 } from './soatToolsSchemaHelpers';
@@ -20,6 +23,7 @@ export interface ToolDefinition {
   inputSchema: JsonObjectSchema;
   method: string;
   path: (args: Record<string, unknown>) => string;
+  query?: (args: Record<string, unknown>) => string;
   body?: (args: Record<string, unknown>) => Record<string, unknown>;
   iamAction?: string;
 }
@@ -209,41 +213,6 @@ export const buildInputSchema = (
   };
 };
 
-export const buildPathFn = (
-  pathTemplate: string,
-  pathParams: Array<{ name: string; camelName: string }>
-): ((args: Record<string, unknown>) => string) => {
-  return (args: Record<string, unknown>) => {
-    let result = pathTemplate;
-    for (const { name, camelName } of pathParams) {
-      const value = args[camelName];
-      if (value !== undefined) {
-        result = result.replace(`{${name}}`, encodeURIComponent(String(value)));
-      }
-    }
-    return result;
-  };
-};
-
-export const buildBodyFn = (
-  bodyProps: Array<{
-    snakeName: string;
-    camelName: string;
-  }>
-): ((args: Record<string, unknown>) => Record<string, unknown>) | undefined => {
-  if (bodyProps.length === 0) return undefined;
-
-  return (args: Record<string, unknown>) => {
-    const body: Record<string, unknown> = {};
-    for (const { snakeName, camelName } of bodyProps) {
-      if (args[camelName] !== undefined) {
-        body[snakeName] = args[camelName];
-      }
-    }
-    return body;
-  };
-};
-
 export const extractPathParams = (args: {
   parameters: Array<{ name?: string; in?: string; [key: string]: unknown }>;
   spec: OpenApiSpec;
@@ -407,6 +376,7 @@ export const processOperation = (args: {
     inputSchema,
     method: httpMethod,
     path: buildPathFn(args.pathTemplate, pathParams),
+    query: buildQueryFn(queryParams),
     body: buildBodyFn(bodyProps),
     iamAction: args.operation['x-iam-action'],
   };

--- a/packages/server/src/lib/soatToolsSchemaHelpers.ts
+++ b/packages/server/src/lib/soatToolsSchemaHelpers.ts
@@ -102,3 +102,58 @@ export const resolveParameter = (
   }
   return param;
 };
+
+export const buildPathFn = (
+  pathTemplate: string,
+  pathParams: Array<{ name: string; camelName: string }>
+): ((args: Record<string, unknown>) => string) => {
+  return (args: Record<string, unknown>) => {
+    let result = pathTemplate;
+    for (const { name, camelName } of pathParams) {
+      const value = args[camelName];
+      if (value !== undefined) {
+        result = result.replace(`{${name}}`, encodeURIComponent(String(value)));
+      }
+    }
+    return result;
+  };
+};
+
+export const buildQueryFn = (
+  queryParams: Array<{ name: string; camelName: string }>
+): ((args: Record<string, unknown>) => string) | undefined => {
+  if (queryParams.length === 0) return undefined;
+
+  return (args: Record<string, unknown>) => {
+    const search = new URLSearchParams();
+    for (const { name, camelName } of queryParams) {
+      const value = args[camelName];
+      if (value === undefined || value === null) continue;
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          search.append(name, String(item));
+        }
+      } else {
+        search.append(name, String(value));
+      }
+    }
+    const qs = search.toString();
+    return qs ? `?${qs}` : '';
+  };
+};
+
+export const buildBodyFn = (
+  bodyProps: Array<{ snakeName: string; camelName: string }>
+): ((args: Record<string, unknown>) => Record<string, unknown>) | undefined => {
+  if (bodyProps.length === 0) return undefined;
+
+  return (args: Record<string, unknown>) => {
+    const body: Record<string, unknown> = {};
+    for (const { snakeName, camelName } of bodyProps) {
+      if (args[camelName] !== undefined) {
+        body[snakeName] = args[camelName];
+      }
+    }
+    return body;
+  };
+};

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -32,9 +32,10 @@ for (const tool of soatTools) {
     description: tool.description,
     inputSchema: tool.inputSchema,
     handler: async (args: Record<string, unknown>) => {
+      const url = tool.path(args) + (tool.query ? tool.query(args) : '');
       const data = await apiCall(
         tool.method,
-        tool.path(args),
+        url,
         tool.body ? { body: tool.body(args) } : {}
       );
       return { content: [{ type: 'text' as const, text: toMcpText(data) }] };

--- a/packages/server/src/rest/openapi/v1/webhooks.yaml
+++ b/packages/server/src/rest/openapi/v1/webhooks.yaml
@@ -19,17 +19,17 @@ tags:
 security:
   - bearerAuth: []
 paths:
-  /api/v1/projects/{project_id}/webhooks:
+  /api/v1/webhooks:
     get:
-      description: Lists all webhooks configured for the specified project
+      description: Lists webhooks. Use the project_id query parameter to filter by project.
       tags:
         - Webhooks
-      summary: List webhooks for a project
+      summary: List webhooks
       operationId: listWebhooks
       parameters:
         - name: project_id
-          in: path
-          required: true
+          in: query
+          required: false
           schema:
             type: string
       responses:
@@ -46,17 +46,11 @@ paths:
         '403':
           description: Forbidden
     post:
-      description: Creates a new webhook for the specified project
+      description: Creates a new webhook for a project
       tags:
         - Webhooks
       summary: Create a webhook
       operationId: createWebhook
-      parameters:
-        - name: project_id
-          in: path
-          required: true
-          schema:
-            type: string
       requestBody:
         required: true
         content:
@@ -77,7 +71,7 @@ paths:
         '403':
           description: Forbidden
 
-  /api/v1/projects/{project_id}/webhooks/{webhook_id}:
+  /api/v1/webhooks/{webhook_id}:
     get:
       description: Retrieves the details of a specific webhook
       tags:
@@ -85,11 +79,6 @@ paths:
       summary: Get a webhook
       operationId: getWebhook
       parameters:
-        - name: project_id
-          in: path
-          required: true
-          schema:
-            type: string
         - name: webhook_id
           in: path
           required: true
@@ -115,11 +104,6 @@ paths:
       summary: Update a webhook
       operationId: updateWebhook
       parameters:
-        - name: project_id
-          in: path
-          required: true
-          schema:
-            type: string
         - name: webhook_id
           in: path
           required: true
@@ -153,11 +137,6 @@ paths:
       summary: Delete a webhook
       operationId: deleteWebhook
       parameters:
-        - name: project_id
-          in: path
-          required: true
-          schema:
-            type: string
         - name: webhook_id
           in: path
           required: true
@@ -173,7 +152,7 @@ paths:
         '404':
           description: Webhook not found
 
-  /api/v1/projects/{project_id}/webhooks/{webhook_id}/deliveries:
+  /api/v1/webhooks/{webhook_id}/deliveries:
     get:
       description: Lists all event deliveries for a specific webhook
       tags:
@@ -181,11 +160,6 @@ paths:
       summary: List deliveries for a webhook
       operationId: listWebhookDeliveries
       parameters:
-        - name: project_id
-          in: path
-          required: true
-          schema:
-            type: string
         - name: webhook_id
           in: path
           required: true
@@ -217,7 +191,7 @@ paths:
         '404':
           description: Webhook not found
 
-  /api/v1/projects/{project_id}/webhooks/{webhook_id}/deliveries/{delivery_id}:
+  /api/v1/webhooks/{webhook_id}/deliveries/{delivery_id}:
     get:
       description: Retrieves the details of a specific webhook delivery
       tags:
@@ -225,11 +199,6 @@ paths:
       summary: Get a delivery
       operationId: getWebhookDelivery
       parameters:
-        - name: project_id
-          in: path
-          required: true
-          schema:
-            type: string
         - name: webhook_id
           in: path
           required: true
@@ -254,7 +223,7 @@ paths:
         '404':
           description: Delivery not found
 
-  /api/v1/projects/{project_id}/webhooks/{webhook_id}/secret:
+  /api/v1/webhooks/{webhook_id}/secret:
     get:
       description: Retrieves the signing secret for the specified webhook
       tags:
@@ -262,11 +231,6 @@ paths:
       summary: Get webhook secret
       operationId: getWebhookSecret
       parameters:
-        - name: project_id
-          in: path
-          required: true
-          schema:
-            type: string
         - name: webhook_id
           in: path
           required: true
@@ -286,7 +250,7 @@ paths:
         '404':
           description: Webhook not found
 
-  /api/v1/projects/{project_id}/webhooks/{webhook_id}/rotate-secret:
+  /api/v1/webhooks/{webhook_id}/rotate-secret:
     post:
       description: Rotates the secret key for the specified webhook
       tags:
@@ -294,11 +258,6 @@ paths:
       summary: Rotate webhook secret
       operationId: rotateWebhookSecret
       parameters:
-        - name: project_id
-          in: path
-          required: true
-          schema:
-            type: string
         - name: webhook_id
           in: path
           required: true
@@ -366,10 +325,13 @@ components:
     CreateWebhookRequest:
       type: object
       required:
+        - project_id
         - name
         - url
         - events
       properties:
+        project_id:
+          type: string
         name:
           type: string
         description:

--- a/packages/server/src/rest/v1/webhooks.ts
+++ b/packages/server/src/rest/v1/webhooks.ts
@@ -14,46 +14,77 @@ import {
   updateWebhook,
 } from 'src/lib/webhooks';
 
+const resolveProjectPublicId = (args: {
+  bodyProjectId: string | undefined;
+  apiKeyProjectPublicId: string | undefined;
+}): string | undefined => {
+  return args.bodyProjectId ?? args.apiKeyProjectPublicId;
+};
+
+const resolvePolicyId = async (
+  policyPublicId: string | undefined
+): Promise<{ id: number | null } | { error: string }> => {
+  if (!policyPublicId) return { id: null };
+  const policy = await db.Policy.findOne({
+    where: { publicId: policyPublicId },
+  });
+  if (!policy) return { error: 'Invalid policy' };
+  return { id: policy.id };
+};
+
 const webhooksRouter = new Router<Context>();
 
-webhooksRouter.get('/projects/:project_id/webhooks', async (ctx: Context) => {
+webhooksRouter.get('/webhooks', async (ctx: Context) => {
   if (!ctx.authUser) {
     ctx.status = 401;
     ctx.body = { error: 'Unauthorized' };
     return;
   }
 
-  const allowed = await ctx.authUser.isAllowed({
-    projectPublicId: ctx.params.project_id,
+  const projectPublicId = ctx.query.projectId as string | undefined;
+
+  const projectIds = await ctx.authUser.resolveProjectIds({
+    projectPublicId,
     action: 'webhooks:ListWebhooks',
   });
-  if (!allowed) {
+
+  if (projectIds === null) {
     ctx.status = 403;
     ctx.body = { error: 'Forbidden' };
     return;
   }
 
-  const project = await db.Project.findOne({
-    where: { publicId: ctx.params.project_id },
-  });
-  if (!project) {
-    ctx.status = 404;
-    ctx.body = { error: 'Project not found' };
-    return;
-  }
-
-  ctx.body = await listWebhooks({ projectIds: [project.id] });
+  ctx.body = await listWebhooks({ projectIds: projectIds ?? [] });
 });
 
-webhooksRouter.post('/projects/:project_id/webhooks', async (ctx: Context) => {
+webhooksRouter.post('/webhooks', async (ctx: Context) => {
   if (!ctx.authUser) {
     ctx.status = 401;
     ctx.body = { error: 'Unauthorized' };
     return;
   }
 
+  const body = ctx.request.body as {
+    projectId?: string;
+    name?: string;
+    description?: string;
+    url?: string;
+    events?: string[];
+    policyId?: string;
+  };
+
+  const resolvedProjectPublicId = resolveProjectPublicId({
+    bodyProjectId: body.projectId,
+    apiKeyProjectPublicId: ctx.authUser.apiKeyProjectPublicId,
+  });
+  if (!resolvedProjectPublicId) {
+    ctx.status = 400;
+    ctx.body = { error: 'project_id is required' };
+    return;
+  }
+
   const allowed = await ctx.authUser.isAllowed({
-    projectPublicId: ctx.params.project_id,
+    projectPublicId: resolvedProjectPublicId,
     action: 'webhooks:CreateWebhook',
   });
   if (!allowed) {
@@ -61,23 +92,6 @@ webhooksRouter.post('/projects/:project_id/webhooks', async (ctx: Context) => {
     ctx.body = { error: 'Forbidden' };
     return;
   }
-
-  const project = await db.Project.findOne({
-    where: { publicId: ctx.params.project_id },
-  });
-  if (!project) {
-    ctx.status = 404;
-    ctx.body = { error: 'Project not found' };
-    return;
-  }
-
-  const body = ctx.request.body as {
-    name?: string;
-    description?: string;
-    url?: string;
-    events?: string[];
-    policyId?: string;
-  };
 
   if (!body.name || !body.url || !body.events || body.events.length === 0) {
     ctx.status = 400;
@@ -87,22 +101,25 @@ webhooksRouter.post('/projects/:project_id/webhooks', async (ctx: Context) => {
     return;
   }
 
-  let policyInternalId: number | null = null;
-  if (body.policyId) {
-    const policy = await db.Policy.findOne({
-      where: { publicId: body.policyId },
-    });
-    if (!policy) {
-      ctx.status = 400;
-      ctx.body = { error: 'Invalid policy' };
-      return;
-    }
-    policyInternalId = policy.id;
+  const project = await db.Project.findOne({
+    where: { publicId: resolvedProjectPublicId },
+  });
+  if (!project) {
+    ctx.status = 400;
+    ctx.body = { error: 'Invalid project ID' };
+    return;
+  }
+
+  const policyResult = await resolvePolicyId(body.policyId);
+  if ('error' in policyResult) {
+    ctx.status = 400;
+    ctx.body = { error: policyResult.error };
+    return;
   }
 
   const webhook = await createWebhook({
     projectId: project.id,
-    policyId: policyInternalId,
+    policyId: policyResult.id,
     name: body.name,
     description: body.description,
     url: body.url,
@@ -113,193 +130,176 @@ webhooksRouter.post('/projects/:project_id/webhooks', async (ctx: Context) => {
   ctx.body = webhook;
 });
 
+webhooksRouter.get('/webhooks/:webhook_id', async (ctx: Context) => {
+  if (!ctx.authUser) {
+    ctx.status = 401;
+    ctx.body = { error: 'Unauthorized' };
+    return;
+  }
+
+  const webhook = await getWebhook({ id: ctx.params.webhook_id });
+  if (!webhook) {
+    ctx.status = 404;
+    ctx.body = { error: 'Webhook not found' };
+    return;
+  }
+
+  const allowed = await ctx.authUser.isAllowed({
+    projectPublicId: webhook.projectId!,
+    action: 'webhooks:GetWebhook',
+  });
+  if (!allowed) {
+    ctx.status = 403;
+    ctx.body = { error: 'Forbidden' };
+    return;
+  }
+
+  ctx.body = webhook;
+});
+
+webhooksRouter.put('/webhooks/:webhook_id', async (ctx: Context) => {
+  if (!ctx.authUser) {
+    ctx.status = 401;
+    ctx.body = { error: 'Unauthorized' };
+    return;
+  }
+
+  const webhook = await getWebhook({ id: ctx.params.webhook_id });
+  if (!webhook) {
+    ctx.status = 404;
+    ctx.body = { error: 'Webhook not found' };
+    return;
+  }
+
+  const allowed = await ctx.authUser.isAllowed({
+    projectPublicId: webhook.projectId!,
+    action: 'webhooks:UpdateWebhook',
+  });
+  if (!allowed) {
+    ctx.status = 403;
+    ctx.body = { error: 'Forbidden' };
+    return;
+  }
+
+  const body = ctx.request.body as {
+    name?: string;
+    description?: string;
+    url?: string;
+    events?: string[];
+    active?: boolean;
+    policyId?: string | null;
+  };
+
+  let policyInternalId: number | null | undefined;
+  if (body.policyId !== undefined) {
+    const policyResult = await resolvePolicyId(body.policyId ?? undefined);
+    if ('error' in policyResult) {
+      ctx.status = 400;
+      ctx.body = { error: policyResult.error };
+      return;
+    }
+    policyInternalId = policyResult.id;
+  }
+
+  const updated = await updateWebhook({
+    id: ctx.params.webhook_id,
+    name: body.name,
+    description: body.description,
+    url: body.url,
+    events: body.events,
+    active: body.active,
+    policyId: policyInternalId,
+  });
+
+  ctx.body = updated;
+});
+
+webhooksRouter.delete('/webhooks/:webhook_id', async (ctx: Context) => {
+  if (!ctx.authUser) {
+    ctx.status = 401;
+    ctx.body = { error: 'Unauthorized' };
+    return;
+  }
+
+  const webhook = await getWebhook({ id: ctx.params.webhook_id });
+  if (!webhook) {
+    ctx.status = 404;
+    ctx.body = { error: 'Webhook not found' };
+    return;
+  }
+
+  const allowed = await ctx.authUser.isAllowed({
+    projectPublicId: webhook.projectId!,
+    action: 'webhooks:DeleteWebhook',
+  });
+  if (!allowed) {
+    ctx.status = 403;
+    ctx.body = { error: 'Forbidden' };
+    return;
+  }
+
+  await deleteWebhook({ id: ctx.params.webhook_id });
+  ctx.status = 204;
+});
+
+webhooksRouter.get('/webhooks/:webhook_id/deliveries', async (ctx: Context) => {
+  if (!ctx.authUser) {
+    ctx.status = 401;
+    ctx.body = { error: 'Unauthorized' };
+    return;
+  }
+
+  const webhook = await getWebhook({ id: ctx.params.webhook_id });
+  if (!webhook) {
+    ctx.status = 404;
+    ctx.body = { error: 'Webhook not found' };
+    return;
+  }
+
+  const allowed = await ctx.authUser.isAllowed({
+    projectPublicId: webhook.projectId!,
+    action: 'webhooks:ListWebhookDeliveries',
+  });
+  if (!allowed) {
+    ctx.status = 403;
+    ctx.body = { error: 'Forbidden' };
+    return;
+  }
+
+  const webhookRecord = await db.Webhook.findOne({
+    where: { publicId: ctx.params.webhook_id },
+  });
+
+  const limit = ctx.query.limit ? parseInt(ctx.query.limit as string, 10) : 50;
+  const offset = ctx.query.offset
+    ? parseInt(ctx.query.offset as string, 10)
+    : 0;
+
+  ctx.body = await listWebhookDeliveries({
+    webhookId: webhookRecord!.id,
+    limit,
+    offset,
+  });
+});
+
 webhooksRouter.get(
-  '/projects/:project_id/webhooks/:webhook_id',
+  '/webhooks/:webhook_id/deliveries/:delivery_id',
   async (ctx: Context) => {
     if (!ctx.authUser) {
       ctx.status = 401;
       ctx.body = { error: 'Unauthorized' };
-      return;
-    }
-
-    const allowed = await ctx.authUser.isAllowed({
-      projectPublicId: ctx.params.project_id,
-      action: 'webhooks:GetWebhook',
-    });
-    if (!allowed) {
-      ctx.status = 403;
-      ctx.body = { error: 'Forbidden' };
       return;
     }
 
     const webhook = await getWebhook({ id: ctx.params.webhook_id });
-    if (!webhook || webhook.projectId !== ctx.params.project_id) {
+    if (!webhook) {
       ctx.status = 404;
       ctx.body = { error: 'Webhook not found' };
       return;
     }
 
-    ctx.body = webhook;
-  }
-);
-
-webhooksRouter.put(
-  '/projects/:project_id/webhooks/:webhook_id',
-  async (ctx: Context) => {
-    if (!ctx.authUser) {
-      ctx.status = 401;
-      ctx.body = { error: 'Unauthorized' };
-      return;
-    }
-
     const allowed = await ctx.authUser.isAllowed({
-      projectPublicId: ctx.params.project_id,
-      action: 'webhooks:UpdateWebhook',
-    });
-    if (!allowed) {
-      ctx.status = 403;
-      ctx.body = { error: 'Forbidden' };
-      return;
-    }
-
-    const webhook = await getWebhook({ id: ctx.params.webhook_id });
-    if (!webhook || webhook.projectId !== ctx.params.project_id) {
-      ctx.status = 404;
-      ctx.body = { error: 'Webhook not found' };
-      return;
-    }
-
-    const body = ctx.request.body as {
-      name?: string;
-      description?: string;
-      url?: string;
-      events?: string[];
-      active?: boolean;
-      policyId?: string | null;
-    };
-
-    let policyInternalId: number | null | undefined;
-    if (body.policyId !== undefined) {
-      if (body.policyId === null) {
-        policyInternalId = null;
-      } else {
-        const policy = await db.Policy.findOne({
-          where: { publicId: body.policyId },
-        });
-        if (!policy) {
-          ctx.status = 400;
-          ctx.body = { error: 'Invalid policy' };
-          return;
-        }
-        policyInternalId = policy.id;
-      }
-    }
-
-    const updated = await updateWebhook({
-      id: ctx.params.webhook_id,
-      name: body.name,
-      description: body.description,
-      url: body.url,
-      events: body.events,
-      active: body.active,
-      policyId: policyInternalId,
-    });
-
-    ctx.body = updated;
-  }
-);
-
-webhooksRouter.delete(
-  '/projects/:project_id/webhooks/:webhook_id',
-  async (ctx: Context) => {
-    if (!ctx.authUser) {
-      ctx.status = 401;
-      ctx.body = { error: 'Unauthorized' };
-      return;
-    }
-
-    const allowed = await ctx.authUser.isAllowed({
-      projectPublicId: ctx.params.project_id,
-      action: 'webhooks:DeleteWebhook',
-    });
-    if (!allowed) {
-      ctx.status = 403;
-      ctx.body = { error: 'Forbidden' };
-      return;
-    }
-
-    const webhook = await getWebhook({ id: ctx.params.webhook_id });
-    if (!webhook || webhook.projectId !== ctx.params.project_id) {
-      ctx.status = 404;
-      ctx.body = { error: 'Webhook not found' };
-      return;
-    }
-
-    await deleteWebhook({ id: ctx.params.webhook_id });
-    ctx.status = 204;
-  }
-);
-
-webhooksRouter.get(
-  '/projects/:project_id/webhooks/:webhook_id/deliveries',
-  async (ctx: Context) => {
-    if (!ctx.authUser) {
-      ctx.status = 401;
-      ctx.body = { error: 'Unauthorized' };
-      return;
-    }
-
-    const allowed = await ctx.authUser.isAllowed({
-      projectPublicId: ctx.params.project_id,
-      action: 'webhooks:ListWebhookDeliveries',
-    });
-    if (!allowed) {
-      ctx.status = 403;
-      ctx.body = { error: 'Forbidden' };
-      return;
-    }
-
-    const webhookRecord = await db.Webhook.findOne({
-      where: { publicId: ctx.params.webhook_id },
-      include: [{ model: db.Project, as: 'project' }],
-    });
-
-    if (
-      !webhookRecord ||
-      (webhookRecord as unknown as { project: { publicId: string } }).project
-        .publicId !== ctx.params.project_id
-    ) {
-      ctx.status = 404;
-      ctx.body = { error: 'Webhook not found' };
-      return;
-    }
-
-    const limit = ctx.query.limit
-      ? parseInt(ctx.query.limit as string, 10)
-      : 50;
-    const offset = ctx.query.offset
-      ? parseInt(ctx.query.offset as string, 10)
-      : 0;
-
-    ctx.body = await listWebhookDeliveries({
-      webhookId: webhookRecord.id,
-      limit,
-      offset,
-    });
-  }
-);
-
-webhooksRouter.get(
-  '/projects/:project_id/webhooks/:webhook_id/deliveries/:delivery_id',
-  async (ctx: Context) => {
-    if (!ctx.authUser) {
-      ctx.status = 401;
-      ctx.body = { error: 'Unauthorized' };
-      return;
-    }
-
-    const allowed = await ctx.authUser.isAllowed({
-      projectPublicId: ctx.params.project_id,
+      projectPublicId: webhook.projectId!,
       action: 'webhooks:GetWebhookDelivery',
     });
     if (!allowed) {
@@ -321,36 +321,33 @@ webhooksRouter.get(
   }
 );
 
-webhooksRouter.get(
-  '/projects/:project_id/webhooks/:webhook_id/secret',
-  async (ctx: Context) => {
-    if (!ctx.authUser) {
-      throw new DomainError('UNAUTHORIZED', 'Unauthorized');
-    }
-
-    const allowed = await ctx.authUser.isAllowed({
-      projectPublicId: ctx.params.project_id,
-      action: 'webhooks:GetWebhookSecret',
-    });
-    if (!allowed) {
-      throw new DomainError('FORBIDDEN', 'Forbidden');
-    }
-
-    const webhook = await getWebhook({ id: ctx.params.webhook_id });
-    if (!webhook || webhook.projectId !== ctx.params.project_id) {
-      throw new DomainError('RESOURCE_NOT_FOUND', 'Webhook not found');
-    }
-
-    const secretData = await findWebhookSecret({ id: ctx.params.webhook_id });
-    if (!secretData) {
-      throw new DomainError('RESOURCE_NOT_FOUND', 'Webhook not found');
-    }
-    ctx.body = secretData;
+webhooksRouter.get('/webhooks/:webhook_id/secret', async (ctx: Context) => {
+  if (!ctx.authUser) {
+    throw new DomainError('UNAUTHORIZED', 'Unauthorized');
   }
-);
+
+  const webhook = await getWebhook({ id: ctx.params.webhook_id });
+  if (!webhook) {
+    throw new DomainError('RESOURCE_NOT_FOUND', 'Webhook not found');
+  }
+
+  const allowed = await ctx.authUser.isAllowed({
+    projectPublicId: webhook.projectId!,
+    action: 'webhooks:GetWebhookSecret',
+  });
+  if (!allowed) {
+    throw new DomainError('FORBIDDEN', 'Forbidden');
+  }
+
+  const secretData = await findWebhookSecret({ id: ctx.params.webhook_id });
+  if (!secretData) {
+    throw new DomainError('RESOURCE_NOT_FOUND', 'Webhook not found');
+  }
+  ctx.body = secretData;
+});
 
 webhooksRouter.post(
-  '/projects/:project_id/webhooks/:webhook_id/rotate-secret',
+  '/webhooks/:webhook_id/rotate-secret',
   async (ctx: Context) => {
     if (!ctx.authUser) {
       ctx.status = 401;
@@ -358,20 +355,20 @@ webhooksRouter.post(
       return;
     }
 
+    const webhook = await getWebhook({ id: ctx.params.webhook_id });
+    if (!webhook) {
+      ctx.status = 404;
+      ctx.body = { error: 'Webhook not found' };
+      return;
+    }
+
     const allowed = await ctx.authUser.isAllowed({
-      projectPublicId: ctx.params.project_id,
+      projectPublicId: webhook.projectId!,
       action: 'webhooks:RotateWebhookSecret',
     });
     if (!allowed) {
       ctx.status = 403;
       ctx.body = { error: 'Forbidden' };
-      return;
-    }
-
-    const webhook = await getWebhook({ id: ctx.params.webhook_id });
-    if (!webhook || webhook.projectId !== ctx.params.project_id) {
-      ctx.status = 404;
-      ctx.body = { error: 'Webhook not found' };
       return;
     }
 

--- a/packages/server/tests/unit/tests/lib/soatToolsHelpers.test.ts
+++ b/packages/server/tests/unit/tests/lib/soatToolsHelpers.test.ts
@@ -1,4 +1,37 @@
 import { extractBodyProps } from 'src/lib/soatToolsHelpers';
+import { buildQueryFn } from 'src/lib/soatToolsSchemaHelpers';
+
+describe('buildQueryFn', () => {
+  test('returns undefined when there are no query params', () => {
+    expect(buildQueryFn([])).toBeUndefined();
+  });
+
+  test('builds a query string from camelCase args using snake_case keys', () => {
+    const fn = buildQueryFn([
+      { name: 'project_id', camelName: 'projectId' },
+      { name: 'limit', camelName: 'limit' },
+    ]);
+    expect(fn?.({ projectId: 'prj_01', limit: 50 })).toBe(
+      '?project_id=prj_01&limit=50'
+    );
+  });
+
+  test('omits undefined and null values', () => {
+    const fn = buildQueryFn([
+      { name: 'project_id', camelName: 'projectId' },
+      { name: 'limit', camelName: 'limit' },
+    ]);
+    expect(fn?.({ projectId: 'prj_01', limit: undefined })).toBe(
+      '?project_id=prj_01'
+    );
+    expect(fn?.({})).toBe('');
+  });
+
+  test('repeats the key for array values', () => {
+    const fn = buildQueryFn([{ name: 'events', camelName: 'events' }]);
+    expect(fn?.({ events: ['a', 'b'] })).toBe('?events=a&events=b');
+  });
+});
 
 describe('extractBodyProps', () => {
   const emptySpec = {};

--- a/packages/server/tests/unit/tests/lib/webhookDispatcher.test.ts
+++ b/packages/server/tests/unit/tests/lib/webhookDispatcher.test.ts
@@ -36,8 +36,9 @@ describe('webhookDispatcher', () => {
 
   test('dispatcher delivers webhook for exact event match', async () => {
     await authenticatedTestClient(adminToken)
-      .post(`/api/v1/projects/${projectId}/webhooks`)
+      .post(`/api/v1/webhooks`)
       .send({
+        project_id: projectId,
         name: 'Exact Match Webhook',
         url: 'https://example.com/hook-exact',
         events: ['files.created'],
@@ -69,8 +70,9 @@ describe('webhookDispatcher', () => {
 
   test('dispatcher delivers webhook for wildcard event match', async () => {
     await authenticatedTestClient(adminToken)
-      .post(`/api/v1/projects/${projectId}/webhooks`)
+      .post(`/api/v1/webhooks`)
       .send({
+        project_id: projectId,
         name: 'Wildcard Webhook',
         url: 'https://example.com/hook-wildcard',
         events: ['*'],
@@ -94,8 +96,9 @@ describe('webhookDispatcher', () => {
 
   test('dispatcher delivers webhook for prefix wildcard event match', async () => {
     await authenticatedTestClient(adminToken)
-      .post(`/api/v1/projects/${projectId}/webhooks`)
+      .post(`/api/v1/webhooks`)
       .send({
+        project_id: projectId,
         name: 'Prefix Wildcard Webhook',
         url: 'https://example.com/hook-prefix',
         events: ['agents.*'],
@@ -121,8 +124,9 @@ describe('webhookDispatcher', () => {
     fetchMock.mockClear();
 
     await authenticatedTestClient(adminToken)
-      .post(`/api/v1/projects/${projectId}/webhooks`)
+      .post(`/api/v1/webhooks`)
       .send({
+        project_id: projectId,
         name: 'Non-Matching Webhook',
         url: 'https://example.com/hook-nomatch',
         events: ['files.deleted'],
@@ -155,8 +159,9 @@ describe('webhookDispatcher', () => {
     fetchMock.mockClear();
 
     await authenticatedTestClient(adminToken)
-      .post(`/api/v1/projects/${projectId}/webhooks`)
+      .post(`/api/v1/webhooks`)
       .send({
+        project_id: projectId,
         name: 'Files Prefix Webhook',
         url: 'https://example.com/hook-files-prefix',
         events: ['files.*'],
@@ -190,8 +195,9 @@ describe('webhookDispatcher', () => {
     fetchMock.mockRejectedValue(new Error('Network unreachable'));
 
     await authenticatedTestClient(adminToken)
-      .post(`/api/v1/projects/${projectId}/webhooks`)
+      .post(`/api/v1/webhooks`)
       .send({
+        project_id: projectId,
         name: 'Retry Failure Webhook',
         url: 'https://example.com/hook-retry-fail',
         events: ['files.created'],
@@ -229,8 +235,9 @@ describe('webhookDispatcher', () => {
     );
 
     await authenticatedTestClient(adminToken)
-      .post(`/api/v1/projects/${projectId}/webhooks`)
+      .post(`/api/v1/webhooks`)
       .send({
+        project_id: projectId,
         name: 'Non-OK Status Webhook',
         url: 'https://example.com/hook-non-ok',
         events: ['files.created'],

--- a/packages/server/tests/unit/tests/rest/webhooks.test.ts
+++ b/packages/server/tests/unit/tests/rest/webhooks.test.ts
@@ -55,11 +55,12 @@ describe('Webhooks', () => {
       .send({ policy_ids: [policyId] });
   });
 
-  describe('POST /api/v1/projects/:projectId/webhooks', () => {
+  describe('POST /api/v1/webhooks', () => {
     test('authenticated user can create a webhook', async () => {
       const response = await authenticatedTestClient(userToken)
-        .post(`/api/v1/projects/${projectId}/webhooks`)
+        .post('/api/v1/webhooks')
         .send({
+          project_id: projectId,
           name: 'Test Webhook',
           url: 'https://example.com/hook',
           events: ['file.created', 'file.*'],
@@ -77,20 +78,31 @@ describe('Webhooks', () => {
 
     test('returns 400 when required fields are missing', async () => {
       const response = await authenticatedTestClient(userToken)
-        .post(`/api/v1/projects/${projectId}/webhooks`)
-        .send({ name: 'No URL' });
+        .post('/api/v1/webhooks')
+        .send({ project_id: projectId, name: 'No URL' });
 
       expect(response.status).toBe(400);
     });
 
-    test('unauthenticated request returns 401', async () => {
-      const response = await testClient
-        .post(`/api/v1/projects/${projectId}/webhooks`)
+    test('returns 400 when project_id is missing', async () => {
+      const response = await authenticatedTestClient(userToken)
+        .post('/api/v1/webhooks')
         .send({
           name: 'Test',
           url: 'https://example.com/hook',
           events: ['*'],
         });
+
+      expect(response.status).toBe(400);
+    });
+
+    test('unauthenticated request returns 401', async () => {
+      const response = await testClient.post('/api/v1/webhooks').send({
+        project_id: projectId,
+        name: 'Test',
+        url: 'https://example.com/hook',
+        events: ['*'],
+      });
 
       expect(response.status).toBe(401);
     });
@@ -105,8 +117,9 @@ describe('Webhooks', () => {
       const noPermToken = await loginAs('webhooksnoperm', 'pass123');
 
       const response = await authenticatedTestClient(noPermToken)
-        .post(`/api/v1/projects/${projectId}/webhooks`)
+        .post('/api/v1/webhooks')
         .send({
+          project_id: projectId,
           name: 'Test',
           url: 'https://example.com/hook',
           events: ['*'],
@@ -116,10 +129,10 @@ describe('Webhooks', () => {
     });
   });
 
-  describe('GET /api/v1/projects/:projectId/webhooks', () => {
-    test('authenticated user can list webhooks', async () => {
+  describe('GET /api/v1/webhooks', () => {
+    test('authenticated user can list webhooks filtered by project', async () => {
       const response = await authenticatedTestClient(userToken).get(
-        `/api/v1/projects/${projectId}/webhooks`
+        `/api/v1/webhooks?project_id=${projectId}`
       );
 
       expect(response.status).toBe(200);
@@ -129,20 +142,21 @@ describe('Webhooks', () => {
 
     test('unauthenticated request returns 401', async () => {
       const response = await testClient.get(
-        `/api/v1/projects/${projectId}/webhooks`
+        `/api/v1/webhooks?project_id=${projectId}`
       );
 
       expect(response.status).toBe(401);
     });
   });
 
-  describe('GET /api/v1/projects/:projectId/webhooks/:webhookId', () => {
+  describe('GET /api/v1/webhooks/:webhookId', () => {
     let webhookId: string;
 
     beforeAll(async () => {
       const res = await authenticatedTestClient(userToken)
-        .post(`/api/v1/projects/${projectId}/webhooks`)
+        .post('/api/v1/webhooks')
         .send({
+          project_id: projectId,
           name: 'Get Test',
           url: 'https://example.com/get',
           events: ['*'],
@@ -152,7 +166,7 @@ describe('Webhooks', () => {
 
     test('authenticated user can get a webhook', async () => {
       const response = await authenticatedTestClient(userToken).get(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}`
+        `/api/v1/webhooks/${webhookId}`
       );
 
       expect(response.status).toBe(200);
@@ -163,28 +177,27 @@ describe('Webhooks', () => {
 
     test('returns 404 for non-existent webhook', async () => {
       const response = await authenticatedTestClient(userToken).get(
-        `/api/v1/projects/${projectId}/webhooks/nonexistent`
+        '/api/v1/webhooks/nonexistent'
       );
 
       expect(response.status).toBe(404);
     });
 
     test('unauthenticated request returns 401', async () => {
-      const response = await testClient.get(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}`
-      );
+      const response = await testClient.get(`/api/v1/webhooks/${webhookId}`);
 
       expect(response.status).toBe(401);
     });
   });
 
-  describe('GET /api/v1/projects/:projectId/webhooks/:webhookId/secret', () => {
+  describe('GET /api/v1/webhooks/:webhookId/secret', () => {
     let webhookId: string;
 
     beforeAll(async () => {
       const res = await authenticatedTestClient(userToken)
-        .post(`/api/v1/projects/${projectId}/webhooks`)
+        .post('/api/v1/webhooks')
         .send({
+          project_id: projectId,
           name: 'Secret Test',
           url: 'https://example.com/secret',
           events: ['*'],
@@ -194,7 +207,7 @@ describe('Webhooks', () => {
 
     test('authenticated user can get the webhook secret', async () => {
       const response = await authenticatedTestClient(userToken).get(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}/secret`
+        `/api/v1/webhooks/${webhookId}/secret`
       );
 
       expect(response.status).toBe(200);
@@ -204,7 +217,7 @@ describe('Webhooks', () => {
 
     test('returns 404 for non-existent webhook', async () => {
       const response = await authenticatedTestClient(userToken).get(
-        `/api/v1/projects/${projectId}/webhooks/nonexistent/secret`
+        '/api/v1/webhooks/nonexistent/secret'
       );
 
       expect(response.status).toBe(404);
@@ -212,7 +225,7 @@ describe('Webhooks', () => {
 
     test('unauthenticated request returns 401', async () => {
       const response = await testClient.get(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}/secret`
+        `/api/v1/webhooks/${webhookId}/secret`
       );
 
       expect(response.status).toBe(401);
@@ -245,20 +258,21 @@ describe('Webhooks', () => {
         .send({ policy_ids: [limitedPolicyRes.body.id] });
 
       const response = await authenticatedTestClient(noSecretPermToken).get(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}/secret`
+        `/api/v1/webhooks/${webhookId}/secret`
       );
 
       expect(response.status).toBe(403);
     });
   });
 
-  describe('PUT /api/v1/projects/:projectId/webhooks/:webhookId', () => {
+  describe('PUT /api/v1/webhooks/:webhookId', () => {
     let webhookId: string;
 
     beforeAll(async () => {
       const res = await authenticatedTestClient(userToken)
-        .post(`/api/v1/projects/${projectId}/webhooks`)
+        .post('/api/v1/webhooks')
         .send({
+          project_id: projectId,
           name: 'Update Test',
           url: 'https://example.com/update',
           events: ['*'],
@@ -268,7 +282,7 @@ describe('Webhooks', () => {
 
     test('authenticated user can update a webhook', async () => {
       const response = await authenticatedTestClient(userToken)
-        .put(`/api/v1/projects/${projectId}/webhooks/${webhookId}`)
+        .put(`/api/v1/webhooks/${webhookId}`)
         .send({
           name: 'Updated Name',
           active: false,
@@ -283,20 +297,21 @@ describe('Webhooks', () => {
 
     test('unauthenticated request returns 401', async () => {
       const response = await testClient
-        .put(`/api/v1/projects/${projectId}/webhooks/${webhookId}`)
+        .put(`/api/v1/webhooks/${webhookId}`)
         .send({ name: 'X' });
 
       expect(response.status).toBe(401);
     });
   });
 
-  describe('POST /api/v1/projects/:projectId/webhooks/:webhookId/rotate-secret', () => {
+  describe('POST /api/v1/webhooks/:webhookId/rotate-secret', () => {
     let webhookId: string;
 
     beforeAll(async () => {
       const res = await authenticatedTestClient(userToken)
-        .post(`/api/v1/projects/${projectId}/webhooks`)
+        .post('/api/v1/webhooks')
         .send({
+          project_id: projectId,
           name: 'Rotate Test',
           url: 'https://example.com/rotate',
           events: ['*'],
@@ -306,7 +321,7 @@ describe('Webhooks', () => {
 
     test('authenticated user can rotate secret', async () => {
       const response = await authenticatedTestClient(userToken).post(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}/rotate-secret`
+        `/api/v1/webhooks/${webhookId}/rotate-secret`
       );
 
       expect(response.status).toBe(200);
@@ -316,20 +331,21 @@ describe('Webhooks', () => {
 
     test('unauthenticated request returns 401', async () => {
       const response = await testClient.post(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}/rotate-secret`
+        `/api/v1/webhooks/${webhookId}/rotate-secret`
       );
 
       expect(response.status).toBe(401);
     });
   });
 
-  describe('GET /api/v1/projects/:projectId/webhooks/:webhookId/deliveries', () => {
+  describe('GET /api/v1/webhooks/:webhookId/deliveries', () => {
     let webhookId: string;
 
     beforeAll(async () => {
       const res = await authenticatedTestClient(userToken)
-        .post(`/api/v1/projects/${projectId}/webhooks`)
+        .post('/api/v1/webhooks')
         .send({
+          project_id: projectId,
           name: 'Deliveries Test',
           url: 'https://example.com/deliveries',
           events: ['*'],
@@ -339,7 +355,7 @@ describe('Webhooks', () => {
 
     test('authenticated user can list deliveries', async () => {
       const response = await authenticatedTestClient(userToken).get(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}/deliveries`
+        `/api/v1/webhooks/${webhookId}/deliveries`
       );
 
       expect(response.status).toBe(200);
@@ -350,20 +366,21 @@ describe('Webhooks', () => {
 
     test('unauthenticated request returns 401', async () => {
       const response = await testClient.get(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}/deliveries`
+        `/api/v1/webhooks/${webhookId}/deliveries`
       );
 
       expect(response.status).toBe(401);
     });
   });
 
-  describe('GET /api/v1/projects/:projectId/webhooks/:webhookId/deliveries/:deliveryId', () => {
+  describe('GET /api/v1/webhooks/:webhookId/deliveries/:deliveryId', () => {
     let webhookId: string;
 
     beforeAll(async () => {
       const res = await authenticatedTestClient(userToken)
-        .post(`/api/v1/projects/${projectId}/webhooks`)
+        .post('/api/v1/webhooks')
         .send({
+          project_id: projectId,
           name: 'Delivery detail test',
           url: 'https://example.com/delivery-detail',
           events: ['*'],
@@ -373,7 +390,7 @@ describe('Webhooks', () => {
 
     test('returns 404 for non-existent delivery', async () => {
       const response = await authenticatedTestClient(userToken).get(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}/deliveries/wdh_nonexistent`
+        `/api/v1/webhooks/${webhookId}/deliveries/wdh_nonexistent`
       );
 
       expect(response.status).toBe(404);
@@ -381,20 +398,21 @@ describe('Webhooks', () => {
 
     test('unauthenticated request returns 401', async () => {
       const response = await testClient.get(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}/deliveries/wdh_nonexistent`
+        `/api/v1/webhooks/${webhookId}/deliveries/wdh_nonexistent`
       );
 
       expect(response.status).toBe(401);
     });
   });
 
-  describe('DELETE /api/v1/projects/:projectId/webhooks/:webhookId', () => {
+  describe('DELETE /api/v1/webhooks/:webhookId', () => {
     let webhookId: string;
 
     beforeAll(async () => {
       const res = await authenticatedTestClient(userToken)
-        .post(`/api/v1/projects/${projectId}/webhooks`)
+        .post('/api/v1/webhooks')
         .send({
+          project_id: projectId,
           name: 'Delete Test',
           url: 'https://example.com/delete',
           events: ['*'],
@@ -404,21 +422,19 @@ describe('Webhooks', () => {
 
     test('authenticated user can delete a webhook', async () => {
       const response = await authenticatedTestClient(userToken).delete(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}`
+        `/api/v1/webhooks/${webhookId}`
       );
 
       expect(response.status).toBe(204);
 
       const getResponse = await authenticatedTestClient(userToken).get(
-        `/api/v1/projects/${projectId}/webhooks/${webhookId}`
+        `/api/v1/webhooks/${webhookId}`
       );
       expect(getResponse.status).toBe(404);
     });
 
     test('unauthenticated request returns 401', async () => {
-      const response = await testClient.delete(
-        `/api/v1/projects/${projectId}/webhooks/someid`
-      );
+      const response = await testClient.delete('/api/v1/webhooks/someid');
 
       expect(response.status).toBe(401);
     });

--- a/packages/website/docs/modules/webhooks.md
+++ b/packages/website/docs/modules/webhooks.md
@@ -76,7 +76,7 @@ Deliveries are retried up to three times. Each attempt and its outcome are recor
 
 ### Secret and Signature Verification
 
-Every webhook has a secret generated at creation time. The secret is returned in the response body on create or secret rotation. You can also retrieve it explicitly via `GET /api/v1/projects/{project_id}/webhooks/{webhook_id}/secret` (requires `webhooks:GetWebhookSecret`).
+Every webhook has a secret generated at creation time. The secret is returned in the response body on create or secret rotation. You can also retrieve it explicitly via `GET /api/v1/webhooks/{webhook_id}/secret` (requires `webhooks:GetWebhookSecret`).
 
 To verify a delivery:
 
@@ -142,8 +142,8 @@ import { SoatClient } from '@soat/sdk';
 const soat = new SoatClient({ baseUrl: 'https://api.example.com', token: 'sk_...' });
 
 const { data, error } = await soat.webhooks.createWebhook({
-  path: { project_id: 'proj_ABC' },
   body: {
+    project_id: 'proj_ABC',
     name: 'My Webhook',
     url: 'https://example.com/hook',
     events: ['sessions.*'],
@@ -157,10 +157,11 @@ if (error) throw new Error(JSON.stringify(error));
 <TabItem value="curl" label="curl">
 
 ```bash
-curl -X POST https://api.example.com/api/v1/projects/proj_ABC/webhooks \
+curl -X POST https://api.example.com/api/v1/webhooks \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -d '{
+    "project_id": "proj_ABC",
     "name": "My Webhook",
     "url": "https://example.com/hook",
     "events": ["sessions.*"]

--- a/packages/website/docs/tutorials/chat-with-llm.md
+++ b/packages/website/docs/tutorials/chat-with-llm.md
@@ -533,8 +533,8 @@ const WEBHOOK_BASE_URL =
 
 const { data: webhook, error: webhookErr } =
   await adminSoat.webhooks.createWebhook({
-    path: { project_id: PROJECT_ID },
     body: {
+      project_id: PROJECT_ID,
       name: 'session-events',
       url: `${WEBHOOK_BASE_URL}/webhook`,
       events: ['sessions.generation.*'],
@@ -550,10 +550,10 @@ const WEBHOOK_ID = webhook.id; // whk_...
 <TabItem value="curl" label="curl">
 
 ```bash
-WEBHOOK_ID=$(curl -s -X POST "$SOAT_BASE_URL/api/v1/projects/$PROJECT_ID/webhooks" \
+WEBHOOK_ID=$(curl -s -X POST "$SOAT_BASE_URL/api/v1/webhooks" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
-  -d "{\"name\":\"session-events\",\"url\":\"$WEBHOOK_BASE_URL/webhook\",\"events\":[\"sessions.generation.*\"]}" \
+  -d "{\"project_id\":\"$PROJECT_ID\",\"name\":\"session-events\",\"url\":\"$WEBHOOK_BASE_URL/webhook\",\"events\":[\"sessions.generation.*\"]}" \
   | jq -r '.id')
 echo "WEBHOOK_ID: $WEBHOOK_ID"
 ```
@@ -662,10 +662,9 @@ Wait for the async delivery, inspect the webhook listener output, then fetch ses
 <TabItem value="cli" label="CLI" default>
 
 ```bash
-for _ in $(seq 1 20); do soat list-webhook-deliveries --project-id "$PROJECT_ID" --webhook-id "$WEBHOOK_ID" | jq -e '[.data[] | select(.status == "completed")] | length > 0' && break || sleep 1; done # → ignore
+for _ in $(seq 1 20); do soat list-webhook-deliveries --webhook-id "$WEBHOOK_ID" | jq -e '[.data[] | select(.status == "completed")] | length > 0' && break || sleep 1; done # → ignore
 
 soat list-webhook-deliveries \
-  --project-id "$PROJECT_ID" \
   --webhook-id "$WEBHOOK_ID" | jq '.data[] | {event_type, status, status_code}'
 
 cat session-webhooks.log
@@ -684,7 +683,7 @@ wait "$LISTENER_PID" 2>/dev/null || true
 ```ts
 const { data: deliveries, error: deliveriesErr } =
   await adminSoat.webhooks.listWebhookDeliveries({
-    path: { project_id: PROJECT_ID, webhook_id: WEBHOOK_ID },
+    path: { webhook_id: WEBHOOK_ID },
   });
 
 if (deliveriesErr) throw new Error(JSON.stringify(deliveriesErr));
@@ -709,7 +708,7 @@ for (const msg of messages2.data ?? []) {
 <TabItem value="curl" label="curl">
 
 ```bash
-curl -s "$SOAT_BASE_URL/api/v1/projects/$PROJECT_ID/webhooks/$WEBHOOK_ID/deliveries" \
+curl -s "$SOAT_BASE_URL/api/v1/webhooks/$WEBHOOK_ID/deliveries" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   | jq '.data[] | {event_type, status, status_code}'
 

--- a/tests/smoke-tests.sh
+++ b/tests/smoke-tests.sh
@@ -1511,7 +1511,7 @@ echo "Webhooks listed."
 
 # Get webhook
 echo "--- Getting webhook ---"
-WEBHOOK_GET_RESP=$($SOAT_CLI get-webhook --project-id "$PROJECT_PUBLIC_ID" --webhook-id "$WEBHOOK_ID")
+WEBHOOK_GET_RESP=$($SOAT_CLI get-webhook --webhook-id "$WEBHOOK_ID")
 if ! printf '%s\n' "$WEBHOOK_GET_RESP" | jq -e --arg id "$WEBHOOK_ID" '.id == $id' >/dev/null 2>&1; then
   echo "ERROR: GET webhook returned unexpected payload" >&2
   echo "$WEBHOOK_GET_RESP" >&2
@@ -1521,7 +1521,7 @@ echo "Webhook retrieved."
 
 # Update webhook
 echo "--- Updating webhook ---"
-WEBHOOK_UPDATE_RESP=$($SOAT_CLI update-webhook --project-id "$PROJECT_PUBLIC_ID" --webhook-id "$WEBHOOK_ID" \
+WEBHOOK_UPDATE_RESP=$($SOAT_CLI update-webhook --webhook-id "$WEBHOOK_ID" \
   --name "Updated Smoke Webhook" --active false)
 if ! printf '%s\n' "$WEBHOOK_UPDATE_RESP" | jq -e '.active == false' >/dev/null 2>&1; then
   echo "ERROR: UPDATE webhook did not return active=false" >&2
@@ -1532,12 +1532,12 @@ echo "Webhook updated."
 
 # Rotate secret
 echo "--- Rotating webhook secret ---"
-$SOAT_CLI rotate-webhook-secret --project-id "$PROJECT_PUBLIC_ID" --webhook-id "$WEBHOOK_ID" >/dev/null
+$SOAT_CLI rotate-webhook-secret --webhook-id "$WEBHOOK_ID" >/dev/null
 echo "Webhook secret rotated."
 
 # List deliveries
 echo "--- Listing webhook deliveries ---"
-WEBHOOK_DELIVERIES_RESP=$($SOAT_CLI list-webhook-deliveries --project-id "$PROJECT_PUBLIC_ID" --webhook-id "$WEBHOOK_ID")
+WEBHOOK_DELIVERIES_RESP=$($SOAT_CLI list-webhook-deliveries --webhook-id "$WEBHOOK_ID")
 if ! printf '%s\n' "$WEBHOOK_DELIVERIES_RESP" | jq -e '((type == "array") or (type == "object" and (.data | type == "array")))' >/dev/null 2>&1; then
   echo "ERROR: LIST webhook deliveries did not return an array" >&2
   echo "$WEBHOOK_DELIVERIES_RESP" >&2
@@ -1547,7 +1547,7 @@ echo "Webhook deliveries listed."
 
 # Delete webhook
 echo "--- Deleting webhook ---"
-$SOAT_CLI delete-webhook --project-id "$PROJECT_PUBLIC_ID" --webhook-id "$WEBHOOK_ID"
+$SOAT_CLI delete-webhook --webhook-id "$WEBHOOK_ID"
 echo "Webhook deleted."
 echo "Webhooks coverage: OK"
 


### PR DESCRIPTION
## Summary

- Moves webhooks from `/projects/{project_id}/webhooks/...` to `/webhooks/...`, consistent with every other project-owned resource (agents, secrets, files, ai-providers, etc.)
- `project_id` moves to the request **body** on `POST /webhooks` and a **query param** on `GET /webhooks`
- Single-resource operations (`GET/PUT/DELETE /webhooks/{id}`, deliveries, secret, rotate-secret) derive the project from the webhook itself for authorization — no `project_id` in the path or body needed
- Auth pattern now matches `secrets.ts`: uses `resolveProjectIds` for list and `webhook.projectId` for per-resource checks
- Extracted `resolveProjectPublicId` and `resolvePolicyId` helpers to keep handler complexity within the ESLint limit
- OpenAPI spec, SDK, CLI manifest, tests, and smoke tests all updated

## Test plan

- [ ] `pnpm --filter @soat/server typecheck` — passes
- [ ] `pnpm eslint --fix packages/server/src/rest/v1/webhooks.ts` — passes (no errors)
- [ ] `pnpm --filter @soat/sdk generate` — regenerated
- [ ] `pnpm --filter @soat/cli generate` — regenerated (150 routes, webhook commands now lack `--project-id` on single-resource ops)
- [ ] Unit tests updated to use new flat paths (`POST /api/v1/webhooks`, `GET /api/v1/webhooks?project_id=...`, etc.)
- [ ] Smoke test updated: `--project-id` removed from `get-webhook`, `update-webhook`, `rotate-webhook-secret`, `list-webhook-deliveries`, `delete-webhook`

https://claude.ai/code/session_01JiNxfRX7jLuWA1s9oRkMgJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiNxfRX7jLuWA1s9oRkMgJ)_