### PR TITLE
feat(app): AI Guide Chat sidebar (Phase 4)

### DIFF
--- a/packages/app/src/chat/guideAgent.ts
+++ b/packages/app/src/chat/guideAgent.ts
@@ -1,0 +1,87 @@
+import { apiFetch } from '@/api/client';
+import type { ViewDescriptor } from '@/engine/types';
+
+import type { GenerateResponse, GuideToolCall, ToolOutput } from './types';
+
+const MAX_TOOL_ROUNDS = 8;
+
+type ToolCallExecutor = (call: GuideToolCall) => {
+  output: unknown;
+  view?: ViewDescriptor;
+};
+
+export type GuideTurnResult =
+  | { ok: true; text: string; view?: ViewDescriptor }
+  | { ok: false; error: string };
+
+const generate = (args: {
+  token: string;
+  agentId: string;
+  messages: Array<{ role: string; content: string }>;
+}) => {
+  return apiFetch<GenerateResponse>({
+    url: `/api/v1/agents/${encodeURIComponent(args.agentId)}/generate`,
+    method: 'POST',
+    token: args.token,
+    body: { messages: args.messages },
+  });
+};
+
+const submitToolOutputs = (args: {
+  token: string;
+  agentId: string;
+  generationId: string;
+  toolOutputs: ToolOutput[];
+}) => {
+  return apiFetch<GenerateResponse>({
+    url: `/api/v1/agents/${encodeURIComponent(
+      args.agentId
+    )}/generate/${encodeURIComponent(args.generationId)}/tool-outputs`,
+    method: 'POST',
+    token: args.token,
+    body: { tool_outputs: args.toolOutputs },
+  });
+};
+
+// Run one guide turn: start a generation, resolve any render_page tool calls by
+// mounting views, and resume until the agent produces its final text reply.
+export const runGuideTurn = async (args: {
+  token: string;
+  agentId: string;
+  messages: Array<{ role: string; content: string }>;
+  executeToolCall: ToolCallExecutor;
+}): Promise<GuideTurnResult> => {
+  let result = await generate({
+    token: args.token,
+    agentId: args.agentId,
+    messages: args.messages,
+  });
+
+  let lastView: ViewDescriptor | undefined;
+
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+    if (!result.ok) return { ok: false, error: result.error.message };
+    if (result.data.status !== 'requires_action') break;
+
+    const calls = result.data.tool_calls ?? [];
+    const toolOutputs: ToolOutput[] = calls.map((call) => {
+      const executed = args.executeToolCall(call);
+      if (executed.view) lastView = executed.view;
+      return { tool_call_id: call.tool_call_id, output: executed.output };
+    });
+
+    result = await submitToolOutputs({
+      token: args.token,
+      agentId: args.agentId,
+      generationId: result.data.id,
+      toolOutputs,
+    });
+  }
+
+  if (!result.ok) return { ok: false, error: result.error.message };
+  if (result.data.status === 'requires_action') {
+    return { ok: false, error: 'The guide stopped before finishing.' };
+  }
+
+  return { ok: true, text: result.data.text ?? '', view: lastView };
+};

--- a/packages/app/src/chat/guideChat.tsx
+++ b/packages/app/src/chat/guideChat.tsx
@@ -1,0 +1,377 @@
+import * as React from 'react';
+
+import { useAuth } from '@/auth/authContext';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useNavigation } from '@/engine/navigationContext';
+import { useSpec } from '@/engine/specContext';
+import type { ViewDescriptor } from '@/engine/types';
+import { cn } from '@/lib/utils';
+
+import { runGuideTurn } from './guideAgent';
+import { listAiProviders, provisionGuide } from './guideProvisioning';
+import { executeRenderPage } from './renderPage';
+import type { AiProvider, ChatMessage } from './types';
+
+const providerStorageKey = (projectId: string): string => {
+  return `soat-guide-provider:${projectId}`;
+};
+
+type ProvisionState =
+  | { status: 'idle' }
+  | { status: 'provisioning' }
+  | { status: 'ready'; agentId: string }
+  | { status: 'error'; error: string };
+
+// Scoped to a single project: the panel is remounted (keyed on projectId) when
+// the project changes, so this hook never needs to reset state across projects.
+const useGuideSession = (args: { token: string; projectId: string }) => {
+  const { token, projectId } = args;
+  const { modules } = useSpec();
+  const [providers, setProviders] = React.useState<AiProvider[]>([]);
+  const [providersLoading, setProvidersLoading] = React.useState(true);
+  const [providerId, setProviderId] = React.useState<string | null>(null);
+  const [provision, setProvision] = React.useState<ProvisionState>({
+    status: 'idle',
+  });
+  // Guards against stale provisioning results when the provider changes mid-flight.
+  const reqRef = React.useRef(0);
+
+  const runProvision = React.useCallback(
+    (id: string) => {
+      const seq = ++reqRef.current;
+      setProvision({ status: 'provisioning' });
+      provisionGuide({ token, projectId, providerId: id, modules }).then(
+        (result) => {
+          if (seq !== reqRef.current) return;
+          setProvision(
+            result.ok
+              ? { status: 'ready', agentId: result.agentId }
+              : { status: 'error', error: result.error }
+          );
+        }
+      );
+    },
+    [token, projectId, modules]
+  );
+
+  // Load providers once on mount; auto-provision the remembered selection.
+  React.useEffect(() => {
+    let cancelled = false;
+    listAiProviders({ token, projectId })
+      .then((list) => {
+        if (cancelled) return;
+        setProviders(list);
+        const stored = localStorage.getItem(providerStorageKey(projectId));
+        const valid =
+          stored &&
+          list.some((p) => {
+            return p.id === stored;
+          })
+            ? stored
+            : null;
+        if (valid) {
+          setProviderId(valid);
+          runProvision(valid);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setProvidersLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token, projectId, runProvision]);
+
+  const selectProvider = React.useCallback(
+    (id: string) => {
+      localStorage.setItem(providerStorageKey(projectId), id);
+      setProviderId(id);
+      runProvision(id);
+    },
+    [projectId, runProvision]
+  );
+
+  return { providers, providersLoading, providerId, provision, selectProvider };
+};
+
+const ProviderPicker = ({
+  providers,
+  providersLoading,
+  providerId,
+  onSelect,
+}: {
+  providers: AiProvider[];
+  providersLoading: boolean;
+  providerId: string | null;
+  onSelect: (id: string) => void;
+}) => {
+  if (providersLoading) {
+    return (
+      <p className="text-sm text-muted-foreground">{'Loading providers…'}</p>
+    );
+  }
+  if (providers.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {'No AI providers in this project. Create one to enable the guide.'}
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      <label
+        htmlFor="guide-provider"
+        className="text-xs font-medium text-muted-foreground"
+      >
+        {'AI provider'}
+      </label>
+      <select
+        id="guide-provider"
+        aria-label="AI provider"
+        value={providerId ?? ''}
+        onChange={(e) => {
+          return onSelect(e.target.value);
+        }}
+        className="h-9 rounded-md border border-input bg-transparent px-3 text-sm"
+      >
+        <option value="" disabled>
+          {'Choose a provider…'}
+        </option>
+        {providers.map((p) => {
+          return (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          );
+        })}
+      </select>
+    </div>
+  );
+};
+
+const MessageBubble = ({
+  message,
+  onMountView,
+}: {
+  message: ChatMessage;
+  onMountView: (view: ViewDescriptor) => void;
+}) => {
+  const isUser = message.role === 'user';
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-1',
+        isUser ? 'items-end' : 'items-start'
+      )}
+    >
+      <div
+        className={cn(
+          'max-w-[85%] whitespace-pre-wrap rounded-lg px-3 py-2 text-sm',
+          isUser
+            ? 'bg-primary text-primary-foreground'
+            : 'bg-muted text-foreground'
+        )}
+      >
+        {message.content}
+      </div>
+      {message.view && (
+        <button
+          onClick={() => {
+            return message.view && onMountView(message.view);
+          }}
+          className="text-xs text-primary underline-offset-2 hover:underline"
+        >
+          {`Showing: ${message.view.tag} (${message.view.mode}) →`}
+        </button>
+      )}
+    </div>
+  );
+};
+
+const GuidePanel = ({
+  token,
+  projectId,
+}: {
+  token: string;
+  projectId: string;
+}) => {
+  const { spec, modules } = useSpec();
+  const { navigate } = useNavigation();
+  const { providers, providersLoading, providerId, provision, selectProvider } =
+    useGuideSession({ token, projectId });
+
+  const [messages, setMessages] = React.useState<ChatMessage[]>([]);
+  const [input, setInput] = React.useState('');
+  const [sending, setSending] = React.useState(false);
+
+  const agentId = provision.status === 'ready' ? provision.agentId : null;
+
+  const send = async () => {
+    const text = input.trim();
+    if (!text || !agentId || !spec || sending) return;
+    const history: ChatMessage[] = [
+      ...messages,
+      { role: 'user', content: text },
+    ];
+    setMessages(history);
+    setInput('');
+    setSending(true);
+
+    const result = await runGuideTurn({
+      token,
+      agentId,
+      messages: history.map((m) => {
+        return { role: m.role, content: m.content };
+      }),
+      executeToolCall: (call) => {
+        return executeRenderPage({
+          toolArgs: call.args,
+          spec,
+          modules,
+          activeProjectId: projectId,
+          navigate,
+        });
+      },
+    });
+
+    setMessages((prev) => {
+      return [
+        ...prev,
+        result.ok
+          ? { role: 'assistant', content: result.text, view: result.view }
+          : { role: 'assistant', content: `⚠ ${result.error}` },
+      ];
+    });
+    setSending(false);
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-3 p-3">
+      <ProviderPicker
+        providers={providers}
+        providersLoading={providersLoading}
+        providerId={providerId}
+        onSelect={selectProvider}
+      />
+
+      {provision.status === 'provisioning' && (
+        <p className="text-sm text-muted-foreground">
+          {'Preparing the guide…'}
+        </p>
+      )}
+      {provision.status === 'error' && (
+        <p className="text-sm text-destructive">{provision.error}</p>
+      )}
+
+      <div className="flex flex-1 flex-col gap-3 overflow-y-auto">
+        {messages.length === 0 && agentId && (
+          <p className="text-sm text-muted-foreground">
+            {'Ask me to show or manage anything in this project.'}
+          </p>
+        )}
+        {messages.map((m, i) => {
+          return <MessageBubble key={i} message={m} onMountView={navigate} />;
+        })}
+        {sending && (
+          <p className="text-xs text-muted-foreground">{'Thinking…'}</p>
+        )}
+      </div>
+
+      <form
+        className="flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void send();
+        }}
+      >
+        <Input
+          aria-label="Message the guide"
+          placeholder="Show me the agents…"
+          value={input}
+          disabled={!agentId || sending}
+          onChange={(e) => {
+            return setInput(e.target.value);
+          }}
+        />
+        <Button
+          type="submit"
+          size="sm"
+          disabled={!agentId || sending || !input.trim()}
+        >
+          {'Send'}
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export const GuideChat = () => {
+  const { state } = useAuth();
+  const { activeProjectId } = useNavigation();
+  const [collapsed, setCollapsed] = React.useState(false);
+  const token = state.status === 'authenticated' ? state.token : '';
+
+  // The active project is derived from the main view's URL, which the guide
+  // itself changes when it mounts a non-project-scoped view. Pin the guide to
+  // the last project the user selected so its session survives navigation; it
+  // only switches when the user explicitly opens a different project.
+  // Track the last non-null project so the panel survives navigation to
+  // views that are not project-scoped (where activeProjectId becomes null).
+  const [pinnedProjectId, setPinnedProjectId] = React.useState<string | null>(
+    activeProjectId
+  );
+  const [prevActiveProjectId, setPrevActiveProjectId] =
+    React.useState(activeProjectId);
+  if (prevActiveProjectId !== activeProjectId) {
+    setPrevActiveProjectId(activeProjectId);
+    if (activeProjectId !== null) setPinnedProjectId(activeProjectId);
+  }
+  const guideProjectId = activeProjectId ?? pinnedProjectId;
+
+  if (collapsed) {
+    return (
+      <aside className="flex h-full w-12 shrink-0 flex-col items-center border-l bg-muted/20 py-3">
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Open guide"
+          onClick={() => {
+            return setCollapsed(false);
+          }}
+        >
+          {'💬'}
+        </Button>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="flex h-full w-80 shrink-0 flex-col border-l bg-muted/20">
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <span className="text-sm font-semibold">{'AI Guide'}</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Collapse guide"
+          onClick={() => {
+            return setCollapsed(true);
+          }}
+        >
+          {'×'}
+        </Button>
+      </div>
+      {guideProjectId ? (
+        <GuidePanel
+          key={guideProjectId}
+          token={token}
+          projectId={guideProjectId}
+        />
+      ) : (
+        <p className="p-4 text-sm text-muted-foreground">
+          {'Select a project to use the AI guide.'}
+        </p>
+      )}
+    </aside>
+  );
+};

--- a/packages/app/src/chat/guideConfig.ts
+++ b/packages/app/src/chat/guideConfig.ts
@@ -1,0 +1,86 @@
+import type { ModuleInfo, ModuleOp } from '@/engine/types';
+
+// Identity of the find-or-created guide resources, per project.
+export const GUIDE_AGENT_NAME = 'soat-app-guide';
+export const RENDER_PAGE_TOOL_NAME = 'render_page';
+
+// JSON Schema for the render_page client tool. Tool schemas are camelCase by
+// convention (they are not part of the snake_case REST contract), so the model
+// returns args keyed by operationId/pathParams/mode.
+export const renderPageParameters = {
+  type: 'object',
+  required: ['operationId', 'mode'],
+  properties: {
+    operationId: {
+      type: 'string',
+      description:
+        'The OpenAPI operationId of the view to mount, e.g. "listAgents", "getAgent", "createAgent".',
+    },
+    mode: {
+      type: 'string',
+      enum: ['list', 'detail', 'create', 'edit', 'action'],
+      description:
+        'list (collection), detail (single item), create/edit (forms), action (item-scoped POST).',
+    },
+    pathParams: {
+      type: 'object',
+      additionalProperties: { type: 'string' },
+      description:
+        'Path parameters required by the operation, e.g. { "agent_id": "agt_123" }. project_id is injected automatically for project-scoped views.',
+    },
+  },
+} as const;
+
+export const RENDER_PAGE_TOOL_DESCRIPTION =
+  'Mount a view in the SOAT App UI for the user. Use it whenever the user asks to see, open, create, or edit a resource.';
+
+// A compact per-module index of the operations the guide can render, so the
+// model knows what it can mount without receiving the full OpenAPI document.
+const describeOp = (mode: string, op: ModuleOp | undefined): string | null => {
+  if (!op) return null;
+  return `${op.operation.operationId} (${mode})`;
+};
+
+const moduleIndexLine = (m: ModuleInfo): string => {
+  const ops = [
+    describeOp('list', m.listOp),
+    describeOp('detail', m.getOp),
+    describeOp('create', m.createOp),
+    describeOp('edit', m.updateOp),
+    ...(m.actions ?? []).map((op) => {
+      return describeOp('action', op);
+    }),
+  ].filter((entry): entry is string => {
+    return entry !== null;
+  });
+  return `- ${m.label}${m.isProjectScoped ? ' (project-scoped)' : ''}: ${ops.join(', ')}`;
+};
+
+export const buildModuleIndex = (modules: ModuleInfo[]): string => {
+  return modules
+    .filter((m) => {
+      return m.listOp || m.getOp || m.createOp || (m.actions?.length ?? 0) > 0;
+    })
+    .map(moduleIndexLine)
+    .join('\n');
+};
+
+export const buildGuideInstructions = (args: {
+  modules: ModuleInfo[];
+  projectId: string;
+}): string => {
+  return [
+    'You are the SOAT App guide. You help the user navigate the SOAT web app by',
+    `mounting views with the "${RENDER_PAGE_TOOL_NAME}" tool. The user is working`,
+    `in project "${args.projectId}".`,
+    '',
+    'When the user asks to see, open, create, or edit a resource, call',
+    `"${RENDER_PAGE_TOOL_NAME}" with the operationId, the mode, and any required`,
+    'path parameters. Do not invent operationIds — use only those listed below.',
+    'After mounting a view, briefly confirm what you showed. For plain questions,',
+    'just answer without mounting anything.',
+    '',
+    'Available views:',
+    buildModuleIndex(args.modules),
+  ].join('\n');
+};

--- a/packages/app/src/chat/guideProvisioning.ts
+++ b/packages/app/src/chat/guideProvisioning.ts
@@ -1,0 +1,151 @@
+import { apiFetch } from '@/api/client';
+import type { ModuleInfo } from '@/engine/types';
+
+import {
+  buildGuideInstructions,
+  GUIDE_AGENT_NAME,
+  RENDER_PAGE_TOOL_DESCRIPTION,
+  RENDER_PAGE_TOOL_NAME,
+  renderPageParameters,
+} from './guideConfig';
+import type { AiProvider } from './types';
+
+type NamedRecord = { id: string; name?: string; type?: string };
+type AgentRecord = {
+  id: string;
+  name?: string;
+  ai_provider_id?: string;
+  tool_ids?: string[];
+};
+
+export type ProvisionResult =
+  | { ok: true; agentId: string }
+  | { ok: false; error: string };
+
+const GUIDE_UNAVAILABLE =
+  'The guide is unavailable for you. Ask an admin to grant agent and tool permissions in this project.';
+
+export const listAiProviders = async (args: {
+  token: string;
+  projectId: string;
+}): Promise<AiProvider[]> => {
+  const result = await apiFetch<unknown>({
+    url: `/api/v1/ai-providers?project_id=${encodeURIComponent(args.projectId)}`,
+    token: args.token,
+  });
+  if (!result.ok || !Array.isArray(result.data)) return [];
+  return result.data.filter((item): item is AiProvider => {
+    return (
+      typeof item === 'object' &&
+      item !== null &&
+      typeof (item as AiProvider).id === 'string'
+    );
+  });
+};
+
+const findByName = <T extends { name?: string }>(
+  list: unknown,
+  name: string
+): T | null => {
+  if (!Array.isArray(list)) return null;
+  return (
+    (list.find((item) => {
+      return (
+        typeof item === 'object' && item !== null && (item as T).name === name
+      );
+    }) as T | undefined) ?? null
+  );
+};
+
+// Find or create the render_page client tool. Returns the tool's public id.
+const ensureRenderPageTool = async (args: {
+  token: string;
+  projectId: string;
+}): Promise<string | null> => {
+  const existing = await apiFetch<unknown>({
+    url: `/api/v1/tools?project_id=${encodeURIComponent(args.projectId)}`,
+    token: args.token,
+  });
+  if (!existing.ok) return null;
+  const found = findByName<NamedRecord>(existing.data, RENDER_PAGE_TOOL_NAME);
+  if (found) return found.id;
+
+  const created = await apiFetch<NamedRecord>({
+    url: '/api/v1/tools',
+    method: 'POST',
+    token: args.token,
+    body: {
+      project_id: args.projectId,
+      name: RENDER_PAGE_TOOL_NAME,
+      type: 'client',
+      description: RENDER_PAGE_TOOL_DESCRIPTION,
+      parameters: renderPageParameters,
+    },
+  });
+  return created.ok ? created.data.id : null;
+};
+
+// Find or create the soat-app-guide agent bound to the chosen provider with the
+// render_page tool attached. Idempotent: re-binds the provider if it changed.
+export const provisionGuide = async (args: {
+  token: string;
+  projectId: string;
+  providerId: string;
+  modules: ModuleInfo[];
+}): Promise<ProvisionResult> => {
+  const toolId = await ensureRenderPageTool({
+    token: args.token,
+    projectId: args.projectId,
+  });
+  if (!toolId) return { ok: false, error: GUIDE_UNAVAILABLE };
+
+  const instructions = buildGuideInstructions({
+    modules: args.modules,
+    projectId: args.projectId,
+  });
+
+  const list = await apiFetch<unknown>({
+    url: `/api/v1/agents?project_id=${encodeURIComponent(args.projectId)}`,
+    token: args.token,
+  });
+  if (!list.ok) return { ok: false, error: GUIDE_UNAVAILABLE };
+
+  const existing = findByName<AgentRecord>(list.data, GUIDE_AGENT_NAME);
+
+  if (!existing) {
+    const created = await apiFetch<AgentRecord>({
+      url: '/api/v1/agents',
+      method: 'POST',
+      token: args.token,
+      body: {
+        project_id: args.projectId,
+        ai_provider_id: args.providerId,
+        name: GUIDE_AGENT_NAME,
+        instructions,
+        tool_ids: [toolId],
+      },
+    });
+    return created.ok
+      ? { ok: true, agentId: created.data.id }
+      : { ok: false, error: GUIDE_UNAVAILABLE };
+  }
+
+  // Re-bind the provider / tool when the selection drifted from the stored agent.
+  const toolIds = existing.tool_ids ?? [];
+  const needsUpdate =
+    existing.ai_provider_id !== args.providerId || !toolIds.includes(toolId);
+  if (needsUpdate) {
+    await apiFetch<AgentRecord>({
+      url: `/api/v1/agents/${encodeURIComponent(existing.id)}`,
+      method: 'PUT',
+      token: args.token,
+      body: {
+        ai_provider_id: args.providerId,
+        instructions,
+        tool_ids: toolIds.includes(toolId) ? toolIds : [...toolIds, toolId],
+      },
+    });
+  }
+
+  return { ok: true, agentId: existing.id };
+};

--- a/packages/app/src/chat/renderPage.ts
+++ b/packages/app/src/chat/renderPage.ts
@@ -1,0 +1,124 @@
+import { viewToPath } from '@/engine/routeUtils';
+import type {
+  ModuleInfo,
+  ModuleOp,
+  OpenApiSpec,
+  ViewDescriptor,
+  ViewMode,
+} from '@/engine/types';
+
+const VIEW_MODES: ViewMode[] = ['list', 'detail', 'create', 'edit', 'action'];
+
+const moduleOps = (m: ModuleInfo): ModuleOp[] => {
+  return [
+    m.listOp,
+    m.getOp,
+    m.createOp,
+    m.updateOp,
+    m.deleteOp,
+    ...(m.actions ?? []),
+  ].filter((op): op is ModuleOp => {
+    return op !== undefined;
+  });
+};
+
+// The module owning an operationId. Used to label the descriptor and to decide
+// whether the active project must be injected; navigation re-derives the tag
+// from the resulting URL.
+const moduleForOperation = (
+  operationId: string,
+  modules: ModuleInfo[]
+): ModuleInfo | null => {
+  for (const m of modules) {
+    if (
+      moduleOps(m).some((op) => {
+        return op.operation.operationId === operationId;
+      })
+    ) {
+      return m;
+    }
+  }
+  return null;
+};
+
+const coerceStringRecord = (value: unknown): Record<string, string> => {
+  if (typeof value !== 'object' || value === null) return {};
+  const out: Record<string, string> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (val !== null && val !== undefined) out[key] = String(val);
+  }
+  return out;
+};
+
+// Translate a render_page tool call into a validated ViewDescriptor. Returns
+// null when the operationId or mode is missing/invalid so the caller can report
+// a tool error instead of crashing the engine.
+export const toViewDescriptor = (args: {
+  toolArgs: Record<string, unknown>;
+  modules: ModuleInfo[];
+  activeProjectId: string | null;
+}): ViewDescriptor | null => {
+  const { operationId, mode } = args.toolArgs;
+  if (typeof operationId !== 'string' || !operationId) return null;
+  if (typeof mode !== 'string' || !VIEW_MODES.includes(mode as ViewMode)) {
+    return null;
+  }
+
+  const module = moduleForOperation(operationId, args.modules);
+  if (module === null) return null;
+
+  // Inject the active project for project-scoped views so the model does not
+  // have to repeat the project id on every call.
+  const pathParams = coerceStringRecord(args.toolArgs.pathParams);
+  if (
+    module.isProjectScoped &&
+    args.activeProjectId &&
+    !pathParams.project_id
+  ) {
+    pathParams.project_id = args.activeProjectId;
+  }
+
+  return { tag: module.tag, operationId, pathParams, mode: mode as ViewMode };
+};
+
+export type RenderPageResult = {
+  output: Record<string, unknown>;
+  view?: ViewDescriptor;
+};
+
+// Execute a render_page tool call: validate the descriptor against the spec,
+// mount the view, and return a compact summary to feed back to the model.
+export const executeRenderPage = (args: {
+  toolArgs: Record<string, unknown>;
+  spec: OpenApiSpec;
+  modules: ModuleInfo[];
+  activeProjectId: string | null;
+  navigate: (descriptor: ViewDescriptor) => void;
+}): RenderPageResult => {
+  const descriptor = toViewDescriptor({
+    toolArgs: args.toolArgs,
+    modules: args.modules,
+    activeProjectId: args.activeProjectId,
+  });
+
+  if (!descriptor || viewToPath(descriptor, args.spec) === null) {
+    return {
+      output: {
+        ok: false,
+        error: `Cannot render: unknown operationId '${String(
+          args.toolArgs.operationId
+        )}' or invalid mode.`,
+      },
+    };
+  }
+
+  args.navigate(descriptor);
+  return {
+    output: {
+      ok: true,
+      operationId: descriptor.operationId,
+      mode: descriptor.mode,
+    },
+    view: descriptor,
+  };
+};

--- a/packages/app/src/chat/types.ts
+++ b/packages/app/src/chat/types.ts
@@ -1,0 +1,39 @@
+import type { ViewDescriptor } from '@/engine/types';
+
+// An AI provider as returned by GET /api/v1/ai-providers (snake_case contract).
+export type AiProvider = {
+  id: string;
+  name: string;
+  provider: string;
+  default_model?: string;
+};
+
+// A single pending tool call from a `requires_action` generation response.
+// The Agents module returns tool calls as { tool_call_id, tool_name, args }.
+export type GuideToolCall = {
+  tool_call_id: string;
+  tool_name: string;
+  args: Record<string, unknown>;
+};
+
+// Response shape of POST /agents/{id}/generate and the tool-outputs endpoint.
+export type GenerateResponse = {
+  id: string;
+  status: 'completed' | 'requires_action';
+  text?: string | null;
+  tool_calls?: GuideToolCall[] | null;
+};
+
+// A tool output submitted back to resume a paused generation.
+export type ToolOutput = {
+  tool_call_id: string;
+  output: unknown;
+};
+
+// A message rendered in the chat transcript. Assistant messages that mounted a
+// view carry the descriptor so the user can re-mount it from the transcript.
+export type ChatMessage = {
+  role: 'user' | 'assistant';
+  content: string;
+  view?: ViewDescriptor;
+};

--- a/packages/app/src/views/workspace.tsx
+++ b/packages/app/src/views/workspace.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { apiFetch } from '@/api/client';
 import { useAuth } from '@/auth/authContext';
+import { GuideChat } from '@/chat/guideChat';
 import { Button } from '@/components/ui/button';
 import { EngineView } from '@/engine/engineView';
 import { useNavigation } from '@/engine/navigationContext';
@@ -338,6 +339,7 @@ export const Workspace = () => {
       <main className="flex-1 overflow-y-auto p-6">
         <MainArea />
       </main>
+      <GuideChat />
     </div>
   );
 };

--- a/packages/app/tests/unit/chat/guideAgent.test.ts
+++ b/packages/app/tests/unit/chat/guideAgent.test.ts
@@ -1,0 +1,93 @@
+import { http, HttpResponse } from 'msw';
+
+import { runGuideTurn } from '@/chat/guideAgent';
+import type { GuideToolCall } from '@/chat/types';
+
+import { server } from '../msw/server';
+
+const base = {
+  token: 'test-token',
+  agentId: 'agt_guide',
+  messages: [{ role: 'user', content: 'hi' }],
+};
+
+const noopExecutor = () => ({ output: { ok: true } });
+
+describe('runGuideTurn', () => {
+  test('returns the final text for a completed generation', async () => {
+    server.use(
+      http.post('*/api/v1/agents/agt_guide/generate', () =>
+        HttpResponse.json({ id: 'gen_1', status: 'completed', text: 'Hello!' })
+      )
+    );
+
+    const result = await runGuideTurn({ ...base, executeToolCall: noopExecutor });
+
+    expect(result).toEqual({ ok: true, text: 'Hello!', view: undefined });
+  });
+
+  test('resolves tool calls and resumes until completed', async () => {
+    const seen: GuideToolCall[] = [];
+    let toolOutputsBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post('*/api/v1/agents/agt_guide/generate', () =>
+        HttpResponse.json({
+          id: 'gen_1',
+          status: 'requires_action',
+          tool_calls: [
+            {
+              tool_call_id: 'c1',
+              tool_name: 'render_page',
+              args: { operationId: 'listAgents', mode: 'list' },
+            },
+          ],
+        })
+      ),
+      http.post(
+        '*/api/v1/agents/agt_guide/generate/gen_1/tool-outputs',
+        async ({ request }) => {
+          toolOutputsBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({
+            id: 'gen_1',
+            status: 'completed',
+            text: 'Here are your agents.',
+          });
+        }
+      )
+    );
+
+    const result = await runGuideTurn({
+      ...base,
+      executeToolCall: (call) => {
+        seen.push(call);
+        return { output: { ok: true }, view: { tag: 'Agents', operationId: 'listAgents', pathParams: {}, mode: 'list' } };
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.text).toBe('Here are your agents.');
+      expect(result.view?.operationId).toBe('listAgents');
+    }
+    expect(seen[0].tool_name).toBe('render_page');
+    expect(toolOutputsBody).toEqual({
+      tool_outputs: [{ tool_call_id: 'c1', output: { ok: true } }],
+    });
+  });
+
+  test('surfaces an API error', async () => {
+    server.use(
+      http.post('*/api/v1/agents/agt_guide/generate', () =>
+        HttpResponse.json(
+          { error: { code: 'AI_PROVIDER_ERROR', message: 'boom' } },
+          { status: 502 }
+        )
+      )
+    );
+
+    const result = await runGuideTurn({ ...base, executeToolCall: noopExecutor });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe('boom');
+  });
+});

--- a/packages/app/tests/unit/chat/guideChat.test.tsx
+++ b/packages/app/tests/unit/chat/guideChat.test.tsx
@@ -1,0 +1,145 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+
+import { GuideChat } from '@/chat/guideChat';
+
+import { NavProbe, renderWithAuth } from '../testUtils';
+import { server } from '../msw/server';
+
+const PROJECT_PATH = '/app/v1/projects/prj_1';
+
+const providerHandler = () =>
+  http.get('*/api/v1/ai-providers', () =>
+    HttpResponse.json([{ id: 'aip_1', name: 'OpenAI', provider: 'openai' }])
+  );
+
+// Handlers that let the guide provision successfully (no existing tool/agent).
+const provisioningHandlers = () => [
+  http.get('*/api/v1/tools', () => HttpResponse.json([])),
+  http.post('*/api/v1/tools', () => HttpResponse.json({ id: 'tool_1' })),
+  http.get('*/api/v1/agents', () => HttpResponse.json([])),
+  http.post('*/api/v1/agents', () =>
+    HttpResponse.json({ id: 'agt_guide', name: 'soat-app-guide' })
+  ),
+];
+
+const renderGuide = () =>
+  renderWithAuth(
+    <>
+      <GuideChat />
+      <NavProbe />
+    </>,
+    { initialPath: PROJECT_PATH }
+  );
+
+describe('GuideChat', () => {
+  test('prompts to select a project when none is active', async () => {
+    renderWithAuth(<GuideChat />, { initialPath: '/app/' });
+    expect(
+      await screen.findByText(/select a project to use the ai guide/i)
+    ).toBeInTheDocument();
+  });
+
+  test('renders the provider picker for the active project', async () => {
+    server.use(providerHandler());
+    renderGuide();
+    const select = await screen.findByLabelText('AI provider');
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'OpenAI' })).toBeInTheDocument();
+    // The composer is disabled until a provider is chosen and provisioned.
+    expect(screen.getByLabelText('Message the guide')).toBeDisabled();
+  });
+
+  test('shows an empty state when the project has no providers', async () => {
+    server.use(
+      http.get('*/api/v1/ai-providers', () => HttpResponse.json([]))
+    );
+    renderGuide();
+    expect(
+      await screen.findByText(/no ai providers in this project/i)
+    ).toBeInTheDocument();
+  });
+
+  test('drives a turn that mounts a view and answers in the chat', async () => {
+    server.use(providerHandler(), ...provisioningHandlers());
+    server.use(
+      http.post('*/api/v1/agents/agt_guide/generate', () =>
+        HttpResponse.json({
+          id: 'gen_1',
+          status: 'requires_action',
+          tool_calls: [
+            {
+              tool_call_id: 'c1',
+              tool_name: 'render_page',
+              args: { operationId: 'listAgents', mode: 'list' },
+            },
+          ],
+        })
+      ),
+      http.post(
+        '*/api/v1/agents/agt_guide/generate/gen_1/tool-outputs',
+        () =>
+          HttpResponse.json({
+            id: 'gen_1',
+            status: 'completed',
+            text: 'Here are your agents.',
+          })
+      )
+    );
+
+    renderGuide();
+
+    await userEvent.selectOptions(
+      await screen.findByLabelText('AI provider'),
+      'aip_1'
+    );
+
+    const input = await screen.findByLabelText('Message the guide');
+    await waitFor(() => expect(input).toBeEnabled());
+
+    await userEvent.type(input, 'show agents');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    expect(
+      await screen.findByText('Here are your agents.')
+    ).toBeInTheDocument();
+    // The view was actually mounted via real navigation.
+    expect(screen.getByTestId('nav-probe')).toHaveTextContent('listAgents');
+    // The transcript offers a re-mount affordance for the shown view.
+    expect(
+      screen.getByRole('button', { name: /Showing: Agents \(list\)/ })
+    ).toBeInTheDocument();
+  });
+
+  test('surfaces a provisioning failure', async () => {
+    server.use(providerHandler());
+    server.use(
+      http.get('*/api/v1/tools', () => HttpResponse.json([])),
+      http.post('*/api/v1/tools', () =>
+        HttpResponse.json({ error: 'Forbidden' }, { status: 403 })
+      )
+    );
+    renderGuide();
+
+    await userEvent.selectOptions(
+      await screen.findByLabelText('AI provider'),
+      'aip_1'
+    );
+
+    expect(await screen.findByText(/guide is unavailable/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('Message the guide')).toBeDisabled();
+  });
+
+  test('collapses and re-opens the sidebar', async () => {
+    server.use(providerHandler());
+    renderGuide();
+    await screen.findByLabelText('AI provider');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Collapse guide' }));
+    expect(screen.queryByLabelText('AI provider')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open guide' }));
+    expect(await screen.findByLabelText('AI provider')).toBeInTheDocument();
+  });
+});

--- a/packages/app/tests/unit/chat/guideConfig.test.ts
+++ b/packages/app/tests/unit/chat/guideConfig.test.ts
@@ -1,0 +1,52 @@
+import {
+  buildGuideInstructions,
+  buildModuleIndex,
+  GUIDE_AGENT_NAME,
+  renderPageParameters,
+  RENDER_PAGE_TOOL_NAME,
+} from '@/chat/guideConfig';
+import { parseModules } from '@/engine/specUtils';
+
+import { testSpec } from '../fixtures/spec';
+
+const modules = parseModules(testSpec);
+
+describe('buildModuleIndex', () => {
+  test('lists each operation with its mode', () => {
+    const index = buildModuleIndex(modules);
+    expect(index).toContain('listAgents (list)');
+    expect(index).toContain('getAgent (detail)');
+    expect(index).toContain('createAgent (create)');
+    expect(index).toContain('updateAgent (edit)');
+    expect(index).toContain('generateAgent (action)');
+  });
+
+  test('marks project-scoped modules', () => {
+    const index = buildModuleIndex(modules);
+    expect(index).toMatch(/Webhooks \(project-scoped\)/);
+  });
+});
+
+describe('buildGuideInstructions', () => {
+  test('embeds the project id, tool name, and module index', () => {
+    const instructions = buildGuideInstructions({
+      modules,
+      projectId: 'prj_42',
+    });
+    expect(instructions).toContain('prj_42');
+    expect(instructions).toContain(RENDER_PAGE_TOOL_NAME);
+    expect(instructions).toContain('listAgents (list)');
+  });
+});
+
+describe('render_page tool definition', () => {
+  test('requires operationId and mode and is camelCase', () => {
+    expect(renderPageParameters.required).toEqual(['operationId', 'mode']);
+    expect(renderPageParameters.properties.operationId.type).toBe('string');
+    expect(renderPageParameters.properties.mode.enum).toContain('list');
+  });
+
+  test('exposes a stable guide agent name', () => {
+    expect(GUIDE_AGENT_NAME).toBe('soat-app-guide');
+  });
+});

--- a/packages/app/tests/unit/chat/guideProvisioning.test.ts
+++ b/packages/app/tests/unit/chat/guideProvisioning.test.ts
@@ -1,0 +1,142 @@
+import { http, HttpResponse } from 'msw';
+
+import { listAiProviders, provisionGuide } from '@/chat/guideProvisioning';
+import { parseModules } from '@/engine/specUtils';
+
+import { testSpec } from '../fixtures/spec';
+import { server } from '../msw/server';
+
+const modules = parseModules(testSpec);
+const base = { token: 'test-token', projectId: 'prj_1' };
+
+describe('listAiProviders', () => {
+  test('returns providers scoped to the project', async () => {
+    let requestedUrl = '';
+    server.use(
+      http.get('*/api/v1/ai-providers', ({ request }) => {
+        requestedUrl = request.url;
+        return HttpResponse.json([
+          { id: 'aip_1', name: 'OpenAI', provider: 'openai' },
+        ]);
+      })
+    );
+    const providers = await listAiProviders(base);
+    expect(providers).toHaveLength(1);
+    expect(providers[0].id).toBe('aip_1');
+    expect(requestedUrl).toContain('project_id=prj_1');
+  });
+
+  test('returns an empty list on error', async () => {
+    server.use(
+      http.get('*/api/v1/ai-providers', () =>
+        HttpResponse.json({ error: 'Forbidden' }, { status: 403 })
+      )
+    );
+    expect(await listAiProviders(base)).toEqual([]);
+  });
+});
+
+describe('provisionGuide', () => {
+  test('creates the render_page tool and guide agent when absent', async () => {
+    let toolBody: Record<string, unknown> | undefined;
+    let agentBody: Record<string, unknown> | undefined;
+    server.use(
+      http.get('*/api/v1/tools', () => HttpResponse.json([])),
+      http.post('*/api/v1/tools', async ({ request }) => {
+        toolBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ id: 'tool_1', name: 'render_page' });
+      }),
+      http.get('*/api/v1/agents', () => HttpResponse.json([])),
+      http.post('*/api/v1/agents', async ({ request }) => {
+        agentBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ id: 'agt_guide', name: 'soat-app-guide' });
+      })
+    );
+
+    const result = await provisionGuide({ ...base, providerId: 'aip_1', modules });
+
+    expect(result).toEqual({ ok: true, agentId: 'agt_guide' });
+    expect(toolBody).toMatchObject({ name: 'render_page', type: 'client' });
+    expect(agentBody).toMatchObject({
+      name: 'soat-app-guide',
+      ai_provider_id: 'aip_1',
+      tool_ids: ['tool_1'],
+    });
+  });
+
+  test('reuses the existing tool and agent without creating duplicates', async () => {
+    let createdTool = false;
+    let createdAgent = false;
+    server.use(
+      http.get('*/api/v1/tools', () =>
+        HttpResponse.json([{ id: 'tool_x', name: 'render_page', type: 'client' }])
+      ),
+      http.post('*/api/v1/tools', () => {
+        createdTool = true;
+        return HttpResponse.json({ id: 'tool_x' });
+      }),
+      http.get('*/api/v1/agents', () =>
+        HttpResponse.json([
+          {
+            id: 'agt_x',
+            name: 'soat-app-guide',
+            ai_provider_id: 'aip_1',
+            tool_ids: ['tool_x'],
+          },
+        ])
+      ),
+      http.post('*/api/v1/agents', () => {
+        createdAgent = true;
+        return HttpResponse.json({ id: 'agt_x' });
+      })
+    );
+
+    const result = await provisionGuide({ ...base, providerId: 'aip_1', modules });
+
+    expect(result).toEqual({ ok: true, agentId: 'agt_x' });
+    expect(createdTool).toBe(false);
+    expect(createdAgent).toBe(false);
+  });
+
+  test('re-binds the provider when the existing agent points elsewhere', async () => {
+    let updateBody: Record<string, unknown> | undefined;
+    server.use(
+      http.get('*/api/v1/tools', () =>
+        HttpResponse.json([{ id: 'tool_x', name: 'render_page', type: 'client' }])
+      ),
+      http.get('*/api/v1/agents', () =>
+        HttpResponse.json([
+          {
+            id: 'agt_x',
+            name: 'soat-app-guide',
+            ai_provider_id: 'aip_OLD',
+            tool_ids: ['tool_x'],
+          },
+        ])
+      ),
+      http.put('*/api/v1/agents/agt_x', async ({ request }) => {
+        updateBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ id: 'agt_x' });
+      })
+    );
+
+    const result = await provisionGuide({ ...base, providerId: 'aip_NEW', modules });
+
+    expect(result).toEqual({ ok: true, agentId: 'agt_x' });
+    expect(updateBody).toMatchObject({ ai_provider_id: 'aip_NEW' });
+  });
+
+  test('reports unavailable when the user cannot create a tool', async () => {
+    server.use(
+      http.get('*/api/v1/tools', () => HttpResponse.json([])),
+      http.post('*/api/v1/tools', () =>
+        HttpResponse.json({ error: 'Forbidden' }, { status: 403 })
+      )
+    );
+
+    const result = await provisionGuide({ ...base, providerId: 'aip_1', modules });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/unavailable/i);
+  });
+});

--- a/packages/app/tests/unit/chat/renderPage.test.ts
+++ b/packages/app/tests/unit/chat/renderPage.test.ts
@@ -1,0 +1,106 @@
+import { executeRenderPage, toViewDescriptor } from '@/chat/renderPage';
+import { parseModules } from '@/engine/specUtils';
+import type { ViewDescriptor } from '@/engine/types';
+
+import { testSpec } from '../fixtures/spec';
+
+const modules = parseModules(testSpec);
+
+describe('toViewDescriptor', () => {
+  test('builds a descriptor for a known operation', () => {
+    const descriptor = toViewDescriptor({
+      toolArgs: { operationId: 'listAgents', mode: 'list' },
+      modules,
+      activeProjectId: null,
+    });
+    expect(descriptor).toEqual({
+      tag: 'Agents',
+      operationId: 'listAgents',
+      pathParams: {},
+      mode: 'list',
+    });
+  });
+
+  test('injects the active project for project-scoped views only', () => {
+    const scoped = toViewDescriptor({
+      toolArgs: { operationId: 'listWebhooks', mode: 'list' },
+      modules,
+      activeProjectId: 'prj_1',
+    });
+    expect(scoped?.pathParams).toEqual({ project_id: 'prj_1' });
+
+    const unscoped = toViewDescriptor({
+      toolArgs: { operationId: 'listAgents', mode: 'list' },
+      modules,
+      activeProjectId: 'prj_1',
+    });
+    expect(unscoped?.pathParams).toEqual({});
+  });
+
+  test('coerces provided path params to strings', () => {
+    const descriptor = toViewDescriptor({
+      toolArgs: {
+        operationId: 'getAgent',
+        mode: 'detail',
+        pathParams: { agent_id: 'agt_9' },
+      },
+      modules,
+      activeProjectId: null,
+    });
+    expect(descriptor?.pathParams).toEqual({ agent_id: 'agt_9' });
+  });
+
+  test('returns null for an unknown operationId', () => {
+    expect(
+      toViewDescriptor({
+        toolArgs: { operationId: 'nope', mode: 'list' },
+        modules,
+        activeProjectId: null,
+      })
+    ).toBeNull();
+  });
+
+  test('returns null for an invalid mode', () => {
+    expect(
+      toViewDescriptor({
+        toolArgs: { operationId: 'listAgents', mode: 'explode' },
+        modules,
+        activeProjectId: null,
+      })
+    ).toBeNull();
+  });
+});
+
+describe('executeRenderPage', () => {
+  test('navigates and returns an ok summary on success', () => {
+    const navigated: ViewDescriptor[] = [];
+    const result = executeRenderPage({
+      toolArgs: { operationId: 'listAgents', mode: 'list' },
+      spec: testSpec,
+      modules,
+      activeProjectId: null,
+      navigate: (d) => navigated.push(d),
+    });
+    expect(result.output).toEqual({
+      ok: true,
+      operationId: 'listAgents',
+      mode: 'list',
+    });
+    expect(result.view?.operationId).toBe('listAgents');
+    expect(navigated).toHaveLength(1);
+  });
+
+  test('returns an error summary without navigating on a bad call', () => {
+    const navigated: ViewDescriptor[] = [];
+    const result = executeRenderPage({
+      toolArgs: { operationId: 'unknownOp', mode: 'list' },
+      spec: testSpec,
+      modules,
+      activeProjectId: null,
+      navigate: (d) => navigated.push(d),
+    });
+    expect(result.output).toMatchObject({ ok: false });
+    expect(result.view).toBeUndefined();
+    expect(navigated).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a collapsible right-sidebar chat panel (`GuideChat`) to the workspace shell where users can ask the AI to show or manage any resource in the active project
- On first use, auto-provisions a `soat-app-guide` agent with a `render_page` client tool; reuses or re-binds the provider if they already exist
- Runs a generate → tool-output loop: when the agent calls `render_page`, the UI mounts the requested view and feeds the result back so the agent can answer in natural language
- The panel shows a transcript with "Showing: Tag (mode) →" re-mount affordances and stays alive when the main view navigates away from a project-scoped URL (pinned project ID)

## Test plan

- [ ] `pnpm --filter @soat/app typecheck` — no TypeScript errors
- [ ] `pnpm --filter @soat/app eslint src` — no lint errors (only pre-existing warnings in unrelated files)
- [ ] `pnpm --filter @soat/app test` — 142 tests pass across 21 test files, including 27 new chat tests covering all modules: `guideConfig`, `renderPage`, `guideProvisioning`, `guideAgent`, `guideChat`

https://claude.ai/code/session_015thaF5U1B5xgXuUudotKhx

---
_Generated by [Claude Code](https://claude.ai/code/session_015thaF5U1B5xgXuUudotKhx)_